### PR TITLE
Replace memoryone with memory_depth, various PEP8, a few integer division corrections

### DIFF
--- a/axelrod/strategies/alternator.py
+++ b/axelrod/strategies/alternator.py
@@ -5,7 +5,7 @@ class Alternator(Player):
     """A player who alternates between cooperating and defecting."""
 
     name = 'Alternator'
-    memoryone = True
+    memory_depth = 1
 
     def strategy(self, opponent):
         if len(self.history) == 0:

--- a/axelrod/strategies/appeaser.py
+++ b/axelrod/strategies/appeaser.py
@@ -9,7 +9,7 @@ class Appeaser(Player):
     """
 
     name = 'Appeaser'
-    memoryone = False  # Depends on internal memory.
+    memory_depth = float('inf')  # Depends on internal memory.
 
     def strategy(self, opponent):
         if len(self.history) == 0:

--- a/axelrod/strategies/averagecopier.py
+++ b/axelrod/strategies/averagecopier.py
@@ -6,7 +6,7 @@ class AverageCopier(Player):
     """The player will cooperate with probability p if the opponent's cooperation ratio is p."""
 
     name = 'Average Copier'
-    memoryone = False  # Long memory
+    memory_depth = float('inf')  # Long memory
 
     def strategy(self, opponent):
         """Randomly picks a strategy (not affected by history)."""
@@ -23,7 +23,7 @@ class NiceAverageCopier(Player):
     """Same as Average Copier, but always starts by cooperating."""
 
     name = 'Nice Average Copier'
-    memoryone = False  # Long memory
+    memory_depth = float('inf')  # Long memory
 
     def strategy(self, opponent):
         """Randomly picks a strategy (not affected by history)."""

--- a/axelrod/strategies/cooperator.py
+++ b/axelrod/strategies/cooperator.py
@@ -5,7 +5,7 @@ class Cooperator(Player):
     """A player who only ever cooperates."""
 
     name = 'Cooperator'
-    memory_depth = 1  # Four-Vector = (1,1,1,1)
+    memory_depth = 0  # Memory-one Four-Vector = (1,1,1,1)
 
     def strategy(self, opponent):
         return 'C'

--- a/axelrod/strategies/cooperator.py
+++ b/axelrod/strategies/cooperator.py
@@ -5,7 +5,7 @@ class Cooperator(Player):
     """A player who only ever cooperates."""
 
     name = 'Cooperator'
-    memoryone = True  # Four-Vector = (1,1,1,1)
+    memory_depth = 1  # Four-Vector = (1,1,1,1)
 
     def strategy(self, opponent):
         return 'C'
@@ -15,7 +15,7 @@ class TrickyCooperator(Player):
     """A cooperator that is trying to be tricky."""
 
     name = "Tricky Cooperator"
-    memoryone = False  # Long memory
+    memory_depth = 10  # Long memory
 
     def strategy(self, opponent):
         """Almost always cooperates, but will try to trick the opponent by defecting.

--- a/axelrod/strategies/darwin.py
+++ b/axelrod/strategies/darwin.py
@@ -1,5 +1,8 @@
 import inspect
-from axelrod import Player
+from axelrod import Player, Game
+
+
+(R, P, S, T) = Game().RPST()
 
 
 class Darwin(Player):
@@ -20,12 +23,13 @@ class Darwin(Player):
     """
 
     name = "Darwin"
+    memory_depth = float('inf')
     genome = ['C']
     valid_callers = ["play"]    # What functions may invoke our strategy.
