### PR TITLE
Change Player.strategy() to raise Exception instead of None …

### DIFF
--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -106,7 +106,7 @@ class Player(object):
 
     def strategy(self, opponent):
         """This is a placeholder strategy."""
-        return None
+        raise NotImplementedError()
 
     def play(self, opponent, noise=0):
         """This pits two players against each other."""

--- a/axelrod/tests/unit/test_defector.py
+++ b/axelrod/tests/unit/test_defector.py
@@ -15,7 +15,8 @@ class TestDefector(TestPlayer):
         'memory_depth': 0,
         'stochastic': False,
         'inspects_source': False,
-        'manipulates_state': False
+        'manipulates_state': False,
+        'manipulates_source': False
     }
 
     def test_strategy(self):

--- a/axelrod/tests/unit/test_geller.py
+++ b/axelrod/tests/unit/test_geller.py
@@ -14,7 +14,7 @@ class TestGeller(TestPlayer):
         'stochastic': True,
         'inspects_source': True,  # Finds out what opponent will do
         'manipulates_state': False,
-        'manipulates_state': False
+        'manipulates_source': False
     }
 
 

--- a/axelrod/tests/unit/test_grumpy.py
+++ b/axelrod/tests/unit/test_grumpy.py
@@ -1,8 +1,7 @@
 """Test for the grumpy strategy."""
 
 import axelrod
-from .test_player import TestPlayer, test_responses
-
+from .test_player import TestPlayer, test_responses, TestOpponent
 
 C, D = 'C', 'D'
 
@@ -30,7 +29,7 @@ class TestGrumpy(TestPlayer):
         Starts by defecting if grumpy
         """
         P1 = axelrod.Grumpy(starting_state = 'Grumpy')
-        P2 = axelrod.Player()
+        P2 = TestOpponent()
         self.assertEqual(P1.strategy(P2), D)
 
     def test_strategy(self):
@@ -39,20 +38,20 @@ class TestGrumpy(TestPlayer):
         Player will then not become nice until lower nice threshold is hit.
         """
         P1 = axelrod.Grumpy(grumpy_threshold = 3, nice_threshold=0)
-        P2 = axelrod.Player()
+        P2 = TestOpponent()
         test_responses(self, P1, P2, [C, D, D, D], [C, C, C, C], [C])
 
         P1 = axelrod.Grumpy(grumpy_threshold = 3, nice_threshold=0)
-        P2 = axelrod.Player()
+        P2 = TestOpponent()
         test_responses(self, P1, P2, [C, C, D, D, D], [D, D, D, D, D], [D])
 
         P1 = axelrod.Grumpy(grumpy_threshold = 3, nice_threshold=0)
-        P2 = axelrod.Player()
+        P2 = TestOpponent()
         test_responses(self, P1, P2, [C, C, D, D, D, D, D, D],
                        [D, D, D, D, D, C, C, C], [D])
 
         P1 = axelrod.Grumpy(grumpy_threshold = 3, nice_threshold=0)
-        P2 = axelrod.Player()
+        P2 = TestOpponent()
         test_responses(self, P1, P2, [C, C, D, D, D, D, D, D, D, D, D],
                        [D, D, D, D, D, C, C, C, C, C, C], [C])
 

--- a/axelrod/tests/unit/test_mindreader.py
+++ b/axelrod/tests/unit/test_mindreader.py
@@ -16,7 +16,7 @@ class TestMindReader(TestPlayer):
         'memory_depth': -10,
         'stochastic': False,
         'inspects_source': True,
-        'manipulates_state': False,
+        'manipulates_source': False,
         'manipulates_state': False
     }
 

--- a/axelrod/tests/unit/test_mock_player.py
+++ b/axelrod/tests/unit/test_mock_player.py
@@ -2,6 +2,7 @@ import unittest
 import axelrod
 
 from axelrod import MockPlayer, simulate_play, update_histories
+from axelrod.tests.unit.test_player import TestOpponent
 
 C, D = 'C', 'D'
 
@@ -35,8 +36,8 @@ class TestMockPlayer(unittest.TestCase):
 class TestUpdateHistories(unittest.TestCase):
 
     def test_various(self):
-        p1 = axelrod.Player()
-        p2 = axelrod.Player()
+        p1 = TestOpponent()
+        p2 = TestOpponent()
         update_histories(p1, p2, C, C)
         self.assertEqual(p1.history, [C])
         self.assertEqual(p2.history, [C])
