### PR TITLE
Zd patch

### DIFF
--- a/axelrod/game.py
+++ b/axelrod/game.py
@@ -9,13 +9,13 @@ class Game(object):
             ('D', 'C'): (t, s),
         }
 
-    def RPTS(self):
+    def RPST(self):
         """Return the values in the game matrix in the Press and Dyson notation."""
         R = self.scores[('C', 'C')][0]
         P = self.scores[('D', 'D')][0]
-        T = self.scores[('C', 'D')][0]
-        S = self.scores[('D', 'C')][0]
-        return (R, P, T, S)
+        S = self.scores[('C', 'D')][0]
+        T = self.scores[('D', 'C')][0]
+        return (R, P, S, T)
 
     def score(self, pair):
         """Return the appropriate score for decision pair.

--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -82,7 +82,7 @@ ordinary_strategies = [
     TrickyDefector,
     TwoTitsForTat,
     WinStayLoseShift,
-    Extort2,
+    ZDExtort2,
     ZDGTFT2,
     e,
 ]

--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -82,7 +82,7 @@ ordinary_strategies = [
     TrickyDefector,
     TwoTitsForTat,
     WinStayLoseShift,
-    ZDChi,
+    Extort2,
     ZDGTFT2,
     e,
 ]

--- a/axelrod/strategies/memoryone.py
+++ b/axelrod/strategies/memoryone.py
@@ -123,7 +123,7 @@ class ZDGTFT2(ZeroDeterminantPlayer):
         (R, P, S, T) = Game().RPST()
         ZeroDeterminantPlayer.__init__(self, phi=0.25, s=0.5, l=R)
 
-class Extort2(ZeroDeterminantPlayer):
+class ZDExtort2(ZeroDeterminantPlayer):
     """An Extortionate Zero Determinant Strategy."""
 
     name = 'ZD-Extort-2'

--- a/axelrod/strategies/memoryone.py
+++ b/axelrod/strategies/memoryone.py
@@ -4,7 +4,6 @@ from axelrod import Player, Game
 
 """IPD Strategies: http://www.prisoners-dilemma.com/strategies.html"""
 
-
 class WinStayLoseShift(Player):
     """Win-Stay Lose-Shift, also called Pavlov."""
 
@@ -35,8 +34,6 @@ class MemoryOnePlayer(Player):
 
     def __init__(self, four_vector, initial='C'):
         Player.__init__(self)
-        #if four_vector is None:
-            #four_vector = [1,0,0,1]
         self._four_vector = dict( zip(  [ ('C','C'), ('C','D'), ('D','C'), ('D','D')], map(float, four_vector) ) )
         self._initial = initial
         self.stochastic = False
@@ -90,8 +87,7 @@ class StochasticWSLS(MemoryOnePlayer):
         super(self.__class__, self).__init__(four_vector)
 
 class ZeroDeterminantPlayer(MemoryOnePlayer):
-    """Abstraction for ZD players. The correct formula is Equation 14 in http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0077886 .
-    These players enforce a linear difference in stationary payoffs s * (S_xy - l) = S_yx - l, yielding extortionate strategies with l = P and generous strategies when l = R and s > 0"""
+    """Abstraction for ZD players. The correct formula is Equation 14 in http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0077886 . These players enforce a linear difference in stationary payoffs s * (S_xy - l) = S_yx - l, yielding extortionate strategies with l = P and generous strategies when l = R and s > 0"""
     name = 'ZD ABC'
 
     def __init__(self, phi=0., s=None, l=None):

--- a/axelrod/strategies/memoryone.py
+++ b/axelrod/strategies/memoryone.py
@@ -88,33 +88,35 @@ class StochasticWSLS(MemoryOnePlayer):
         super(self.__class__, self).__init__(four_vector)
 
 class ZDChi(MemoryOnePlayer):