-    outcomes = { ('C','C') : 1,
-                 ('C','D') : -5,
-                 ('D','C') : 5,
-                 ('D','D') : -1
+    outcomes = { ('C','C') : R,
+                 ('C','D') : S,
+                 ('D','C') : T,
+                 ('D','D') : P
                }
 
     def __init__(self):

--- a/axelrod/strategies/defector.py
+++ b/axelrod/strategies/defector.py
@@ -5,7 +5,7 @@ class Defector(Player):
     """A player who only ever defects."""
 
     name = 'Defector'
-    memoryone = True  # Four-Vector = (0,0,0,0)
+    memory_depth = 1  # Four-Vector = (0,0,0,0)
 
     def strategy(self, opponent):
         return 'D'
@@ -15,7 +15,7 @@ class TrickyDefector(Player):
     """A defector that is trying to be tricky."""
 
     name = "Tricky Defector"
-    memoryone = False  # Long memory
+    memory_depth = float('inf')  # Long memory
 
     def strategy(self, opponent):
         """Almost always defects, but will try to trick the opponent into cooperating.

--- a/axelrod/strategies/defector.py
+++ b/axelrod/strategies/defector.py
@@ -5,7 +5,7 @@ class Defector(Player):
     """A player who only ever defects."""
 
     name = 'Defector'
-    memory_depth = 1  # Four-Vector = (0,0,0,0)
+    memory_depth = 0  # Memory-one Four-Vector = (0,0,0,0)
 
     def strategy(self, opponent):
         return 'D'

--- a/axelrod/strategies/forgiver.py
+++ b/axelrod/strategies/forgiver.py
@@ -8,14 +8,14 @@ class Forgiver(Player):
     """
 
     name = 'Forgiver'
-    memoryone = False  # Long memory
+    memory_depth = float('inf')  # Long memory
 
     def strategy(self, opponent):
         """
         Begins by playing C, then plays D if the opponent has defected more than 10 percent of the time
         """
         try:
-            if opponent.history.count('D') > len(opponent.history)/10:
+            if opponent.history.count('D') > len(opponent.history) / 10.:
                 return 'D'
             return 'C'
         except IndexError:
@@ -30,7 +30,7 @@ class ForgivingTitForTat(Player):
     """
 
     name = 'Forgiving Tit For Tat'
-    memoryone = False  # Long memory
+    memory_depth = float('inf')  # Long memory
 
     def strategy(self, opponent):
         """
@@ -39,7 +39,7 @@ class ForgivingTitForTat(Player):
         and their most recent decision was defect.
         """
         try:
-            if opponent.history.count('D') > len(opponent.history)/10:
+            if opponent.history.count('D') > len(opponent.history) / 10.:
                 return opponent.history[-1]
             return 'C'
         except IndexError:

--- a/axelrod/strategies/geller.py
+++ b/axelrod/strategies/geller.py
@@ -33,6 +33,7 @@ class Geller(Player):
 
     name = 'Geller'
     default = lambda self: 'C' if random.random() > 0.5 else 'D'
+    memory_depth = -1
 
     def strategy(self, opponent):
         """

--- a/axelrod/strategies/gobymajority.py
+++ b/axelrod/strategies/gobymajority.py
@@ -9,8 +9,13 @@ class GoByMajority(Player):
     default this is 0)
     """
 
-    memory = 0
-    memoryone = False  # Long memory
+    # memory_depth is set by __init__
+
+    def __init__(self, memory_depth=0):
+        Player.__init__(self)
+        self.memory_depth = memory_depth
+        # Set class var for consistency with other strategies
+        self.__class__.memory_depth = memory_depth
 
     def strategy(self, opponent):
         """This is affected by the history of the opponent.
@@ -18,35 +23,50 @@ class GoByMajority(Player):
         As long as the opponent cooperates at least as often as they defect then the player will cooperate.
         If at any point the opponent has more defections than cooperations in memory the player defects.
         """
-        history = opponent.history[-self.memory:]
+
+        memory = self.memory_depth
+        history = opponent.history[-memory:]
         if sum([s == 'D' for s in history]) > sum([s == 'C' for s in history]):
             return 'D'
         return 'C'
 
     def __repr__(self):
         """The string method for the strategy."""
-        return 'Go By Majority' + (self.memory > 0) * ("/%i" % self.memory)
+        memory = self.memory_depth
+        return 'Go By Majority' + (memory > 0) * ("/%i" % memory)
 
 
 class GoByMajority40(GoByMajority):
-    """ :code:`GoByMajority` player with a memory of 40.
+    """ 
+    GoByMajority player with a memory of 40.
     """
