### PR TITLE
Close matplotlib memory leak that results from running several tourna…

### DIFF
--- a/axelrod/tournament_manager.py
+++ b/axelrod/tournament_manager.py
@@ -140,6 +140,7 @@ class TournamentManager(object):
     def _save_plot(self, figure, file_name, dpi=400):
         figure.savefig(file_name, bbox_inches='tight', dpi=dpi)
         figure.clf()
+        plt.close(figure)
 
     def _save_cache_to_file(self, cache, file_name):
         self._logger.debug(


### PR DESCRIPTION
Close matplotlib memory leak that results from running several tournments and generating many figures. Otherwise eventually this happens:

/usr/lib/pymodules/python2.7/matplotlib/pyplot.py:412: RuntimeWarning: More than 20 figures have been opened. Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are retained until explicitly closed and may consume too much memory. (To control this warning, see the rcParam `figure.max_num_figures`).