-    """An Extortionate Zero Determinant Strategy enforcing the relationship 's_x - P = chi (s_y - P)'. See the Press and Dyson paper in PNAS for the original formula."""
+    """An Extortionate Zero Determinant Strategy enforcing the relationship 's_x - P = chi (s_y - P)'. See the Press and Dyson paper in PNAS for the original formula. Supposedly ZD Extort-2 is (8/9, 1/2, 1/3, 0), which corresponds to phi=1/18 and chi=2."""
 
     name = 'ZD Extort-2'
 
-    def __init__(self, chi=2):
+    def __init__(self, phi=1./18, chi=2.):
         chi = float(chi)
-        (R, P, T, S) = Game().RPTS()
+        (R, P, S, T) = Game().RPST()
 
         phi_max = float(P-S) / ((P-S) + chi * (T-P))
-        phi = phi_max / 2.
+        if phi > phi_max:
+            raise ValueError
 
-        p1 = 1. - phi*(chi - 1) * float(R-P) / (P-S)
-        p2 = 1 - phi * (1 + chi * float(T-P) / (P-S))
+        p1 = 1. - phi*(chi - 1) * float(R-P) / float(P-S)
+        p2 = 1 - phi * (1 + chi * float(T-P) / float(P-S))
         p3 = phi * (chi + float(T-P)/(P-S))
         p4 = 0
 
         four_vector = (p1, p2, p3, p4)
+        print self.name, four_vector
         super(self.__class__, self).__init__(four_vector)
 
 class ZDGTFT2(MemoryOnePlayer):
-    """A Generous Zero Determinant Strategy enforcing the relationship 's_x - R = 2 (s_y - R)'. There are infinitely many such strategies depending on the choice of parameters. See the paper "From extortion to generosity, evolution in the Iterated Prisoner's Dilemma" PNAS 2013 for more details."""
+    """A Generous Zero Determinant Strategy enforcing the relationship 's_x - R = 2 (s_y - R)'. There are infinitely many such strategies depending on the choice of parameters. See the paper "From extortion to generosity, evolution in the Iterated Prisoner's Dilemma" PNAS 2013 for more details. Supposedly ZDGTFT2 is (1, 1/8, 1, 1/4). Note that this chi appears to be 1/chi for extortionate strategies."""
 
     name = 'ZD GTFT2'
 
     def __init__(self, phi=1., chi=0.5):
         chi = float(chi)
-        (R, P, T, S) = Game().RPTS()
+        (R, P, T, S) = Game().RPST()
         kappa = R
         B = T
         C = T-R 
@@ -123,7 +125,7 @@ class ZDGTFT2(MemoryOnePlayer):
         #if min_chi < 0:
             #min_chi = 0
         #chi = min_chi
-        p1 = 1. - phi*(1-chi) * (R-kappa)
+        p1 = 1. - phi*(1-chi) * (B - C - kappa)
         p2 = 1. - phi * (chi *C + B - (1 - chi)*kappa)
         p3 = phi * (chi*B + C + (1- chi)*kappa)
         p4 = phi*(1-chi)*kappa

--- a/axelrod/tests/test_game.py
+++ b/axelrod/tests/test_game.py
@@ -13,9 +13,9 @@ class TestGame(unittest.TestCase):
         expected_scores = {('C', 'D'): (0, 5), ('D', 'C'): (5, 0), ('D', 'D'): (1, 1), ('C', 'C'): (3, 3)}
         self.assertEquals(self.game.scores, expected_scores)
 
-    def test_RPTS(self):
+    def test_RPST(self):
         expected_values = (3, 1, 0, 5)
-        self.assertEquals(self.game.RPTS(), expected_values)
+        self.assertEquals(self.game.RPST(), expected_values)
 
     def test_score(self):
         self.assertEquals(self.game.score(('C', 'C')), (3, 3))

--- a/axelrod/tests/test_memoryone.py
+++ b/axelrod/tests/test_memoryone.py
@@ -189,15 +189,15 @@ class TestStochasticWSLS(TestPlayer):
         self.assertEqual(P1.strategy(P2), 'C')
         self.assertEqual(P1.strategy(P2), 'C')
 