-    memory = 40
+
+    def __init__(self, memory_depth=40):
+        super(self.__class__, self).__init__(memory_depth=memory_depth)
 
 
 class GoByMajority20(GoByMajority):
-    """ :code:`GoByMajority` player with a memory of 20.
     """
-    memory = 20
+    GoByMajority player with a memory of 20.
+    """
+
+    def __init__(self, memory_depth=20):
+        super(self.__class__, self).__init__(memory_depth=memory_depth)
 
 
 class GoByMajority10(GoByMajority):
-    """ :code:`GoByMajority` player with a memory of 10.
     """
-    memory = 10
+    GoByMajority player with a memory of 10.
+    """
+
+    def __init__(self, memory_depth=10):
+        super(self.__class__, self).__init__(memory_depth=memory_depth)
 
 
 class GoByMajority5(GoByMajority):
-    """ :code:`GoByMajority` player with a memory of 5.
     """
-    memory = 5
+    GoByMajority player with a memory of 5.
+    """
+
+    def __init__(self, memory_depth=5):
+        super(self.__class__, self).__init__(memory_depth=memory_depth)

--- a/axelrod/strategies/grudger.py
+++ b/axelrod/strategies/grudger.py
@@ -5,7 +5,7 @@ class Grudger(Player):
     """A player starts by cooperating however will defect if at any point the opponent has defected."""
 
     name = 'Grudger'
-    memoryone = False  # Long memory
+    memory_depth = float('inf')  # Long memory
 
     def strategy(self, opponent):
         """Begins by playing C, then plays D for the remaining rounds if the opponent ever plays D."""
@@ -19,7 +19,7 @@ class ForgetfulGrudger(Player):
     opponent has defected, but forgets after meme_length matches."""
 
     name = 'Forgetful Grudger'
-    memoryone = False  # Long memory
+    memory_depth = float('inf')  # Long memory
 
     def __init__(self):
         """Initialised the player."""
@@ -55,7 +55,7 @@ class OppositeGrudger(Player):
     """A player starts by defecting however will cooperate if at any point the opponent has cooperated."""
 
     name = 'Opposite Grudger'
-    memoryone = False  # Long memory
+    memory_depth = float('inf')  # Long memory
 
     def strategy(self, opponent):
         """Begins by playing D, then plays C for the remaining rounds if the opponent ever plays C."""
@@ -68,7 +68,7 @@ class Davis(Player):
     defecting if at any point the opponent has defected."""
 
     name = 'Davis'
-    memoryone = False  # Long memory
+    memory_depth = float('inf')  # Long memory
 
     def __init__(self, rounds_to_cooperate=10):
         Player.__init__(self)

--- a/axelrod/strategies/grumpy.py
+++ b/axelrod/strategies/grumpy.py
@@ -7,7 +7,7 @@ class Grumpy(Player):
     when the opponent co-operates."""
 
     name = 'Grumpy'
-    memoryone = False  # Depends on internal memory.
+    memory_depth = float('inf')  # Depends on internal memory.
 
     def __init__(self, starting_state='Nice', grumpy_threshold=10,
                  nice_threshold=-10):

--- a/axelrod/strategies/hunter.py
+++ b/axelrod/strategies/hunter.py
@@ -6,7 +6,7 @@ class DefectorHunter(Player):
     """A player who hunts for defectors."""
 
     name = 'Defector Hunter'
-    memoryone = False  # Long memory
+    memory_depth = float('inf')  # Long memory
 
     def strategy(self, opponent):
         if (len(self.history) >= 4 and all([h == 'D' for h in opponent.history])):
@@ -18,7 +18,7 @@ class CooperatorHunter(Player):
     """A player who hunts for cooperators."""
 
     name = 'Cooperator Hunter'
-    memoryone = False  # Long memory
+    memory_depth = float('inf')  # Long memory
 
     def strategy(self, opponent):
         if len(self.history) >= 4 and all([h == 'C' for h in opponent.history]):
