### PR TITLE
Heads Up play tests

### DIFF
--- a/axelrod/tests/test_headsup.py
+++ b/axelrod/tests/test_headsup.py
@@ -1,0 +1,67 @@
+"""Test for the cooperator strategy."""
+
+import axelrod
+
+from test_player import TestHeadsUp
+
+C, D = 'C', 'D'
+
+class TestTFTvsWSLS(TestHeadsUp):
+    """Test TFT vs WSLS"""
+    def test_rounds(self):
+        outcomes = [[C, C], [C, C], [C, C], [C, C]]
+        self.versus_test(axelrod.TitForTat, axelrod.WinStayLoseShift, outcomes)
+
+class TestTFTvSTFT(TestHeadsUp):
+    """Test TFT vs Suspicious TFT"""
+    def test_rounds(self):
+        outcomes = [[C, D], [D, C], [C, D], [D, C], [C, D], [D, C]]
+        self.versus_test(axelrod.TitForTat, axelrod.SuspiciousTitForTat, outcomes)
+
+class TestTFTvsBully(TestHeadsUp):
+    """Test TFT vs Bully"""
+    def test_rounds(self):
+        outcomes = [[C, D], [D, D], [D, C], [C, C], [C, D], [D, D]]
+        self.versus_test(axelrod.TitForTat, axelrod.Bully, outcomes)
+
+class TestTF2TvsBully(TestHeadsUp):
+    """Test Tit for Two Tats vs Bully"""
+    def test_rounds(self):
+        outcomes = [[C, D], [C, D], [D, D], [D, C], [C, C], [C, D], [C, D], [D, D]]
+        self.versus_test(axelrod.TitFor2Tats, axelrod.Bully, outcomes)
+
+class TestZDGTFT2vsBully(TestHeadsUp):
+    """Test ZDGTFT2 vs Bully"""
+    def test_rounds(self):
+        outcomes = [[C, D], [D, D], [D, C], [C, C], [C, D], [D, D]]
+        self.versus_test(axelrod.ZDGTFT2, axelrod.Bully, outcomes, random_seed=2)
+
+class TestZDExtort2vsTFT(TestHeadsUp):
+    """Test ZDExtort2 vs Bully"""
+    def test_rounds(self):
+        outcomes = [[C, C], [D, C], [D, D], [D, D], [D, D], [D, D]]
+        self.versus_test(axelrod.ZDExtort2, axelrod.TitForTat, outcomes, random_seed=2)
+
+class FoolMeOncevsBully(TestHeadsUp):
+    """Test Fool Me Once vs Bully"""
+    def test_rounds(self):
+        outcomes = [[C, D], [C, D], [D, D], [D, C], [D, C], [D, C]]
+        self.versus_test(axelrod.FoolMeOnce, axelrod.Bully, outcomes)
+
+class FoolMeOncevsSTFT(TestHeadsUp):
+    """Test Fool Me Once vs Suspicious TFT"""
+    def test_rounds(self):
+        outcomes = [[C, D]] + [[C, C]]*8
+        self.versus_test(axelrod.FoolMeOnce, axelrod.SuspiciousTitForTat, outcomes)
+
+class GrudgervsSTFT(TestHeadsUp):
+    """Test Grudger vs Suspicious TFT"""
+    def test_rounds(self):
+        outcomes = [[C, D], [D, C]] + [[D, D]]*8
+        self.versus_test(axelrod.Grudger, axelrod.SuspiciousTitForTat, outcomes)
+
+class TestWSLSvsBully(TestHeadsUp):
+    """Test WSLS vs Bully"""
+    def test_rounds(self):
+        outcomes = [[C, D], [D, D], [C, C], [C, D], [D, D]]
+        self.versus_test(axelrod.WinStayLoseShift, axelrod.Bully, outcomes)

--- a/axelrod/tests/test_player.py
+++ b/axelrod/tests/test_player.py
@@ -85,7 +85,8 @@ class TestPlayer(unittest.TestCase):
 class TestHeadsUp(unittest.TestCase):
     """Test class for heads up play between two given players."""
     
-    def versus_test(self, player_1_class, player_2_class, outcomes, player_1_history=None, player_2_history=None, random_seed=None):
+    def versus_test(self, player_1_class, player_2_class, outcomes, 
+                    player_1_history=None, player_2_history=None, random_seed=None):
         """Tests a sequence of outcomes for two given players."""
         if random_seed:
             random.seed(random_seed)

