### PR TITLE
92 strategy docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ before_install:
 install: "pip install -r requirements.txt"
 script:
   - python -m unittest discover axelrod/tests/
+  - cd docs/; python strategies.py

--- a/axelrod/strategies/geller.py
+++ b/axelrod/strategies/geller.py
@@ -17,11 +17,6 @@ see what it's going to play, and return a result based on that
 
 This is almost certainly cheating, and more than likely against the
 spirit of the 'competition' :-)
-
-This code will fall into infinite recursion when played against itself,
-a problem that can be alleviated by looking at the name of the function
-calling `strategy`. If it is also `strategy`, we should return some
-default value - for example 'C', 'D' or random.
 """
 
 import inspect

--- a/axelrod/strategies/geller.py
+++ b/axelrod/strategies/geller.py
@@ -26,6 +26,10 @@ from axelrod import Player
 
 
 class Geller(Player):
+    """Observes what the player will do in the next round and adjust.
+
+    If unable to do this: will play randomly.
+    """
 
     name = 'Geller'
     default = lambda self: 'C' if random.random() > 0.5 else 'D'
@@ -45,9 +49,15 @@ class Geller(Player):
             return opponent.strategy(self)
 
 class GellerCooperator(Geller):
+    """Observes what the payer will do (like :code:`Geller`) but if unable to
+    will cooperate.
+    """
     name = 'Geller Cooperator'
     default = lambda self: 'C'
 
 class GellerDefector(Geller):
+    """Observes what the payer will do (like :code:`Geller`) but if unable to
+    will defect.
+    """
     name = 'Geller Defector'
     default = lambda self: 'D'

--- a/axelrod/strategies/gobymajority.py
+++ b/axelrod/strategies/gobymajority.py
@@ -4,7 +4,8 @@ from axelrod import Player
 class GoByMajority(Player):
     """A player examines the history of the opponent: if the opponent has more defections than cooperations then the player defects.
 