@@ -30,7 +30,7 @@ class AlternatorHunter(Player):
     """A player who hunts for alternators."""
 
     name = 'Alternator Hunter'
-    memoryone = False  # Long memory
+    memory_depth = float('inf')  # Long memory
 
     def strategy(self, opponent):
         oh = opponent.history
@@ -43,7 +43,7 @@ class MathConstantHunter(Player):
     """A player who hunts for mathemtical constant players."""
 
     name = "Math Constant Hunter"
-    memoryone = False  # Long memory
+    memory_depth = float('inf')  # Long memory
 
     def strategy(self, opponent):
 
@@ -64,7 +64,7 @@ class RandomHunter(Player):
     """A player who hunts for random players."""
 
     name = "Random Hunter"
-    memoryone = False  # Long memory
+    memory_depth = float('inf')  # Long memory
 
     # We need to make sure this is not marked as stochastic.
     def __init__(self):
@@ -90,7 +90,7 @@ class MetaHunter(MetaPlayer):
     """A player who uses a selection of hunters sequentially."""
 
     name = "Meta Hunter"
-    memoryone = False  # Long memory
+    memory_depth = float('inf')  # Long memory
 
     def __init__(self):
 

--- a/axelrod/strategies/inverse.py
+++ b/axelrod/strategies/inverse.py
@@ -3,15 +3,15 @@ import random
 
 
 class Inverse(Player):
-    """A player who defects with a probability that diminishes relative to how long ago the opponent defected."""
+    """A player who defects with a probability that diminishes relative to how
+    long ago the opponent defected."""
 
     name = 'Inverse'
-    memoryone = False  # Long memory
+    memory_depth = float('inf')  # Long memory
 
     def strategy(self, opponent):
-        """Looks at opponent history to see if they have defected.
-
-        If so, player defection is inversely proportional to when this occurred.
+        """Looks at opponent history to see if they have defected. If so, player
+        defection is inversely proportional to when this occurred.
         """
 
         index = next((index for index, value in enumerate(opponent.history, start=1) if value == 'D'), None)
@@ -21,6 +21,6 @@ class Inverse(Player):
 
         rnd_num = random.random()
 
-        if rnd_num < 1/abs(index):
+        if rnd_num < 1 / float(abs(index)):
             return 'D'
         return 'C'

--- a/axelrod/strategies/mathematicalconstants.py
+++ b/axelrod/strategies/mathematicalconstants.py
@@ -6,7 +6,7 @@ class CotoDeRatio(Player):
     """The player will always aim to bring the ratio of co-operations to
     defections closer to the ratio as given in a sub class"""
 
-    memoryone = False  # Long memory
+    memory_depth = float('inf')  # Long memory
 
     def strategy(self, opponent):
 

--- a/axelrod/strategies/memoryone.py
+++ b/axelrod/strategies/memoryone.py
@@ -9,7 +9,7 @@ class WinStayLoseShift(Player):
     """Win-Stay Lose-Shift, also called Pavlov."""
 
     name = 'Win-Stay Lose-Shift'
-    memoryone = True  # Four-Vector = (1,0,0,1)
+    memory_depth = 1  # Four-Vector = (1,0,0,1)
 
     def __init__(self, initial='C'):
         Player.__init__(self)
@@ -39,7 +39,7 @@ class MemoryOnePlayer(Player):
     with a initializing four_vector."""
 
     name = 'Generic Memory One Player'
-    memoryone = True
+    memory_depth = 1
 
     def __init__(self, four_vector, initial='C'):
         Player.__init__(self)

--- a/axelrod/strategies/meta.py
+++ b/axelrod/strategies/meta.py
@@ -5,7 +5,7 @@ class MetaPlayer(Player):
     """A generic player that has its own team of players."""
 
     team = []
-    memoryone = False  # Long memory
+    memory_depth = float('inf')  # Long memory
 
     def __init__(self):
 