--- a/axelrod/tests/test_player.py
+++ b/axelrod/tests/test_player.py
@@ -83,20 +83,22 @@ class TestPlayer(unittest.TestCase):
             self, P1, P2, history_1, history_2, responses, random_seed=random_seed)
 
 class TestHeadsUp(unittest.TestCase):
+    """Test class for heads up play between two given players."""
     
     def versus_test(self, player_1_class, player_2_class, outcomes, player_1_history=None, player_2_history=None, random_seed=None):
+        """Tests a sequence of outcomes for two given players."""
         if random_seed:
             random.seed(random_seed)
         player_1 = player_1_class()
         player_2 = player_2_class()
-        if player_1.history is not None:
-            player_1.history = player_1_history
-        else:
-            player_1.history = []
-        if player_2.history is not None:
-            player_2.history = player_2_history
-        else:
-            player_2.history = []
+        # Set histories
+        if player_1_history is None:
+            player_1_history = []
+        player_1.history = player_1_history
+        if player_2_history is None:
+            player_2_history = []
+        player_2.history = player_2_history
+        # Test sequence of play
         for outcome_1, outcome_2 in outcomes:
             player_1.play(player_2)
             self.assertEqual(player_1_history[-1], outcome_1)

--- a/axelrod/tests/test_player.py
+++ b/axelrod/tests/test_player.py
@@ -24,6 +24,7 @@ def test_responses(test_class, P1, P2, history_1, history_2, responses, random_s
     for response in responses:
         test_class.assertEqual(P1.strategy(P2), response)
 
+
 class TestPlayer(unittest.TestCase):
 
     name = "Player"
@@ -81,6 +82,7 @@ class TestPlayer(unittest.TestCase):
         P2 = axelrod.Player()
         test_responses(
             self, P1, P2, history_1, history_2, responses, random_seed=random_seed)
+
 
 class TestHeadsUp(unittest.TestCase):
     """Test class for heads up play between two given players."""

--- a/axelrod/tests/test_player.py
+++ b/axelrod/tests/test_player.py
@@ -24,7 +24,6 @@ def test_responses(test_class, P1, P2, history_1, history_2, responses, random_s
     for response in responses:
         test_class.assertEqual(P1.strategy(P2), response)
 
-
 class TestPlayer(unittest.TestCase):
 
     name = "Player"
@@ -82,3 +81,23 @@ class TestPlayer(unittest.TestCase):
         P2 = axelrod.Player()
         test_responses(
             self, P1, P2, history_1, history_2, responses, random_seed=random_seed)
+
+class TestHeadsUp(unittest.TestCase):
+    
+    def versus_test(self, player_1_class, player_2_class, outcomes, player_1_history=None, player_2_history=None, random_seed=None):
+        if random_seed:
+            random.seed(random_seed)
+        player_1 = player_1_class()
+        player_2 = player_2_class()
+        if player_1.history is not None:
+            player_1.history = player_1_history
+        else:
+            player_1.history = []
+        if player_2.history is not None:
+            player_2.history = player_2_history
+        else:
+            player_2.history = []
+        for outcome_1, outcome_2 in outcomes:
+            player_1.play(player_2)
+            self.assertEqual(player_1_history[-1], outcome_1)
+            self.assertEqual(player_2_history[-1], outcome_2)

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -276,6 +276,17 @@ This is equivalent to::
 In this case each player has their history set to :code:`[C]` and the expected responses are D, C, C, C. Note that the histories will elongate as the responses accumulated.
 
 
+Finally, there is a :code:`TestHeadsUp` class that streamlines the testing of two strategies playing each other using a test function :code:`versus_test`. For example, to test several rounds of play of Tit-For-Two-Tats versus Bully::
+
+    class TestTF2TvsBully(TestHeadsUp):
+        """Test Tit for Two Tats vs Bully"""
+        def test_rounds(self):
+            outcomes = [[C, D], [C, D], [D, D], [D, C], [C, C], [C, D], [C, D], [D, D]]
+            self.versus_test(axelrod.TitFor2Tats, axelrod.Bully, outcomes)
+
+The function :code:`versus_test` also accepts a :code:`random_seed` keyword, and like :code:`responses_test` the history is accumulated.
+
+
 How to run tests
 ''''''''''''''''
 


### PR DESCRIPTION
This PR adds a new class TestHeadsUp to test_player.py that takes two strategies and a list of expected rounds of play for testing. It's very similar to the last testing PR. Several examples are included in test_headsup.py and there's a short explanation of how to make more such tests on the contributions page.