### PR TITLE
Reproduce method for Player

### DIFF
--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -28,7 +28,6 @@ def is_cheater(s):
            classifier['manipulates_source'] or\
            classifier['manipulates_state']
 
-
 def update_histories(player1, player2, move1, move2):
     """Updates histories and cooperation / defections counts following play."""
     # Update histories
@@ -73,6 +72,7 @@ class Player(object):
         self.tournament_attributes = {'length': -1, 'game': None}
         self.cooperations = 0
         self.defections = 0
+        self.init_args = ()
 
     def __repr__(self):
         """The string method for the strategy."""
@@ -97,6 +97,16 @@ class Player(object):
         if noise:
             s1, s2 = self._add_noise(noise, s1, s2)
         update_histories(self, opponent, s1, s2)
+
+    def reproduce(self):
+        """Clones the player without history, reapplying configuration
+        parameters as necessary."""
+
+        cls = self.__class__
+        #print(cls)
+        #print(self.init_args)
+        new_player = cls(*self.init_args)
+        return new_player
 
     def reset(self):
         """Resets history.

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -103,9 +103,8 @@ class Player(object):
         parameters as necessary."""
 
         cls = self.__class__
-        #print(cls)
-        #print(self.init_args)
         new_player = cls(*self.init_args)
+        new_player.tournament_attributes = copy.copy(self.tournament_attributes)
         return new_player
 
     def reset(self):

--- a/axelrod/round_robin.py
+++ b/axelrod/round_robin.py
@@ -80,15 +80,21 @@ class RoundRobin(object):
         player1 = self.players[player1_index]
         class1 = player1.__class__
         if player1_index == player2_index:
-            # Check for arguments in __init__. If more than one (self), then
-            # deepcopy rather than instantiating the class variable
-            argspec = inspect.getargspec(player1.__init__)
-            if len(argspec.args) > 1:
-                player2 = copy.deepcopy(player1)
-            else:
-                player2 = class1()
-                player2.tournament_attributes = player1.tournament_attributes
             class2 = class1
+            try:
+                player2 = player1.reproduce()
+            except TypeError:
+                print(class1)
+                exit()
+            ## Check for arguments in __init__. If more than one (self), then
+            ## deepcopy rather than instantiating the class variable
+            #argspec = inspect.getargspec(player1.__init__)
+            #if len(argspec.args) > 1:
+                #player2 = copy.deepcopy(player1)
+            #else:
+                #player2 = class1()
+                #player2.tournament_attributes = player1.tournament_attributes
+            #class2 = class1
         else:
             player2 = self.players[player2_index]
             class2 = player2.__class__

--- a/axelrod/round_robin.py
+++ b/axelrod/round_robin.py
@@ -1,6 +1,4 @@
 from __future__ import division
-import copy
-import inspect
 
 class RoundRobin(object):
     """A class to define play a round robin game of players"""
@@ -80,24 +78,10 @@ class RoundRobin(object):
         player1 = self.players[player1_index]
         class1 = player1.__class__
         if player1_index == player2_index:
-            class2 = class1
-            try:
-                player2 = player1.reproduce()
-            except TypeError:
-                print(class1)
-                exit()
-            ## Check for arguments in __init__. If more than one (self), then
-            ## deepcopy rather than instantiating the class variable
-            #argspec = inspect.getargspec(player1.__init__)
-            #if len(argspec.args) > 1:
-                #player2 = copy.deepcopy(player1)
-            #else:
-                #player2 = class1()
-                #player2.tournament_attributes = player1.tournament_attributes
-            #class2 = class1
+            player2 = player1.reproduce()
         else:
             player2 = self.players[player2_index]
-            class2 = player2.__class__
+        class2 = player2.__class__
         return player1, player2, (class1, class2)
 
     def _stochastic_interaction(self, player1, player2):

--- a/axelrod/strategies/axelrod_tournaments.py
+++ b/axelrod/strategies/axelrod_tournaments.py
@@ -29,6 +29,7 @@ class Davis(Player):
     def __init__(self, rounds_to_cooperate=10):
         Player.__init__(self)
         self._rounds_to_cooperate = rounds_to_cooperate