--- a/axelrod/strategies/oncebitten.py
+++ b/axelrod/strategies/oncebitten.py
@@ -8,7 +8,7 @@ class OnceBitten(Player):
     """
 
     name = 'Once Bitten'
-    memoryone = False  # Long memory
+    memory_depth = float('inf')  # Long memory
 
     def __init__(self):
         """
@@ -52,11 +52,11 @@ class OnceBitten(Player):
 
 class FoolMeOnce(Player):
     """
-    Forgives one D then retaliates forever on a second D.
+    Forgives one D then retaliates forever on a second D. Also known as GRIM.
     """
 
     name = 'Fool Me Once'
-    memoryone = False  # Long memory
+    memory_depth = float('inf')  # Long memory
 
     def __init__(self):
         """
@@ -87,9 +87,9 @@ class ForgetfulFoolMeOnce(Player):
     """
 
     name = 'Forgetful Fool Me Once'
-    memoryone = False  # Long memory
+    memory_depth = float('inf')  # Long memory
 
-    def __init__(self, forget_probability=0.1):
+    def __init__(self, forget_probability = 0.05):
         super(ForgetfulFoolMeOnce, self).__init__()
         self.D_count = 0
         self._initial = 'C'

--- a/axelrod/strategies/oncebitten.py
+++ b/axelrod/strategies/oncebitten.py
@@ -52,7 +52,7 @@ class OnceBitten(Player):
 
 class FoolMeOnce(Player):
     """
-    Forgives one D then retaliates forever on a second D. Also known as GRIM.
+    Forgives one D then retaliates forever on a second D.
     """
 
     name = 'Fool Me Once'

--- a/axelrod/strategies/punisher.py
+++ b/axelrod/strategies/punisher.py
@@ -35,7 +35,7 @@ class Punisher(Player):
             self.grudge_memory += 1
             return 'D'
         elif 'D' in opponent.history[-1:]:
-            self.mem_length = (sum([i == 'D' for i in opponent.history])*20) / float(len(opponent.history))
+            self.mem_length = (sum([i == 'D' for i in opponent.history])*20) / len(opponent.history)
             self.grudged = True
             return 'D'
         return 'C'
@@ -84,7 +84,7 @@ class InversePunisher(Player):
             self.grudge_memory += 1
             return 'D'
         elif 'D' in opponent.history[-1:]:
-            self.mem_length = ((sum([i == 'C' for i in opponent.history]))*20)/float(len(opponent.history))
+            self.mem_length = ((sum([i == 'C' for i in opponent.history]))*20) / len(opponent.history)
             if self.mem_length == 0:
                 self.mem_length += 1
             self.grudged = True

--- a/axelrod/strategies/punisher.py
+++ b/axelrod/strategies/punisher.py
@@ -9,7 +9,7 @@ class Punisher(Player):
     """
 
     name = 'Punisher'
-    memoryone = False  # Long memory
+    memory_depth = float('inf')  # Long memory
 
     def __init__(self):
         """
@@ -35,7 +35,7 @@ class Punisher(Player):
             self.grudge_memory += 1
             return 'D'
         elif 'D' in opponent.history[-1:]:
-            self.mem_length = (sum([i == 'D' for i in opponent.history])*20)/len(opponent.history)
+            self.mem_length = (sum([i == 'D' for i in opponent.history])*20) / float(len(opponent.history))
             self.grudged = True
             return 'D'
         return 'C'
@@ -58,7 +58,7 @@ class InversePunisher(Player):
     """
 
     name = 'Inverse Punisher'
-    memoryone = False  # Long memory
+    memory_depth = float('inf')  # Long memory
 
     def __init__(self):
         """
@@ -84,7 +84,7 @@ class InversePunisher(Player):
             self.grudge_memory += 1
             return 'D'
         elif 'D' in opponent.history[-1:]:
-            self.mem_length = ((sum([i == 'C' for i in opponent.history]))*20)/len(opponent.history)
+            self.mem_length = ((sum([i == 'C' for i in opponent.history]))*20)/float(len(opponent.history))
             if self.mem_length == 0:
                 self.mem_length += 1
             self.grudged = True

