### PR TITLE
Replace disutils for setuptools in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-from distutils.core import setup
+from setuptools import setup
+
 
 setup(
     name='Axelrod',


### PR DESCRIPTION
It would seem that ``python setup.py develop`` is a command supported not supported by ``distutils``
Also, the ``install_requires`` kwarg is not supported by ``distutils``, although it's defined in setup.py

Both are supported by ``setuptools`` though, so it seems that replacing ``distutils`` for it is the answer.

Packaging is not my forte by any extend of the imagination though and I am unaware if changing this is going to kill the rest of the world (I doubt it though)

I particularly l leaned on this article when researching:
http://stackoverflow.com/questions/6344076/differences-between-distribute-distutils-setuptools-and-distutils2