### PR TITLE
Docs update -- removed suspect Tit-for-Tat statement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,10 +54,6 @@ the results from the latest run of the tournament here:
 .. figure:: ./assets/strategies_boxplot.png
    :alt:
 
-As you can see: the 'tit for tat' strategy has not won in this instance,
-that is mainly because more strategies are needed to get anywhere near
-Axelrod's tournament.
-
 You can see the results from the latest run of the tournament here with
 the cheating strategies (which manipulate/read what the opponent does):
 

--- a/axelrod/strategies/memoryone.py
+++ b/axelrod/strategies/memoryone.py
@@ -88,26 +88,6 @@ class StochasticWSLS(MemoryOnePlayer):
         super(self.__class__, self).__init__(four_vector)
 
 class ZDChi(MemoryOnePlayer):
-    """An Extortionate Zero Determinant Strategy. See the Press and Dyson paper in PNAS for the original formula."""
-
-    name = 'ZDChi'
-
-    def __init__(self, chi=2):
-        chi = float(chi)
-        (R, P, T, S) = Game().RPTS()
-
-        phi_max = float(P-S) / ((P-S) + chi * (T-P))
-        phi = phi_max / 2.
-
-        p1 = 1. - phi*(chi - 1) * float(R-P) / (P-S)
-        p2 = 1 - phi * (1 + chi * float(T-P) / (P-S))
-        p3 = phi * (chi + float(T-P)/(P-S))
-        p4 = 0
-
-        four_vector = (p1, p2, p3, p4)
-        super(self.__class__, self).__init__(four_vector)
-
-class ZDChi(MemoryOnePlayer):
     """An Extortionate Zero Determinant Strategy enforcing the relationship 's_x - P = chi (s_y - P)'. See the Press and Dyson paper in PNAS for the original formula."""
 
     name = 'ZD Extort-2'


### PR DESCRIPTION
Very simple change to README.rst as I'm almost certain that Tit-for-Tat should not be expected to "win" the tournament if only there were more strategies. I'm also highly sceptical of the claims in the literature of the superiority of e.g. ZD-strategies as they make rather questionable assumptions (weak selection, arbitrarily long games, using stationary scores instead of the real payoff matrices, etc.) My own work with Chris Lee and Dashiell Fryer shows that non-memory-one strategies can be very effective, and the MetaHunter strategy in this repository is another good example (and much more simple).

In fact, I encourage you all to publish these results, perhaps computing things like mean score per round as the number of rounds gets large and other quantities. The literature is in sore need of some empirical data.