-    An optinal memory attribute will limit the number of turns remembered
+    An optional memory attribute will limit the number of turns remembered (by
+    default this is 0)
     """
 
     memory = 0
@@ -26,14 +27,22 @@ class GoByMajority(Player):
 
 
 class GoByMajority40(GoByMajority):
+    """ :code:`GoByMajority` player with a memory of 40.
+    """
     memory = 40
 
 class GoByMajority20(GoByMajority):
+    """ :code:`GoByMajority` player with a memory of 20.
+    """
     memory = 20
 
 class GoByMajority10(GoByMajority):
+    """ :code:`GoByMajority` player with a memory of 10.
+    """
     memory = 10
 
 class GoByMajority5(GoByMajority):
+    """ :code:`GoByMajority` player with a memory of 5.
+    """
     memory = 5
 

--- a/axelrod/strategies/retaliate.py
+++ b/axelrod/strategies/retaliate.py
@@ -31,10 +31,14 @@ class Retaliate(Player):
 
 
 class Retaliate2(Retaliate):
+    """ :code:`Retaliate` player with a threshold of 8 percent.
+    """
     retaliation_threshold = 0.08
 
 
 class Retaliate3(Retaliate):
+    """ :code:`Retaliate` player with a threshold of 5 percent.
+    """
     retaliation_threshold = 0.05
 
 
@@ -92,10 +96,16 @@ class LimitedRetaliate(Player):
 
 
 class LimitedRetaliate2(LimitedRetaliate):
+    """ :code:`LimitedRetaliate` player with a threshold of 8 percent and a
+    retaliation limit of 15.
+    """
     retaliation_limit = 15
     retaliation_threshold = 0.08
 
 
 class LimitedRetaliate3(LimitedRetaliate):
+    """ :code:`LimitedRetaliate` player with a threshold of 5 percent and a
+    retaliation limit of 20.
+    """
     retaliation_limit = 20
     retaliation_threshold = 0.05

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -21,13 +21,6 @@ I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
 .PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
 
-.PHONY: strategies
-strategies: strategies.rst
-strategies.rst: strategies.py
-	python $< > $@
-
-default: strategies
-
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  html       to make standalone HTML files"
@@ -56,38 +49,38 @@ help:
 clean:
 	rm -rf $(BUILDDIR)/*
 
-html: default
+html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
-dirhtml: default
+dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
-singlehtml: default
+singlehtml:
 	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
 	@echo
 	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
 
-pickle: default
+pickle:
 	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(BUILDDIR)/pickle
 	@echo
 	@echo "Build finished; now you can process the pickle files."
 
-json: default
+json:
 	$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(BUILDDIR)/json
 	@echo
 	@echo "Build finished; now you can process the JSON files."
 
-htmlhelp: default
+htmlhelp:
 	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp
 	@echo
 	@echo "Build finished; now you can run HTML Help Workshop with the" \
 	      ".hhp project file in $(BUILDDIR)/htmlhelp."
 
-qthelp: default
+qthelp:
 	$(SPHINXBUILD) -b qthelp $(ALLSPHINXOPTS) $(BUILDDIR)/qthelp
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
@@ -96,7 +89,7 @@ qthelp: default
 	@echo "To view the help file:"
 	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/Axelrod.qhc"
 
-devhelp: default
+devhelp:
 	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
 	@echo
 	@echo "Build finished."
@@ -105,80 +98,80 @@ devhelp: default
 	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/Axelrod"
 	@echo "# devhelp"
 
-epub: default
+epub:
 	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
 	@echo
 	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
 
-latex: default
+latex:
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo
 	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
 	@echo "Run \`make' in that directory to run these through (pdf)latex" \
 	      "(use \`make latexpdf' here to do that automatically)."
 
-latexpdf: default
+latexpdf:
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo "Running LaTeX files through pdflatex..."
 	$(MAKE) -C $(BUILDDIR)/latex all-pdf
 	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
 
-latexpdfja: default
+latexpdfja:
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo "Running LaTeX files through platex and dvipdfmx..."
 	$(MAKE) -C $(BUILDDIR)/latex all-pdf-ja
 	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
 
-text: default
+text:
 	$(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text
 	@echo
 	@echo "Build finished. The text files are in $(BUILDDIR)/text."
 
-man: default
+man:
 	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
 	@echo
 	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
 
-texinfo: default
+texinfo:
 	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
 	@echo
 	@echo "Build finished. The Texinfo files are in $(BUILDDIR)/texinfo."
 	@echo "Run \`make' in that directory to run these through makeinfo" \
 	      "(use \`make info' here to do that automatically)."
 
-info: default
+info:
 	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
 	@echo "Running Texinfo files through makeinfo..."
 	make -C $(BUILDDIR)/texinfo info
 	@echo "makeinfo finished; the Info files are in $(BUILDDIR)/texinfo."
 
-gettext: default
+gettext:
 	$(SPHINXBUILD) -b gettext $(I18NSPHINXOPTS) $(BUILDDIR)/locale
 	@echo
 	@echo "Build finished. The message catalogs are in $(BUILDDIR)/locale."
 
-changes: default
+changes:
 	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes
 	@echo
 	@echo "The overview file is in $(BUILDDIR)/changes."
 
-linkcheck: default
+linkcheck:
 	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."
 
-doctest: default
+doctest:
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."
 
-xml: default
+xml:
 	$(SPHINXBUILD) -b xml $(ALLSPHINXOPTS) $(BUILDDIR)/xml
 	@echo
 	@echo "Build finished. The XML files are in $(BUILDDIR)/xml."
 
-pseudoxml: default
+pseudoxml:
 	$(SPHINXBUILD) -b pseudoxml $(ALLSPHINXOPTS) $(BUILDDIR)/pseudoxml
 	@echo
 	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -247,6 +247,21 @@ Note that this project is being taken care off by `travis-ci <https://travis-ci.
 You can see the latest build status `here <https://travis-ci.org/Axelrod-Python/Axelrod>`_.
 
 
+Adding the strategy to the documentation
+''''''''''''''''''''''''''''''''''''''''
+
+To index all the strategies and make sure their docstrings get added to the
+documentation::
+
+    cd docs
+    python strategies.py > strategies.rst
+
+This will write the file that is automatically used by `<https://readthedocs.org/>`_ to generate this `list <http://axelrod.readthedocs.org/en/latest/strategies.html>`_ of strategies.
+
+If you would like to build the documentation locally use::
+
+    make html
+
 Contributing to the library
 ---------------------------
 

--- a/docs/strategies.py
+++ b/docs/strategies.py
@@ -1,15 +1,22 @@
+"""
+A script to generate the file needed for the strategy documentation.
+
+Run:
+
+    python strategies.py > strategies.rst
+"""
 import os
 import sys
 
 sys.path.insert(0, os.path.abspath("../"))
 from axelrod import basic_strategies
-from axelrod import strategies
+from axelrod import ordinary_strategies
 from axelrod import cheating_strategies
 
 
 def print_header(string, character):
     print string
-    print character*len(string)
+    print character * len(string)
     print ""
 
 
@@ -25,9 +32,8 @@ if __name__ == "__main__":
     print ""
 
     print_header("A list of all further (honest) strategies", '-')
-    for strategy in strategies:
-        if strategy not in basic_strategies:
-            print ".. autoclass:: %s" % strategy.__name__
+    for strategy in ordinary_strategies:
+        print ".. autoclass:: %s" % strategy.__name__
 
     print ""
 

--- a/docs/strategies.rst
+++ b/docs/strategies.rst
@@ -14,14 +14,19 @@ Here are some of the basic strategies
 A list of all further (honest) strategies
 -----------------------------------------
 
-.. autoclass:: AntiTitForTat
+.. autoclass:: AlternatorHunter
 .. autoclass:: Appeaser
 .. autoclass:: ArrogantQLearner
 .. autoclass:: AverageCopier
 .. autoclass:: CautiousQLearner
+.. autoclass:: CooperatorHunter
+.. autoclass:: DefectorHunter
+.. autoclass:: FoolMeOnce
+.. autoclass:: ForgetfulFoolMeOnce
 .. autoclass:: ForgetfulGrudger
 .. autoclass:: Forgiver
 .. autoclass:: ForgivingTitForTat
+.. autoclass:: GTFT
 .. autoclass:: GoByMajority
 .. autoclass:: GoByMajority10
 .. autoclass:: GoByMajority20
@@ -36,23 +41,36 @@ A list of all further (honest) strategies
 .. autoclass:: LimitedRetaliate
 .. autoclass:: LimitedRetaliate2
 .. autoclass:: LimitedRetaliate3
+.. autoclass:: MathConstantHunter
+.. autoclass:: MetaHunter
+.. autoclass:: MetaMajority
+.. autoclass:: MetaMinority
+.. autoclass:: MetaWinner
+.. autoclass:: NiceAverageCopier
 .. autoclass:: OnceBitten
 .. autoclass:: OppositeGrudger
 .. autoclass:: Pi
 .. autoclass:: Punisher
+.. autoclass:: RandomHunter
 .. autoclass:: Retaliate
 .. autoclass:: Retaliate2
 .. autoclass:: Retaliate3
 .. autoclass:: RiskyQLearner
+.. autoclass:: SneakyTitForTat
+.. autoclass:: StochasticWSLS
+.. autoclass:: SuspiciousTitForTat
 .. autoclass:: TitFor2Tats
 .. autoclass:: TrickyCooperator
 .. autoclass:: TrickyDefector
 .. autoclass:: TwoTitsForTat
+.. autoclass:: WinStayLoseShift
+.. autoclass:: ZDChi
 .. autoclass:: e
 
 A list of the cheating strategies
 ---------------------------------
 
+.. autoclass:: Darwin
 .. autoclass:: Geller
 .. autoclass:: GellerCooperator
 .. autoclass:: GellerDefector


### PR DESCRIPTION
This is relevant to #92. 

I started wanting to change how things were done but ended up just doing some spring cleaning.

- I set the `Makefile` back to how it was before @langner's cool fix which sadly didn't work with readthedocs. I think we'll just have to run `python strategies.py > strategies.rst` when a new strategy gets included (this could also be added to the documentation...)
- I also added running the `strategies.py` script to travis (for example a change in the `_strategies.py` file actually broke this script). It doesn't do anything except check that it runs without any errors.