### PR TITLE
Display names

### DIFF
--- a/axelrod/strategies/gobymajority.py
+++ b/axelrod/strategies/gobymajority.py
@@ -41,7 +41,12 @@ class GoByMajority(Player):
     def __repr__(self):
         """The string method for the strategy."""
         memory = self.memory_depth
-        return 'Go By Majority' + (memory > 0) * (":%i" % memory)
+        name = 'Go By Majority' + (memory > 0) * (":%i" % memory)
+        if self.soft:
+            name = "Soft " + name
+        else:
+            name = "Hard " + name
+        return name
 
 
 class GoByMajority40(GoByMajority):

--- a/axelrod/strategies/gobymajority.py
+++ b/axelrod/strategies/gobymajority.py
@@ -41,7 +41,7 @@ class GoByMajority(Player):
     def __repr__(self):
         """The string method for the strategy."""
         memory = self.memory_depth
-        name = 'Go By Majority' + (memory > 0) * (":%i" % memory)
+        name = 'Go By Majority' + (memory > 0) * (": %i" % memory)
         if self.soft:
             name = "Soft " + name
         else:

--- a/axelrod/strategies/memoryone.py
+++ b/axelrod/strategies/memoryone.py
@@ -65,14 +65,18 @@ class MemoryOnePlayer(Player):
 class GTFT(MemoryOnePlayer):
     """Generous Tit-For-Tat Strategy."""
 
-    name = 'Generous Tit-For-Tat'
+    name = 'GTFT'
 
     def __init__(self, p=None):
         (R, P, S, T) = Game().RPST()
         if not p:
             p = min(1 - float(T - R) / (R - S), float(R - P) / (T - P))
+        self.p = p
         four_vector = [1, p, 1, p]
         super(self.__class__, self).__init__(four_vector)
+
+    def __repr__(self):
+        return "%s: %s" % (self.name, round(self.p, 2))
 
 
 class StochasticCooperator(MemoryOnePlayer):
@@ -171,7 +175,11 @@ class Joss(MemoryOnePlayer):
 
     def __init__(self, p=0.9):
         four_vector = (p, 0, p, 0)
+        self.p = p
         super(self.__class__, self).__init__(four_vector)
+
+    def __repr__(self):
+        return "%s: %s" % (self.name, round(self.p, 2))
 
 
 class SoftJoss(MemoryOnePlayer):
@@ -185,3 +193,7 @@ class SoftJoss(MemoryOnePlayer):
     def __init__(self, q=0.9):
         four_vector = (1., 1 - q, 1, 1 - q)
         super(self.__class__, self).__init__(four_vector)
+        self.q = q
+
+    def __repr__(self):
+        return "%s: %s" % (self.name, round(self.q, 2))

--- a/axelrod/strategies/rand.py
+++ b/axelrod/strategies/rand.py
@@ -17,3 +17,6 @@ class Random(Player):
         if r > self.p:
             return 'D'
         return 'C'
+
+    def __repr__(self):
+        return "%s: %s" % (self.name, round(self.p, 2))

--- a/axelrod/tests/integration/test_tournament.py
+++ b/axelrod/tests/integration/test_tournament.py
@@ -20,8 +20,8 @@ class TestTournament(unittest.TestCase):
         cls.expected_outcome = [
             ('Cooperator', [1800, 1800, 1800, 1800, 1800]),
             ('Defector', [1612, 1612, 1612, 1612, 1612]),
-            ('Go By Majority', [1999, 1999, 1999, 1999, 1999]),
             ('Grudger', [1999, 1999, 1999, 1999, 1999]),
+            ('Soft Go By Majority', [1999, 1999, 1999, 1999, 1999]),
             ('Tit For Tat', [1999, 1999, 1999, 1999, 1999])]
         cls.expected_outcome.sort()
 

--- a/axelrod/tests/unit/test_gobymajority.py
+++ b/axelrod/tests/unit/test_gobymajority.py
@@ -28,7 +28,7 @@ def factory_TestGoByRecentMajority(L):
 
     class TestGoByRecentMajority(TestPlayer):
 
-        name = "Soft Go By Majority:%i" % L
+        name = "Soft Go By Majority: %i" % L
         player = getattr(axelrod, 'GoByMajority%i' % L)
         stochastic = False
 