--- a/axelrod/strategies/qlearner.py
+++ b/axelrod/strategies/qlearner.py
@@ -10,7 +10,7 @@ class RiskyQLearner(Player):
     """
 
     name = 'Risky QLearner'
-    memoryone = False  # Long memory
+    memory_depth = float('inf')  # Long memory
     learning_rate = 0.9
     discount_rate = 0.9
     action_selection_parameter = 0.1

--- a/axelrod/strategies/rand.py
+++ b/axelrod/strategies/rand.py
@@ -6,7 +6,7 @@ class Random(Player):
     """A player who randomly chooses between cooperating and defecting."""
 
     name = 'Random'
-    memory_depth = 1  # Four-Vector = (0.5, 0.5, 0.5, 0.5)
+    memory_depth = 0  # Memory-one Four-Vector = (0.5, 0.5, 0.5, 0.5)
 
     def strategy(self, opponent):
         return random.choice(['C', 'D'])

--- a/axelrod/strategies/rand.py
+++ b/axelrod/strategies/rand.py
@@ -6,7 +6,7 @@ class Random(Player):
     """A player who randomly chooses between cooperating and defecting."""
 
     name = 'Random'
-    memoryone = True  # Four-Vector = (0.5, 0.5, 0.5, 0.5)
+    memory_depth = 1  # Four-Vector = (0.5, 0.5, 0.5, 0.5)
 
     def strategy(self, opponent):
         return random.choice(['C', 'D'])
@@ -18,11 +18,12 @@ class Tullock(Player):
     than the opponent has in previous rounds."""
 
     name = "Tullock"
-    memoryone = False # long memory
+    memory_depth = 11 # long memory, modified by init
 
     def __init__(self, rounds_to_cooperate=11):
         Player.__init__(self)
         self._rounds_to_cooperate = rounds_to_cooperate
+        self.__class__.memory_depth = rounds_to_cooperate
 
     def strategy(self, opponent):
         rounds = self._rounds_to_cooperate
@@ -44,7 +45,7 @@ class Feld(Player):
     """
 
     name = "Feld"
-    memoryone = False # Probabilities are not constant
+    memory_depth = 200 # Varies actually, eventually becomes depth 1
 
     def __init__(self, start_coop_prob=1.0, end_coop_prob=0.5,
                  rounds_of_decay=200):

--- a/axelrod/strategies/retaliate.py
+++ b/axelrod/strategies/retaliate.py
@@ -6,15 +6,16 @@ class Retaliate(Player):
     A player starts by cooperating but will retaliate once the opponent
     has won more than 10 percent times the number of defections the player has.
     """
-    retaliation_threshold = 0.1
-    memoryone = False  # Long memory
 
-    def __init__(self):
+    memory_depth = float('inf')  # Long memory
+
+    def __init__(self, retaliation_threshold=0.1):
         """
         Uses the basic init from the Player class, but also set the name to
         include the retaliation setting.
         """
         Player.__init__(self)
+        self.retaliation_threshold = retaliation_threshold
         self.name = (
             'Retaliate (' +
             str(self.retaliation_threshold) + ')')
@@ -32,15 +33,23 @@ class Retaliate(Player):
 
 
 class Retaliate2(Retaliate):
-    """ :code:`Retaliate` player with a threshold of 8 percent.
     """
-    retaliation_threshold = 0.08
+    Retaliate player with a threshold of 8 percent.
+    """
+
+    def __init__(self, retaliation_threshold=0.08):
+        super(self.__class__, self).__init__(
+            retaliation_threshold=retaliation_threshold)
 
 
 class Retaliate3(Retaliate):
-    """ :code:`Retaliate` player with a threshold of 5 percent.
     """
-    retaliation_threshold = 0.05
+    Retaliate player with a threshold of 5 percent.
+    """
+
+    def __init__(self, retaliation_threshold=0.05):
+        super(self.__class__, self).__init__(
+            retaliation_threshold=retaliation_threshold)
 
 
 class LimitedRetaliate(Player):
