### PR TITLE
Fix implicit imports for tournament repo

### DIFF
--- a/axelrod/__init__.py
+++ b/axelrod/__init__.py
@@ -13,3 +13,4 @@ from .tournament_manager import TournamentManager
 from .tournament_manager_factory import TournamentManagerFactory
 from .result_set import ResultSet
 from .ecosystem import Ecosystem
+from .utils import run_tournaments, setup_logging


### PR DESCRIPTION
The script update_results.sh in the tournament repository doesn't run after the switch to explicit imports. This fixes it.