@@ -57,8 +58,8 @@ class TestUpdateHistories(unittest.TestCase):
 class TestSimulatePlay(unittest.TestCase):
 
     def test_various(self):
-        p1 = axelrod.Player()
-        p2 = axelrod.Player()
+        p1 = TestOpponent()
+        p2 = TestOpponent()
         self.assertEqual(simulate_play(p1, p2), (C, C))
         self.assertEqual(p1.cooperations, 1)
         self.assertEqual(p2.cooperations, 1)

--- a/axelrod/tests/unit/test_player.py
+++ b/axelrod/tests/unit/test_player.py
@@ -65,6 +65,9 @@ class TestPlayerClass(unittest.TestCase):
         self.assertEqual(p1.history[0], D)
         self.assertEqual(p2.history[0], D)
 
+    def test_strategy(self):
+        self.assertRaises(NotImplementedError, self.player().strategy, self.player())
+
 
 def test_responses(test_class, P1, P2, history_1, history_2,
                    responses, random_seed=None):

--- a/axelrod/tests/unit/test_player.py
+++ b/axelrod/tests/unit/test_player.py
@@ -90,31 +90,42 @@ def test_responses(test_class, P1, P2, history_1, history_2,
         test_class.assertEqual(s1, response)
 
 
+class TestOpponent(Player):
+    """A player who only exists so we have something to test against"""
+
+    name = 'TestPlayer'
+    classifier = {
+        'memory_depth': 0,
+        'stochastic': False,
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+
+    @staticmethod
+    def strategy(opponent):
+        return 'C'
+
+
 class TestPlayer(unittest.TestCase):
     "A Test class from which other player test classes are inherited"
-
-    name = "Player"
-    player = Player
-    expected_classifier ={
-        'stochastic': False,
-        'memory_depth': float('inf'),
-        'inspects_source': None,
-        'manipulates_state': None
-    }
+    player = TestOpponent
 
     def test_initialisation(self):
         """Test that the player initiates correctly."""
-        player = self.player()
-        self.assertEqual(player.history, [])
-        self.assertEqual(player.tournament_attributes,
-            {'length': -1, 'game': DefaultGame})
-        self.assertEqual(player.cooperations, 0)
-        self.assertEqual(player.defections, 0)
-        self.classifier_test()
+        if self.__class__ != TestPlayer:
+            player = self.player()
+            self.assertEqual(player.history, [])
+            self.assertEqual(player.tournament_attributes,
+                {'length': -1, 'game': DefaultGame})
+            self.assertEqual(player.cooperations, 0)
+            self.assertEqual(player.defections, 0)
+            self.classifier_test()
 
     def test_repr(self):
         """Test that the representation is correct."""
-        self.assertEqual(str(self.player()), self.name)
+        if self.__class__ != TestPlayer:
+            self.assertEqual(str(self.player()), self.name)
 
     def test_tournament_attributes(self):
         player = self.player()
@@ -130,10 +141,6 @@ class TestPlayer(unittest.TestCase):
         self.assertEqual(p.history, [])
         self.assertEqual(self.player().cooperations, 0)
         self.assertEqual(self.player().defections, 0)
-
-    def test_strategy(self):
-        """Test that strategy method."""
-        self.assertEqual(self.player().strategy(self.player()), None)
 
     def test_clone(self):
         # Make sure that self.init_args has the right number of arguments
@@ -151,7 +158,7 @@ class TestPlayer(unittest.TestCase):
     def first_play_test(self, play, random_seed=None):
         """Tests first move of a strategy."""
         P1 = self.player()
-        P2 = Player()
+        P2 = TestOpponent()
         test_responses(
             self, P1, P2, [], [], [play],
             random_seed=random_seed)
@@ -166,7 +173,7 @@ class TestPlayer(unittest.TestCase):
         for i, history in enumerate(histories):
             # Needs to be in the inner loop in case player retains some state
             P1 = self.player()
-            P2 = Player()
+            P2 = TestOpponent()
             test_responses(self, P1, P2, history[0], history[1], responses[i],
                            random_seed=random_seed)
 
@@ -179,7 +186,7 @@ class TestPlayer(unittest.TestCase):
         """
         P1 = self.player()
         P1.tournament_attributes['length'] = tournament_length
-        P2 = Player()
+        P2 = TestOpponent()
         P2.tournament_attributes['length'] = tournament_length
         test_responses(
             self, P1, P2, history_1, history_2, responses,
@@ -195,7 +202,7 @@ class TestPlayer(unittest.TestCase):
                         msg="memory_depth not in classifier")
         self.assertTrue('stochastic' in player.classifier,
                         msg="stochastic not in classifier")
-        for key in self.expected_classifier:
+        for key in TestOpponent.classifier:
             self.assertEqual(player.classifier[key],
                              self.expected_classifier[key],
                              msg="%s - Behaviour: %s != Expected Behaviour: %s" %

--- a/axelrod/tests/unit/test_qlearner.py
+++ b/axelrod/tests/unit/test_qlearner.py
@@ -91,6 +91,7 @@ class TestArrogantQLearner(TestPlayer):
         'memory_depth': float('inf'),  # Long memory
         'stochastic': True,
         'inspects_source': False,
+        'manipulates_source': False,
         'manipulates_state': False
     }
 
@@ -161,6 +162,7 @@ class TestHesitantQLearner(TestPlayer):
         'memory_depth': float('inf'),  # Long memory
         'stochastic': True,
         'inspects_source': False,
+        'manipulates_source': False,
         'manipulates_state': False
     }
 
@@ -231,6 +233,7 @@ class TestCautiousQLearner(TestPlayer):
         'memory_depth': float('inf'),  # Long memory
         'stochastic': True,
         'inspects_source': False,
+        'manipulates_source': False,
         'manipulates_state': False
     }
 

--- a/axelrod/tests/unit/test_titfortat.py
+++ b/axelrod/tests/unit/test_titfortat.py
@@ -35,6 +35,7 @@ class TestTitFor2Tats(TestPlayer):
     player = axelrod.TitFor2Tats
     expected_classifier = {
         'memory_depth': 2,
+        'stochastic': False,
         'inspects_source': False,
         'manipulates_source': False,
         'manipulates_state': False
@@ -56,6 +57,7 @@ class TestTwoTitsForTat(TestPlayer):
     player = axelrod.TwoTitsForTat
     expected_classifier = {
         'memory_depth': 2,
+        'stochastic': False,
         'inspects_source': False,
         'manipulates_source': False,
         'manipulates_state': False
@@ -79,6 +81,7 @@ class TestBully(TestPlayer):
     player = axelrod.Bully
     expected_classifier = {
         'memory_depth': 1,
+        'stochastic': False,
         'inspects_source': False,
         'manipulates_source': False,
         'manipulates_state': False
@@ -99,6 +102,7 @@ class TestSneakyTitForTat(TestPlayer):
     player = axelrod.SneakyTitForTat
     expected_classifier = {
         'memory_depth': float('inf'),  # Long memory
+        'stochastic': False,
         'inspects_source': False,
         'manipulates_source': False,
         'manipulates_state': False
@@ -120,6 +124,7 @@ class TestSuspiciousTitForTat(TestPlayer):
     player = axelrod.SuspiciousTitForTat
     expected_classifier = {
         'memory_depth': 1, # Four-Vector = (1.,0.,1.,0.)
+        'stochastic': False,
         'inspects_source': False,
         'manipulates_source': False,
         'manipulates_state': False
@@ -140,6 +145,7 @@ class TestAntiTitForTat(TestPlayer):
     player = axelrod.AntiTitForTat
     expected_classifier = {
         'memory_depth': 1, # Four-Vector = (1.,0.,1.,0.)
+        'stochastic': False,
         'inspects_source': False,
         'manipulates_source': False,
         'manipulates_state': False
@@ -160,6 +166,7 @@ class TestHardTitForTat(TestPlayer):
     player = axelrod.HardTitForTat
     expected_classifier = {
         'memory_depth': 3, # Four-Vector = (1.,0.,1.,0.)
+        'stochastic': False,
         'inspects_source': False,
         'manipulates_source': False,
         'manipulates_state': False
@@ -184,6 +191,7 @@ class TestHardTitFor2Tats(TestPlayer):
     player = axelrod.HardTitFor2Tats
     expected_classifier = {
         'memory_depth': 3, # Four-Vector = (1.,0.,1.,0.)
+        'stochastic': False,
         'inspects_source': False,
         'manipulates_source': False,
         'manipulates_state': False


### PR DESCRIPTION
By default Player.strategy now raises an exception instead of returning None. For https://github.com/Axelrod-Python/Axelrod/issues/317

Test framework TestPlayer updated to handle this change. Added TestOpponent player in test framework for players to use as an opponent in tests.

Updated TestPlayer framework to force subclasses to implement expected_classifier correctly. This revealed several tests which were not and were relying on the parent class TestPlayer