+        self.init_args = (self._rounds_to_cooperate,)
 
     def strategy(self, opponent):
         """Begins by playing C, then plays D for the remaining rounds if the
@@ -61,6 +62,9 @@ class Feld(Player):
         self._start_coop_prob = start_coop_prob
         self._end_coop_prob = end_coop_prob
         self._rounds_of_decay = rounds_of_decay
+        self.init_args = (start_coop_prob,
+                          end_coop_prob,
+                          rounds_of_decay)
 
     def _cooperation_probability(self):
         """It's not clear what the interpolating function is, so we'll do
@@ -95,6 +99,7 @@ class Grofman(MemoryOnePlayer):
         p = float(2) / 7
         four_vector = (p, p, p, p)
         super(self.__class__, self).__init__(four_vector)
+        self.init_args = ()
 
 
 class Joss(MemoryOnePlayer):
@@ -109,6 +114,7 @@ class Joss(MemoryOnePlayer):
         four_vector = (p, 0, p, 0)
         self.p = p
         super(self.__class__, self).__init__(four_vector)
+        self.init_args = (p,)
 
     def __repr__(self):
         return "%s: %s" % (self.name, round(self.p, 2))
@@ -192,6 +198,7 @@ class Tullock(Player):
         Player.__init__(self)
         self._rounds_to_cooperate = rounds_to_cooperate
         self.__class__.memory_depth = rounds_to_cooperate
+        self.init_args = (rounds_to_cooperate,)
 
     def strategy(self, opponent):
         rounds = self._rounds_to_cooperate

--- a/axelrod/strategies/cycler.py
+++ b/axelrod/strategies/cycler.py
@@ -54,6 +54,7 @@ class Cycler(Player):
         self.cycle = cycle
         self.name += " " + cycle
         self.classifier['memory_depth'] = len(cycle) - 1
+        self.init_args = (cycle,)
 
     def strategy(self, opponent):
         curent_round = len(self.history)

--- a/axelrod/strategies/darwin.py
+++ b/axelrod/strategies/darwin.py
@@ -43,7 +43,6 @@ class Darwin(Player):
         super(Darwin, self).__init__()
         self.response = self.__class__.genome[0]
 
-
     def strategy(self, opponent):
         # Frustrate psychics and ensure that simulated rounds
         # do not influence genome.
@@ -68,12 +67,10 @@ class Darwin(Player):
 
         return current
 
-
     def reset(self):
         """ Reset instance properties. """
         Player.reset(self)
         self.__class__.genome[0] = 'C' # Ensure initial Cooperate
-
 
     def mutate(self, outcome, trial):
         """ Select response according to outcome. """

--- a/axelrod/strategies/gobymajority.py
+++ b/axelrod/strategies/gobymajority.py
@@ -21,6 +21,7 @@ class GoByMajority(Player):
         Player.__init__(self)
         self.soft = soft
         self.classifier['memory_depth'] = memory_depth
+        self.init_args = (memory_depth, soft)
 
     def strategy(self, opponent):
         """This is affected by the history of the opponent.
@@ -58,8 +59,9 @@ class GoByMajority40(GoByMajority):
     GoByMajority player with a memory of 40.
     """
 
-    def __init__(self, memory_depth=40):
-        super(self.__class__, self).__init__(memory_depth=memory_depth)
+    def __init__(self, memory_depth=40, soft=True):
+        super(self.__class__, self).__init__(memory_depth=memory_depth,
+                                             soft=soft)
 
 
 class GoByMajority20(GoByMajority):