@@ -50,18 +59,20 @@ class LimitedRetaliate(Player):
     the opponent 10 times more often that it has lost or it reaches the
     retaliation limit (20 defections).
     """
-    retaliation_limit = 20
-    retaliation_threshold = 0.1
-    retaliating = False
-    retaliation_count = 0
-    memoryone = False  # Long memory
 
-    def __init__(self):
+    memory_depth = float('inf')  # Long memory
+
+    def __init__(self, retaliation_threshold = 0.1, retaliation_limit = 20,):
         """
         Uses the basic init from the Player class, but also set the name to
         include the retaliation setting.
         """
         Player.__init__(self)
+        self.retaliating = False
+        self.retaliation_count = 0
+        self.retaliation_threshold = retaliation_threshold
+        self.retaliation_limit = retaliation_limit
+
         self.name = (
             'Limited Retaliate (' +
             str(self.retaliation_threshold) +
@@ -73,6 +84,7 @@ class LimitedRetaliate(Player):
         that I've done the same to him, retaliate by playing D but stop doing
         so once I've hit the retaliation limit.
         """
+
         history = zip(self.history, opponent.history)
         if history.count(('C', 'D')) > (
            history.count(('D', 'C')) * self.retaliation_threshold):
@@ -98,16 +110,24 @@ class LimitedRetaliate(Player):
 
 
 class LimitedRetaliate2(LimitedRetaliate):
-    """ :code:`LimitedRetaliate` player with a threshold of 8 percent and a
+    """
+    LimitedRetaliate player with a threshold of 8 percent and a
     retaliation limit of 15.
     """
-    retaliation_limit = 15
-    retaliation_threshold = 0.08
+
+    def __init__(self, retaliation_threshold=0.08, retaliation_limit=15):
+        super(self.__class__, self).__init__(
+            retaliation_threshold=retaliation_threshold,
+            retaliation_limit=retaliation_limit)
 
 
 class LimitedRetaliate3(LimitedRetaliate):
-    """ :code:`LimitedRetaliate` player with a threshold of 5 percent and a
+    """
+    LimitedRetaliate player with a threshold of 5 percent and a
     retaliation limit of 20.
     """
-    retaliation_limit = 20
-    retaliation_threshold = 0.05
+
+    def __init__(self, retaliation_threshold=0.05, retaliation_limit=20):
+        super(self.__class__, self).__init__(
+            retaliation_threshold=retaliation_threshold,
+            retaliation_limit=retaliation_limit)

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -7,7 +7,7 @@ class TitForTat(Player):
     """A player starts by cooperating and then mimics previous move by opponent."""
 
     name = 'Tit For Tat'
-    memoryone = True  # Four-Vector = (1.,0.,1.,0.)
+    memory_depth = 1  # Four-Vector = (1.,0.,1.,0.)
 
     def strategy(self, opponent):
         return 'D' if opponent.history[-1:] == ['D'] else 'C'
@@ -17,7 +17,7 @@ class TitFor2Tats(Player):
     """A player starts by cooperating and then defects only after two defects by opponent."""
 
     name = "Tit For 2 Tats"
-    memoryone = False  # Long memory, memory-2
+    memory_depth = 2  # Long memory, memory-2
 
     def strategy(self, opponent):
         return 'D' if opponent.history[-2:] == ['D', 'D'] else 'C'
@@ -27,7 +27,7 @@ class TwoTitsForTat(Player):
     """A player starts by cooperating and replies to each defect by two defections."""
 
     name = "Two Tits For Tat"
-    memoryone = False  # Long memory, memory-2
+    memory_depth = 2  # Long memory, memory-2
 
     def strategy(self, opponent):
         return 'D' if 'D' in opponent.history[-2:] else 'C'