--- a/axelrod/tests/unit/test_gobymajority.py
+++ b/axelrod/tests/unit/test_gobymajority.py
@@ -9,7 +9,7 @@ C, D = 'C', 'D'
 
 class TestGoByMajority(TestPlayer):
 
-    name = "Go By Majority"
+    name = "Soft Go By Majority"
     player = axelrod.GoByMajority
     stochastic = False
 
@@ -28,7 +28,7 @@ def factory_TestGoByRecentMajority(L):
 
     class TestGoByRecentMajority(TestPlayer):
 
-        name = "Go By Majority:%i" % L
+        name = "Soft Go By Majority:%i" % L
         player = getattr(axelrod, 'GoByMajority%i' % L)
         stochastic = False
 

--- a/axelrod/tests/unit/test_gobymajority.py
+++ b/axelrod/tests/unit/test_gobymajority.py
@@ -24,6 +24,14 @@ class TestGoByMajority(TestPlayer):
         self.responses_test([C, D, D, D], [D, D, C, C], [C])
         self.responses_test([C, C, D, D, C], [D, D, C, C, D], [D])
 
+    def test_repr(self):
+        player = self.player(soft=True)
+        name = str(player)
+        self.assertEqual(name, "Soft Go By Majority")
+        player = self.player(soft=False)
+        name = str(player)
+        self.assertEqual(name, "Hard Go By Majority")
+
 def factory_TestGoByRecentMajority(L):
 
     class TestGoByRecentMajority(TestPlayer):

--- a/axelrod/tests/unit/test_memoryone.py
+++ b/axelrod/tests/unit/test_memoryone.py
@@ -23,7 +23,7 @@ class TestWinStayLoseShift(TestPlayer):
 
 class TestGTFT(TestPlayer):
 
-    name = "Generous Tit-For-Tat"
+    name = "GTFT: 0.33"
     player = axelrod.GTFT
     stochastic = True
 
@@ -146,7 +146,7 @@ class TestGrofman(TestPlayer):
 
 class TestJoss(TestPlayer):
 
-    name = "Joss"
+    name = "Joss: 0.9"
     player = axelrod.Joss
     stochastic = True
 
@@ -161,7 +161,7 @@ class TestJoss(TestPlayer):
 
 class TestSoftJoss(TestPlayer):
 
-    name = "Soft Joss"
+    name = "Soft Joss: 0.9"
     player = axelrod.SoftJoss
     stochastic = True
 

--- a/axelrod/tests/unit/test_rand.py
+++ b/axelrod/tests/unit/test_rand.py
@@ -8,7 +8,7 @@ C, D = 'C', 'D'
 
 class TestRandom(TestPlayer):
 
-    name = "Random"
+    name = "Random: 0.5"
     player = axelrod.Random
     stochastic = True
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -114,6 +114,33 @@ Here is the :code:`reset` method which takes care of resetting this in between r
         self.grudged = False
         self.grudge_memory = 0
 
+
+You can also modify the name of the strategy with the `__repr__` method, which is invoked
+when `str` is applied to a player instance. For example, the player `Random` takes a 
+parameter `p` for how often it cooperates, and the `__repr__` method adds the value
+of this parameter to the name::
+
+    def __repr__(self):
+        return "%s: %s" % (self.name, round(self.p, 2))
+
+Now we have separate names for different instantiations::
+
+    import axelrod
+    player1 = axelrod.Random(p=0.5)
+    player2 = axelrod.Random(p=0.1)
+    print(str(player1))
+    print(str(player2))
+
+This produces the following output::
+
+    'Random: 0.5'
+    'Random: 0.1'
+
+This helps distinguish players in tournaments that have multiple instances of the
+same strategy. If you modify the `__repr__` method of player, be sure to add an
+appropriate test.
+
+
 Adding the strategy to the library
 ''''''''''''''''''''''''''''''''''
 


### PR DESCRIPTION
Just changes the display names of a few strategies so that multiple instances do not have the same name. For example, Random is now named "Random 0.5", and the name changes if you instantiate with different parameters. This way if you have multiple Random players (with different internal probabilities), they don't show up with the same name.