### PR TITLE
Update MetaPlayer reset to also reset team

### DIFF
--- a/axelrod/strategies/meta.py
+++ b/axelrod/strategies/meta.py
@@ -52,6 +52,7 @@ class MetaPlayer(Player):
 
     def reset(self):
         Player.reset(self)
+        # Reset each player as well
         for player in self.team:
             player.reset()
 

--- a/axelrod/strategies/meta.py
+++ b/axelrod/strategies/meta.py
@@ -50,6 +50,11 @@ class MetaPlayer(Player):
         """Determine the meta result based on results of all players."""
         pass
 
+    def reset(self):
+        Player.reset(self)
+        for player in self.team:
+            player.reset()
+
 
 class MetaMajority(MetaPlayer):
     """A player who goes by the majority vote of all other non-meta players."""

--- a/axelrod/tests/unit/test_hunter.py
+++ b/axelrod/tests/unit/test_hunter.py
@@ -66,6 +66,7 @@ class TestAlternatorHunter(TestPlayer):
         self.responses_test([C] * 6, [C, D] * 3, [D])
         self.responses_test([C] * 7, [C, D] * 3 + [C], [D])
 
+
 class TestMathConstantHunter(TestPlayer):
 
     name = "Math Constant Hunter"
@@ -80,6 +81,7 @@ class TestMathConstantHunter(TestPlayer):
 
     def test_strategy(self):
         self.responses_test([C] * 8, [C] * 7 + [D], [D])
+
 
 class TestRandomHunter(TestPlayer):
 
@@ -105,30 +107,3 @@ class TestRandomHunter(TestPlayer):
         P1.history = [C] * 100
         P2.history = [random.choice([C, D]) for i in range(100)]
         self.assertEqual(P1.strategy(P2), D)
-
-class TestMetaHunter(TestPlayer):
-
-    name = "Meta Hunter"
-    player = axelrod.MetaHunter
-    expected_classifier = {
-        'memory_depth': float('inf'),  # Long memory
-        'stochastic' : False,
-        'inspects_source': False,
-        'manipulates_source': False,
-        'manipulates_state': False
-    }
-
-    def test_strategy(self):
-        self.first_play_test(C)
-
-        # We are not using the Cooperator Hunter here, so this should lead to cooperation.
-        self.responses_test([C, C, C, C], [C, C, C, C], [C])
-
-        # After long histories tit-for-tat should come into play.
-        self.responses_test([C] * 101, [C] * 100 + [D], [D])
-
-        # All these others, however, should trigger a defection for the hunter.
-        self.responses_test([C] * 4, [D] * 4, [D])
-        self.responses_test([C] * 6, [C, D] * 3, [D])
-        self.responses_test([C] * 8, [C, C, C, D, C, C, C, D], [D])
-        self.responses_test([C] * 100, [random.choice([C, D]) for i in range(100)],[D])


### PR DESCRIPTION
The MetaPlayer derived strategies retain state between games. I believe this is unintentional.