@@ -41,7 +41,7 @@ class Bully(Player):
     """
 
     name = "Bully"
-    memoryone = True  # Four-Vector = (0.,1.,0.,1.)
+    memory_depth = 1  # Four-Vector = (0.,1.,0.,1.)
 
     def strategy(self, opponent):
         return 'C' if opponent.history[-1:] == ['D'] else 'D'
@@ -51,7 +51,7 @@ class SneakyTitForTat(Player):
     """Tries defecting once and repents if punished."""
 
     name = "Sneaky Tit For Tat"
-    memoryone = False  # Long memory
+    memory_depth = float('inf')  # Long memory
 
     def strategy(self, opponent):
         if len(self.history) < 2:
@@ -67,7 +67,7 @@ class SuspiciousTitForTat(Player):
     """A TFT that initially defects."""
 
     name = "Suspicious Tit For Tat"
-    memoryone = True  # Four-Vector = (1.,0.,1.,0.)
+    memory_depth = 1  # Four-Vector = (1.,0.,1.,0.)
 
     def strategy(self, opponent):
         return 'C' if opponent.history[-1:] == ['C'] else 'D'
@@ -78,7 +78,7 @@ class AntiTitForTat(Player):
     This is similar to BULLY above, except that the first move is cooperation."""
 
     name = 'Anti Tit For Tat'
-    memoryone = True  # Four-Vector = (0.,1.,0.,1.)
+    memory_depth = 1  # Four-Vector = (0.,1.,0.,1.)
 
     def strategy(self, opponent):
         return 'D' if opponent.history[-1:] == ['C'] else 'C'
@@ -92,7 +92,7 @@ class Shubik(Player):
     """
 
     name = 'Shubik'
-    memoryone = False # Responses depend on more than just the last round
+    memory_depth = float('inf')
 
     def __init__(self):
         Player.__init__(self)
@@ -144,7 +144,7 @@ class HardTitForTat(Player):
     """A variant of Tit For Tat that uses a longer history for retaliation."""
 
     name = 'Hard Tit For Tat'
-    memoryone = False  # memory-three
+    memory_depth = 3  # memory-three
 
     def strategy(self, opponent):
         # Cooperate on the first move
@@ -161,7 +161,7 @@ class HardTitFor2Tats(Player):
     retaliation."""
 
     name = "Hard Tit For 2 Tats"
-    memoryone = False  # memory-three
+    memory_depth = 3  # memory-three
 
     def strategy(self, opponent):
         # Cooperate on the first move
@@ -173,4 +173,3 @@ class HardTitFor2Tats(Player):
             return 'D'
         # Otherwise cooperates
         return 'C'
-

--- a/axelrod/tests/unit/test_oncebitten.py
+++ b/axelrod/tests/unit/test_oncebitten.py
@@ -128,7 +128,9 @@ class TestForgetfulFoolMeOnce(TestPlayer):
         self.assertEqual(P1.strategy(P2), 'C')
         P2.history = ['D', 'D']
         self.assertEqual(P1.strategy(P2), 'D')
-        # Sometime will forget count:
+        # Sometime eventually forget count:
+        for i in range(18):
+            self.assertEqual(P1.strategy(P2), 'D')
         self.assertEqual(P1.strategy(P2), 'C')
 
     def test_reset(self):


### PR DESCRIPTION
Fixes #223, strategies now have their memory_depth indicated as follows:
* 0 if the last round is irrelevant (ALLC, ALLD, and Random)
* 1 if the strategy is memory one
* n if the strategy uses the last n rounds (e.g. 2 for TitFor2Tats, 3 for HARD_TFT, various for GoByMajority)
* infinity aka float('inf') if the entire history is used or there is an internal bit of memory that can persist indefinitely.
* For Gellar, since it looks into the future, I set its memory_depth to -1.

While I was going through all the strategy files I made a few various updates e.g. for PEP8, and added in float(...) in a few places where it looked like there was unintentional integer division (e.g. in forgiver). Lastly, Darwin had a game matrix hard-coded, so I updated it to pull from the Game class.

(Edited to link PR with issue in waffle)