@@ -67,23 +69,24 @@ class GoByMajority20(GoByMajority):
     GoByMajority player with a memory of 20.
     """
 
-    def __init__(self, memory_depth=20):
-        super(self.__class__, self).__init__(memory_depth=memory_depth)
-
+    def __init__(self, memory_depth=20, soft=True):
+        super(self.__class__, self).__init__(memory_depth=memory_depth,
+                                             soft=soft)
 
 class GoByMajority10(GoByMajority):
     """
     GoByMajority player with a memory of 10.
     """
 
-    def __init__(self, memory_depth=10):
-        super(self.__class__, self).__init__(memory_depth=memory_depth)
-
+    def __init__(self, memory_depth=10, soft=True):
+        super(self.__class__, self).__init__(memory_depth=memory_depth,
+                                             soft=soft)
 
 class GoByMajority5(GoByMajority):
     """
     GoByMajority player with a memory of 5.
     """
 
-    def __init__(self, memory_depth=5):
-        super(self.__class__, self).__init__(memory_depth=memory_depth)
+    def __init__(self, memory_depth=5, soft=True):
+        super(self.__class__, self).__init__(memory_depth=memory_depth,
+                                             soft=soft)

--- a/axelrod/strategies/grumpy.py
+++ b/axelrod/strategies/grumpy.py
@@ -24,6 +24,7 @@ class Grumpy(Player):
         self.starting_state = starting_state
         self.grumpy_threshold = grumpy_threshold
         self.nice_threshold = nice_threshold
+        self.init_args = (starting_state, grumpy_threshold, nice_threshold)
 
     def strategy(self, opponent):
         """A player that gets grumpier the more the opposition defects,

--- a/axelrod/strategies/memoryone.py
+++ b/axelrod/strategies/memoryone.py
@@ -25,8 +25,9 @@ class WinStayLoseShift(Player):
             ('D', 'C'): 'D',
             ('D', 'D'): 'C',
         }
-        self._initial = initial
         self.classifier['stochastic'] = False