-class TestZDChi(TestPlayer):
+class TestExtort2(TestPlayer):
 
-    name = "ZD Extort-2"
-    player = axelrod.ZDChi
+    name = "ZD-Extort-2"
+    player = axelrod.Extort2
     stochastic = True
 
     def test_four_vector(self):
         P1 = self.player()
-        expected_dictionary = {('C', 'D'): 0.5, ('D', 'C'): 0.75, ('D', 'D'): 0.0, ('C', 'C'): 1.1666666666666667}
+        expected_dictionary = {('C', 'D'): 0.5, ('D', 'C'): 1./3, ('D', 'D'): 0., ('C', 'C'): 8./9}
         for key in sorted(expected_dictionary.keys()):
             self.assertAlmostEqual(P1._four_vector[key],
                     expected_dictionary[key])
@@ -212,15 +212,15 @@ class TestZDChi(TestPlayer):
         P1.history = ['C']
         P2.history = ['C']
         random.seed(2)
-        self.assertEqual(P1.strategy(P2), 'C')
-        self.assertEqual(P1.strategy(P2), 'C')
+        self.assertEqual(P1.strategy(P2), 'D')
+        self.assertEqual(P1.strategy(P2), 'D')
         self.assertEqual(P1.strategy(P2), 'C')
         self.assertEqual(P1.strategy(P2), 'C')
         P1.history = ['C']
         P2.history = ['D']
-        self.assertEqual(P1.strategy(P2), 'D')
-        self.assertEqual(P1.strategy(P2), 'D')
-        self.assertEqual(P1.strategy(P2), 'D')
+        self.assertEqual(P1.strategy(P2), 'C')
+        self.assertEqual(P1.strategy(P2), 'C')
+        self.assertEqual(P1.strategy(P2), 'C')
         self.assertEqual(P1.strategy(P2), 'C')
         P1.history = ['D']
         P2.history = ['C']
@@ -237,13 +237,13 @@ class TestZDChi(TestPlayer):
 
 class TestZDGTFT2(TestPlayer):
 
-    name = "ZD GTFT2"
+    name = "ZD-GTFT-2"
     player = axelrod.ZDGTFT2
     stochastic = True
 
     def test_four_vector(self):
         P1 = self.player()
-        expected_dictionary = {('C', 'D'): 4.0, ('D', 'C'): -1.5, ('D', 'D'): 1.5, ('C', 'C'): 1.0}
+        expected_dictionary = {('C', 'D'): 1./8, ('D', 'C'): 1., ('D', 'D'): 0.25, ('C', 'C'): 1.}
         for key in sorted(expected_dictionary.keys()):
             self.assertAlmostEqual(P1._four_vector[key],
                     expected_dictionary[key])
@@ -264,10 +264,10 @@ class TestZDGTFT2(TestPlayer):
         self.assertEqual(P1.strategy(P2), 'C')
         P1.history = ['C']
         P2.history = ['D']
-        self.assertEqual(P1.strategy(P2), 'C')
-        self.assertEqual(P1.strategy(P2), 'C')
-        self.assertEqual(P1.strategy(P2), 'C')
-        self.assertEqual(P1.strategy(P2), 'C')
+        self.assertEqual(P1.strategy(P2), 'D')
+        self.assertEqual(P1.strategy(P2), 'D')
+        self.assertEqual(P1.strategy(P2), 'D')
+        self.assertEqual(P1.strategy(P2), 'D')
         P1.history = ['D']
         P2.history = ['C']
         self.assertEqual(P1.strategy(P2), 'D')

--- a/axelrod/tests/test_memoryone.py
+++ b/axelrod/tests/test_memoryone.py
@@ -189,10 +189,10 @@ class TestStochasticWSLS(TestPlayer):
         self.assertEqual(P1.strategy(P2), 'C')
         self.assertEqual(P1.strategy(P2), 'C')
 
