### PR TITLE
343 - Change name of is_cheater function.

### DIFF
--- a/axelrod/__init__.py
+++ b/axelrod/__init__.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 from .random_ import random_choice
 from .plot import Plot
 from .game import DefaultGame, Game
-from .player import is_basic, is_cheater, update_histories, Player
+from .player import is_basic, obey_axelrod, update_histories, Player
 from .mock_player import MockPlayer, simulate_play
 from .round_robin import RoundRobin
 from .strategies import *

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -21,14 +21,14 @@ def is_basic(s):
     manipulates_state = s.classifier['manipulates_state']
     return (not stochastic) and (not inspects_source) and (not manipulates_source) and (not manipulates_state) and (depth in (0, 1))
 
-def is_cheater(s):
+def obey_axelrod(s):
     """
-    A function to check if a strategy cheats.
+    A function to check if a strategy obeys Axelrod's original tournament rules.
     """
     classifier = s.classifier
-    return classifier['inspects_source'] or\
+    return not (classifier['inspects_source'] or\
            classifier['manipulates_source'] or\
-           classifier['manipulates_state']
+           classifier['manipulates_state'])
 
 def update_histories(player1, player2, move1, move2):
     """Updates histories and cooperation / defections counts following play."""

--- a/axelrod/strategies/__init__.py
+++ b/axelrod/strategies/__init__.py
@@ -1,4 +1,4 @@
-from ..player import is_basic, is_cheater
+from ..player import is_basic, obey_axelrod
 from ._strategies import *
 
 # `from ._strategies import *` import the collection `strategies`
@@ -13,5 +13,5 @@ strategies.extend((MetaHunter, MetaMajority, MetaMinority, MetaWinner))
 
 demo_strategies = [Cooperator, Defector, TitForTat, Grudger, Random]
 basic_strategies = [s for s in strategies if is_basic(s())]
-ordinary_strategies = [s for s in strategies if not is_cheater(s())]
-cheating_strategies = [s for s in strategies if is_cheater(s())]
+ordinary_strategies = [s for s in strategies if obey_axelrod(s())]
+cheating_strategies = [s for s in strategies if not obey_axelrod(s())]

--- a/axelrod/strategies/meta.py
+++ b/axelrod/strategies/meta.py
@@ -1,10 +1,10 @@
-from axelrod import Player, is_cheater
+from axelrod import Player, obey_axelrod
 from ._strategies import strategies
 from .hunter import DefectorHunter, AlternatorHunter, RandomHunter, MathConstantHunter
 
 
 # Needs to be computed manually to prevent circular dependency
-ordinary_strategies = [s for s in strategies if not is_cheater(s)]
+ordinary_strategies = [s for s in strategies if obey_axelrod(s)]
 
 
 class MetaPlayer(Player):

--- a/axelrod/tests/unit/test_classification.py
+++ b/axelrod/tests/unit/test_classification.py
@@ -51,8 +51,8 @@ class TestClassification(unittest.TestCase):
         player.classifier['memory_depth'] += 1
         self.assertNotEqual(player.classifier, axelrod.Defector.classifier)
 
-    def test_is_cheater(self):
-        """A test that verifies if the is_cheater function works correctly"""
+    def test_obey_axelrod(self):
+        """A test that verifies if the obey_axelrod function works correctly"""
         known_cheaters = [axelrod.Darwin,
                           axelrod.Geller,
                           axelrod.GellerCooperator,
@@ -81,16 +81,51 @@ class TestClassification(unittest.TestCase):
                           axelrod.Random]
 
         for strategy in known_cheaters:
-            self.assertTrue(axelrod.is_cheater(strategy()), msg=strategy)
+            self.assertFalse(axelrod.obey_axelrod(strategy()), msg=strategy)
+
+        for strategy in known_basic:
+            self.assertTrue(axelrod.obey_axelrod(strategy()), msg=strategy)
+
+        for strategy in known_ordinary:
+            self.assertTrue(axelrod.obey_axelrod(strategy()), msg=strategy)
+
+    def test_is_basic(self):
+        """A test that verifies if the is_basic function works correctly"""
+        known_cheaters = [axelrod.Darwin,
+                          axelrod.Geller,
+                          axelrod.GellerCooperator,
+                          axelrod.GellerDefector,
+                          axelrod.MindBender,
+                          axelrod.MindController,
+                          axelrod.MindWarper,
+                          axelrod.MindReader]
+
+        known_basic = [axelrod.Alternator,
+                       axelrod.AntiTitForTat,
+                       axelrod.Bully,
+                       axelrod.Cooperator,
+                       axelrod.Defector,
+                       axelrod.GoByMajority,
+                       axelrod.SuspiciousTitForTat,
+                       axelrod.TitForTat,
+                       axelrod.WinStayLoseShift]
+
+        known_ordinary = [axelrod.AverageCopier,
+                          axelrod.ForgivingTitForTat,
+                          axelrod.GoByMajority20,
+                          axelrod.GTFT,
+                          axelrod.Grudger,
+                          axelrod.Inverse,
+                          axelrod.Random]
+
+        for strategy in known_cheaters:
             self.assertFalse(axelrod.is_basic(strategy()), msg=strategy)
 
         for strategy in known_basic:
             self.assertTrue(axelrod.is_basic(strategy()), msg=strategy)
-            self.assertFalse(axelrod.is_cheater(strategy()), msg=strategy)
 
         for strategy in known_ordinary:
             self.assertFalse(axelrod.is_basic(strategy()), msg=strategy)
-            self.assertFalse(axelrod.is_cheater(strategy()), msg=strategy)
 
 
 class TestStrategies(unittest.TestCase):

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -217,6 +217,8 @@ is 'honest' or not:
 3. :code:`manipulates_state` - does the strategy 'change' any attributes that
    it would not normally be able to. An example of this is :code:`Mind Reader`.
 
+These dimensions are currently relevant to the `obey_axelrod` strategy which
+checks if a strategy obeys Axelrod's original rules.
 
 How to write tests
 ''''''''''''''''''

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -515,7 +515,8 @@ Particular parameters can also be changed:
 - The output directory for the plot and csv files.
 - The number of turns and repetitions for the tournament.
 
-Here is a command that will run the whole tournament, excluding the cheating strategies and using all available CPUS::
+Here is a command that will run the whole tournament, excluding the strategies
+that do not obey Axelrod's original rules and using all available CPUS::
 
     run_axelrod --xc -p 0
 


### PR DESCRIPTION
Following on from the discussion on #343 which ended up being another discussion about cheaters. Have changed the `is_cheater` function to be `obey_axelrod` which makes things a bit less subjective (users can then include whatever strategies they want). 

At present it makes no difference to the library (although the tournament repository) but hopefully will clarify all future discussions about the incoming strategies.

I have added something to the documentation but waiting on #299 this is very minor.