+        self._initial = initial
+        self.init_args = (initial,)
 
     def strategy(self, opponent):
         """Switches if it doesn't get the best payout, traditionally equivalent
@@ -58,6 +59,7 @@ class MemoryOnePlayer(Player):
         self._four_vector = dict(zip([('C', 'C'), ('C', 'D'), ('D', 'C'), ('D', 'D')], map(float, four_vector)))
         self._initial = initial
         self.classifier['stochastic'] = any(0 < x < 1 for x in set(four_vector))
+        self.init_args = (four_vector, initial)
 
     def strategy(self, opponent):
         if not len(opponent.history):
@@ -83,6 +85,7 @@ class GTFT(MemoryOnePlayer):
         self.p = p
         four_vector = [1, p, 1, p]
         super(self.__class__, self).__init__(four_vector)
+        self.init_args = (p,)
 
     def __repr__(self):
         return "%s: %s" % (self.name, round(self.p, 2))
@@ -107,6 +110,7 @@ class StochasticWSLS(MemoryOnePlayer):
         self.ep = ep
         four_vector = (1.-ep, ep, ep, 1.-ep)
         super(self.__class__, self).__init__(four_vector)
+        self.init_args = (ep,)
 
 
 class ZeroDeterminantPlayer(MemoryOnePlayer):
@@ -137,6 +141,7 @@ class ZeroDeterminantPlayer(MemoryOnePlayer):
 
         four_vector = [p1, p2, p3, p4]
         MemoryOnePlayer.__init__(self, four_vector)
+        self.init_args = (phi, s, l)
 
 
 class ZDGTFT2(ZeroDeterminantPlayer):
@@ -144,9 +149,10 @@ class ZDGTFT2(ZeroDeterminantPlayer):
 
     name = 'ZD-GTFT-2'
 
-    def __init__(self, phi=0., chi=2.):
+    def __init__(self):
         (R, P, S, T) = Game().RPST()
         ZeroDeterminantPlayer.__init__(self, phi=0.25, s=0.5, l=R)
+        self.init_args = ()
 
 
 class ZDExtort2(ZeroDeterminantPlayer):
@@ -157,6 +163,7 @@ class ZDExtort2(ZeroDeterminantPlayer):
     def __init__(self):
         (R, P, S, T) = Game().RPST()
         ZeroDeterminantPlayer.__init__(self, phi=1./9, s=0.5, l=P)
+        self.init_args = ()
 
 
 ### Strategies for recreating tournaments
@@ -174,6 +181,7 @@ class SoftJoss(MemoryOnePlayer):
         four_vector = (1., 1 - q, 1, 1 - q)
         super(self.__class__, self).__init__(four_vector)
         self.q = q
+        self.init_args = (q,)
 
     def __repr__(self):
         return "%s: %s" % (self.name, round(self.q, 2))

--- a/axelrod/strategies/memoryone.py
+++ b/axelrod/strategies/memoryone.py
@@ -99,6 +99,7 @@ class StochasticCooperator(MemoryOnePlayer):
     def __init__(self):
         four_vector = (0.935, 0.229, 0.266, 0.42)
         super(self.__class__, self).__init__(four_vector)
+        self.init_args = ()
 
 
 class StochasticWSLS(MemoryOnePlayer):

--- a/axelrod/strategies/meta.py
+++ b/axelrod/strategies/meta.py
@@ -97,6 +97,7 @@ class MetaWinner(MetaPlayer):
             self.team = ordinary_strategies
 
         MetaPlayer.__init__(self)
+        self.init_args = (team,)
 
         # For each player, we will keep the history of proposed moves and
         # a running score since the beginning of the game.

--- a/axelrod/strategies/mindreader.py
+++ b/axelrod/strategies/mindreader.py
@@ -28,8 +28,7 @@ def look_ahead(player_1, player_2, rounds=10):
     # Simulate plays for `rounds` rounds
     strategies = ['C', 'D']
     for strategy in strategies:
-        #opponent_ = copy.deepcopy(player_2) # need deepcopy here
-        opponent_ = player_2
+        opponent_ = copy.deepcopy(player_2) # need deepcopy here
         round_robin = RoundRobin(players=[player_1, opponent_], game=game,
                                  turns=rounds)
         simulate_match(player_1, opponent_, strategy, rounds)
@@ -37,7 +36,6 @@ def look_ahead(player_1, player_2, rounds=10):
 
         # Restore histories and counts
         roll_back_history(player_1, rounds)
-        roll_back_history(player_2, rounds)
 
     return strategies[results.index(max(results))]
 
@@ -51,7 +49,7 @@ class MindReader(Player):
         'stochastic': False,
         'inspects_source': True,  # Finds out what opponent will do
         'manipulates_source': False,
-        'manipulates_state': True
+        'manipulates_state': False
     }
 
     def strategy(self, opponent):

--- a/axelrod/strategies/mindreader.py
+++ b/axelrod/strategies/mindreader.py
@@ -54,9 +54,6 @@ class MindReader(Player):
         'manipulates_state': True
     }
 
-    def __init__(self):
-        Player.__init__(self)
-
     def strategy(self, opponent):
         """Pretends to play the opponent a number of times before each match.
         The primary purpose is to look far enough ahead to see if a defect will

--- a/axelrod/strategies/oncebitten.py
+++ b/axelrod/strategies/oncebitten.py
@@ -100,6 +100,7 @@ class ForgetfulFoolMeOnce(Player):
         self.D_count = 0
         self._initial = 'C'
         self.forget_probability = forget_probability
+        self.init_args = (forget_probability,)
 
     def strategy(self, opponent):
         r = random.random()
@@ -132,10 +133,6 @@ class FoolMeForever(Player):
         'manipulates_source': False,
         'manipulates_state': False
     }
-
-    def __init__(self):
-        Player.__init__(self)
-        self.classifier['stochastic'] = False
 
     def strategy(self, opponent):
         if opponent.defections > 0:

--- a/axelrod/strategies/rand.py
+++ b/axelrod/strategies/rand.py
@@ -17,6 +17,7 @@ class Random(Player):
     def __init__(self, p=0.5):
         Player.__init__(self)
         self.p = p
+        self.init_args = (p,)
 
     def strategy(self, opponent):
         r = random.random()