-class TestExtort2(TestPlayer):
+class TestZDExtort2(TestPlayer):
 
     name = "ZD-Extort-2"
-    player = axelrod.Extort2
+    player = axelrod.ZDExtort2
     stochastic = True
 
     def test_four_vector(self):

--- a/axelrod/tests/test_memoryone.py
+++ b/axelrod/tests/test_memoryone.py
@@ -218,15 +218,15 @@ class TestZDExtort2(TestPlayer):
         self.assertEqual(P1.strategy(P2), 'C')
         P1.history = ['C']
         P2.history = ['D']
-        self.assertEqual(P1.strategy(P2), 'C')
-        self.assertEqual(P1.strategy(P2), 'C')
-        self.assertEqual(P1.strategy(P2), 'C')
+        self.assertEqual(P1.strategy(P2), 'D')
+        self.assertEqual(P1.strategy(P2), 'D')
+        self.assertEqual(P1.strategy(P2), 'D')
         self.assertEqual(P1.strategy(P2), 'C')
         P1.history = ['D']
         P2.history = ['C']
-        self.assertEqual(P1.strategy(P2), 'C')
-        self.assertEqual(P1.strategy(P2), 'C')
-        self.assertEqual(P1.strategy(P2), 'C')
+        self.assertEqual(P1.strategy(P2), 'D')
+        self.assertEqual(P1.strategy(P2), 'D')
+        self.assertEqual(P1.strategy(P2), 'D')
         self.assertEqual(P1.strategy(P2), 'C')
         P1.history = ['D']
         P2.history = ['D']
@@ -270,13 +270,13 @@ class TestZDGTFT2(TestPlayer):
         self.assertEqual(P1.strategy(P2), 'D')
         P1.history = ['D']
         P2.history = ['C']
-        self.assertEqual(P1.strategy(P2), 'D')
-        self.assertEqual(P1.strategy(P2), 'D')
-        self.assertEqual(P1.strategy(P2), 'D')
-        self.assertEqual(P1.strategy(P2), 'D')
+        self.assertEqual(P1.strategy(P2), 'C')
+        self.assertEqual(P1.strategy(P2), 'C')
+        self.assertEqual(P1.strategy(P2), 'C')
+        self.assertEqual(P1.strategy(P2), 'C')
         P1.history = ['D']
         P2.history = ['D']
-        self.assertEqual(P1.strategy(P2), 'C')
-        self.assertEqual(P1.strategy(P2), 'C')
-        self.assertEqual(P1.strategy(P2), 'C')
-        self.assertEqual(P1.strategy(P2), 'C')
+        self.assertEqual(P1.strategy(P2), 'D')
+        self.assertEqual(P1.strategy(P2), 'D')
+        self.assertEqual(P1.strategy(P2), 'D')
+        self.assertEqual(P1.strategy(P2), 'D')


### PR DESCRIPTION


The formulas for ZDGTFT2 were not correct. Unfortunately the parametrization in the Stewart and Plotkin reference appears to be incorrect, however there is a newer reference here. I was able to track down what I believe S&P used in their tournament and updated the strategies accordingly (see here ). Both of these are easily specified from the new parametrization.

Now that we have the correct parametrization of the ZD strategy vectors, it is only necessary to have one abstract ZeroDeterminant player class (MemoryOne subclassed) that can be further subclassed for ZD-Extort-2 and ZD-GTFT-2. I was also able to put in some parameter checks to make sure that the conditional probabilities actually lie between 0 and 1, which they were not guaranteed to before.

There was an error in the Game class in game.py -- the RPST function swapped two of the values.

The failed tests are "designed to fail" since they rely on events with probability not 0 or 1. I'm guessing that these were somehow whitelisted before and that I messed that up by changing the class names? Looks like the checks starting failing when I renamed Extort2 to ZDExtort2.