--- a/axelrod/strategies/retaliate.py
+++ b/axelrod/strategies/retaliate.py
@@ -27,6 +27,7 @@ class Retaliate(Player):
             'Retaliate (' +
             str(self.retaliation_threshold) + ')')
         self.play_counts = defaultdict(int)
+        self.init_args = (retaliation_threshold,)
 
     def strategy(self, opponent):
         """
@@ -94,6 +95,7 @@ class LimitedRetaliate(Player):
         self.retaliation_threshold = retaliation_threshold
         self.retaliation_limit = retaliation_limit
         self.play_counts = defaultdict(int)
+        self.init_args = (retaliation_threshold, retaliation_limit)
 
         self.name = (
             'Limited Retaliate (' +

--- a/axelrod/tests/integration/test_round_robin.py
+++ b/axelrod/tests/integration/test_round_robin.py
@@ -35,7 +35,7 @@ class TestRoundRobin(unittest.TestCase):
     def test_deterministic_cache(self):
         p1, p2, p3 = axelrod.Cooperator(), axelrod.Defector(), axelrod.Random()
         rr = axelrod.RoundRobin(players=[p1, p2, p3], game=self.game, turns=20)
-        self.assertEquals(rr.deterministic_cache, {})
+        self.assertEqual(rr.deterministic_cache, {})
         rr.play()
         self.assertEqual(rr.deterministic_cache[
             (axelrod.Defector, axelrod.Defector)]['scores'], (20, 20))

--- a/axelrod/tests/unit/test_mindreader.py
+++ b/axelrod/tests/unit/test_mindreader.py
@@ -17,7 +17,7 @@ class TestMindReader(TestPlayer):
         'stochastic': False,
         'inspects_source': True,
         'manipulates_state': False,
-        'manipulates_state': True
+        'manipulates_state': False
     }
 
     def test_strategy(self):

--- a/axelrod/tests/unit/test_player.py
+++ b/axelrod/tests/unit/test_player.py
@@ -1,8 +1,9 @@
 import copy
+import inspect
 import random
 import unittest
-import axelrod
 
+import axelrod
 from axelrod import simulate_play, Player
 
 
@@ -127,6 +128,19 @@ class TestPlayer(unittest.TestCase):
     def test_strategy(self):
         """Test that strategy method."""
         self.assertEqual(self.player().strategy(self.player()), None)
+
+    def test_reproduce(self):
+        # Make sure that self.init_args has the right number of arguments
+        p1 = self.player()
+        argspec = inspect.getargspec(p1.__init__)
+        self.assertEqual(len(argspec.args) - 1, len(p1.init_args))
+        # Test that the player is reproduced correctly
+        p2 = p1.reproduce()
+        self.assertEqual(len(p2.history), 0)
+        self.assertEqual(p2.cooperations, 0)
+        self.assertEqual(p2.defections, 0)
+        self.assertEqual(p2.classifier, p1.classifier)
+        self.assertEqual(p2.tournament_attributes, p1.tournament_attributes)
 
     def first_play_test(self, play, random_seed=None):
         """Tests first move of a strategy."""

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -150,6 +150,11 @@ There is also a classifier dictionary that allows for easy classification of
 strategies: take a look at the `Strategy classification`_ section for more
 information.
 
+If your strategy makes use of parameters in its `__init__` method, be sure
+to set `self.init_args = [...]` appropriately with the same arguments (in
+the same order) so that the strategy will be properly duplicated as
+necessary. For example, the strategy `Random` defines `__init__(self, p=0.5)`
+and sets `self.init_args = (p,)` at the end of its `__init__` method.
 
 Adding the strategy to the library
 ''''''''''''''''''''''''''''''''''


### PR DESCRIPTION
Re: #303 

I added `self.init_args = ()` to `Player.__init__`. A child strategy that needs to pass through arguments need only set `self.init_args = (...)` (overriding `reproduce` is not necessary). I updated all the appropriate strategies and added tests.