### PR TITLE
More plots and various plotting improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,10 +90,15 @@ version of the results:
 
 .. image:: http://axelrod-python.github.io/tournament/assets/strategies_boxplot.svg
 
+.. image:: http://axelrod-python.github.io/tournament/assets/strategies_winplot.svg
+
+See the [tournament repository](https://github.com/Axelrod-Python/tournament)
+for many additional plots.
+
 Contributing
 ============
 
-All contributions are welcome: with a particular emphasis on
+All contributions are welcome, with a particular emphasis on
 contributing further strategies.
 
 You can find helpful instructions about contributing in the

--- a/axelrod/payoff.py
+++ b/axelrod/payoff.py
@@ -129,26 +129,6 @@ def normalised_scores(scores, nplayers, turns):
     return [
         [1.0 * s / normalisation for s in r] for r in scores]
 
-#def median(list):
-    #"""
-    #Parameters
-    #----------
-    #list : list
-        #A list of numeric values
-
-    #Returns
-    #-------
-    #float
-        #The median value of the list.
-    #"""
-    #list = sorted(list)
-    #if len(list) < 1:
-        #return None
-    #if len(list) % 2 == 1:
-        #return list[((len(list) + 1) // 2) - 1]
-    #if len(list) % 2 == 0:
-        #return float(sum(list[(len(list) // 2) - 1:(len(list) // 2) + 1])) / 2.0
-
 def ranking(scores, nplayers):
     """
     Parameters
@@ -329,10 +309,11 @@ def payoff_diffs_means(payoff, nplayers, repetitions, turns):
          player_i payoff - player_j payoff in repetition2,
          ...])
 
-        normalized by the number of turns.
+        normalized by the number of turns. I.e. the nplayers x nplayers
+        matrix of mean payoff differences between each player and opponent.
     """
 
-    diffs_matrix = numpy.zeros((nplayers, nplayers))
+    diffs_matrix = [[0] * nplayers for _ in range(nplayers)]
     for player in range(nplayers):
         for opponent in range(nplayers):
             diffs = []
@@ -370,10 +351,8 @@ def score_diffs(payoff, nplayers, repetitions, turns):
     Returns
     -------
     list (of lists of lists)
-        A matrix of mean payoff differences of the form with i, j entry:
-        [player_i payoff - player_j payoff in repetition1,
-         player_i payoff - player_j payoff in repetition2,
-         ...]
+        A matrix of payoff differences of the form with i, j entry:
+        [player_i payoff - player_j payoff for each j and each repetition]
         where the payoffs have been normalized by the number of turns and summed
         over the repititions.
     """

--- a/axelrod/payoff.py
+++ b/axelrod/payoff.py
@@ -1,5 +1,9 @@
 import math
 
+import numpy
+from numpy import median, mean, std
+
+
 def payoff_matrix(interactions, game, nplayers, turns):
     """
     The payoff matrix from a single round robin.
@@ -125,25 +129,25 @@ def normalised_scores(scores, nplayers, turns):
     return [
         [1.0 * s / normalisation for s in r] for r in scores]
 
-def median(list):
-    """
-    Parameters
-    ----------
-    list : list
-        A list of numeric values
+#def median(list):
+    #"""
+    #Parameters
+    #----------
+    #list : list
+        #A list of numeric values
 
-    Returns
-    -------
-    float
-        The median value of the list.
-    """
-    list = sorted(list)
-    if len(list) < 1:
-        return None
-    if len(list) % 2 == 1:
-        return list[((len(list) + 1) // 2) - 1]
-    if len(list) % 2 == 0:
-        return float(sum(list[(len(list) // 2) - 1:(len(list) // 2) + 1])) / 2.0
+    #Returns
+    #-------
+    #float
+        #The median value of the list.
+    #"""
+    #list = sorted(list)
+    #if len(list) < 1:
+        #return None
+    #if len(list) % 2 == 1:
+        #return list[((len(list) + 1) // 2) - 1]
+    #if len(list) % 2 == 0:
+        #return float(sum(list[(len(list) // 2) - 1:(len(list) // 2) + 1])) / 2.0
 
 def ranking(scores, nplayers):
     """
@@ -292,3 +296,93 @@ def wins(payoff, nplayers, repetitions):
                 if winner is not None:
                     wins[winner][repetition] += 1
     return wins
+
+
+def payoff_diffs_means(payoff, nplayers, repetitions, turns):
+    """
+    Parameters
+    ----------
+    payoff : list
+        A matrix of the form:
+
+        [
+            [[a, j], [b, k], [c, l]],
+            [[d, m], [e, n], [f, o]],
+            [[g, p], [h, q], [i, r]],
+        ]
+
+        i.e. one row per player, containing one element per opponent (in
+        order of player index) which lists payoffs for each repetition.
+
+    nplayers : integer
+        The number of players in the tournament.
+    repetitions : integer
+        The number of repetitions in the tournament.
+    turns : integer
+        The number of turns in each round robin.
+
+    Returns
+    -------
+    list (of lists)
+        A matrix of mean payoff differences of the form with i, j entry:
+        mean([player_i payoff - player_j payoff in repetition1,
+         player_i payoff - player_j payoff in repetition2,
+         ...])
+
+        normalized by the number of turns.
+    """
+
+    diffs_matrix = numpy.zeros((nplayers, nplayers))
+    for player in range(nplayers):
+        for opponent in range(nplayers):
+            diffs = []
+            for repetition in range(repetitions):
+                diff = (payoff[player][opponent][repetition] - payoff[opponent][player][repetition]) / float(turns)
+                diffs.append(diff)
+            diffs_matrix[player][opponent] = mean(diffs)
+
+    return diffs_matrix
+
+
+def score_diffs(payoff, nplayers, repetitions, turns):
+    """
+    Parameters
+    ----------
+    payoff : list
+        A matrix of the form:
+
+        [
+            [[a, j], [b, k], [c, l]],
+            [[d, m], [e, n], [f, o]],
+            [[g, p], [h, q], [i, r]],
+        ]
+
+        i.e. one row per player, containing one element per opponent (in
+        order of player index) which lists payoffs for each repetition.
+
+    nplayers : integer
+        The number of players in the tournament.
+    repetitions : integer
+        The number of repetitions in the tournament.
+    turns : integer
+        The number of turns in each round robin.
+
+    Returns
+    -------
+    list (of lists of lists)
+        A matrix of mean payoff differences of the form with i, j entry:
+        [player_i payoff - player_j payoff in repetition1,
+         player_i payoff - player_j payoff in repetition2,
+         ...]
+        where the payoffs have been normalized by the number of turns and summed
+        over the repititions.
+    """
+    diffs = [
+        [] for p in range(nplayers)]
+    for player in range(nplayers):
+        for opponent in range(nplayers):
+            for repetition in range(repetitions):
+                diff = (payoff[player][opponent][repetition] - payoff[opponent][player][repetition]) / float(turns)
+                diffs[player].append(diff)
+
+    return diffs

--- a/axelrod/plot.py
+++ b/axelrod/plot.py
@@ -43,20 +43,20 @@ class Plot(object):
             self.result_set.repetitions,
             len(self.result_set.ranking))
 
-    def boxplot(self):
+    #def boxplot(self):
 
-        if not self.matplotlib_installed:
-            return None
+        #if not self.matplotlib_installed:
+            #return None
 
-        figure = plt.figure()
-        plt.boxplot(self._boxplot_dataset)
-        plt.xticks(
-            self._boxplot_xticks_locations,
-            self._boxplot_xticks_labels,
-            rotation=90)
-        plt.tick_params(axis='both', which='both', labelsize=7)
-        plt.title(self._boxplot_title)
-        return figure
+        #figure = plt.figure()
+        #plt.boxplot(self._boxplot_dataset)
+        #plt.xticks(
+            #self._boxplot_xticks_locations,
+            #self._boxplot_xticks_labels,
+            #rotation=90)
+        #plt.tick_params(axis='both', which='both', labelsize=7)
+        #plt.title(self._boxplot_title)
+        #return figure
 
     @property
     def _sdv_plot_title(self):
@@ -88,7 +88,7 @@ class Plot(object):
         ranked_names = [str(players[i]) for i in ordering]
         return diffs, ranked_names
 
-    def vplot(self, data, names):
+    def vplot(self, data, names, title=None):
         if not self.matplotlib_installed:
             return None
         nplayers = self.result_set.nplayers
@@ -103,9 +103,11 @@ class Plot(object):
             positions,
             names,
             rotation=90)
+
         plt.xlim(0, spacing * (nplayers + 1))
         plt.tick_params(axis='both', which='both', labelsize=7)
-        plt.title(self._sdv_plot_title)
+        if title:
+            plt.title(title)
         return figure
 
     #def bplot(self, data, names):
@@ -134,29 +136,30 @@ class Plot(object):
             return None
 
         diffs, ranked_names = self._sdv_plot_dataset
-        figure = self.vplot(diffs, ranked_names)
+        title = self._sdv_plot_title
+        figure = self.vplot(diffs, ranked_names, title)
         return figure
 
-        if not self.matplotlib_installed:
-            return None
-        diffs, ranked_names = self._sdv_plot_dataset
-        nplayers = self.result_set.nplayers
-        width = max(nplayers / 2, 12)
-        height = width / 4
-        figure = plt.figure(figsize=(width, height))
-        spacing = 4
-        positions = spacing * arange(1, nplayers + 1, 1)
-        plt.violinplot(diffs, positions=positions, widths=spacing / 2,
-                       showmedians=True)
-        plt.xticks(
-            #self._boxplot_xticks_locations,
-            positions,
-            ranked_names,
-            rotation=90)
-        plt.xlim(0, spacing * (nplayers + 1))
-        plt.tick_params(axis='both', which='both', labelsize=7)
-        plt.title(self._sdv_plot_title)
-        return figure
+        #if not self.matplotlib_installed:
+            #return None
+        #diffs, ranked_names = self._sdv_plot_dataset
+        #nplayers = self.result_set.nplayers
+        #width = max(nplayers / 2, 12)
+        #height = width / 4
+        #figure = plt.figure(figsize=(width, height))
+        #spacing = 4
+        #positions = spacing * arange(1, nplayers + 1, 1)
+        #plt.violinplot(diffs, positions=positions, widths=spacing / 2,
+                       #showmedians=True)
+        #plt.xticks(
+            ##self._boxplot_xticks_locations,
+            #positions,
+            #ranked_names,
+            #rotation=90)
+        #plt.xlim(0, spacing * (nplayers + 1))
+        #plt.tick_params(axis='both', which='both', labelsize=7)
+        #plt.title(self._sdv_plot_title)
+        #return figure
 
     @property
     def _pdplot_dataset(self):
@@ -214,19 +217,45 @@ class Plot(object):
         if not self.matplotlib_installed:
             return None
 
-        wins, ranked_names = self._winplot_dataset
+        data, names = self._winplot_dataset
+        title = self._winplot_title
+        figure = self.vplot(data, names, title)
+        # Expand ylim a bit
         maximum = max(max(w) for w in wins)
-
-        figure = plt.figure()
-        plt.boxplot(wins)
-        plt.xticks(
-            self._boxplot_xticks_locations,
-            ranked_names,
-            rotation=90)
-        plt.tick_params(axis='both', which='both', labelsize=7)
-        plt.title(self._winplot_title)
         plt.ylim(-0.5, 0.5 + maximum)
         return figure
+
+
+
+        #figure = plt.figure()
+        #plt.boxplot(wins)
+        #plt.xticks(
+            #self._boxplot_xticks_locations,
+            #ranked_names,
+            #rotation=90)
+        #plt.tick_params(axis='both', which='both', labelsize=7)
+        #plt.title(self._winplot_title)
+
+        #return figure
+
+
+    def boxplot(self):
+
+        if not self.matplotlib_installed:
+            return None
+
+        data = self._boxplot_dataset
+        names = self._boxplot_xticks_labels
+        figure = self.vplot(data, names)
+        plt.tick_params(axis='both', which='both', labelsize=7)
+        plt.title(self._boxplot_title)
+
+        return figure
+
+
+
+
+
 
     def payoff(self):
 

--- a/axelrod/plot.py
+++ b/axelrod/plot.py
@@ -23,10 +23,13 @@ class Plot(object):
         """For making boxplots."""
         if not self.matplotlib_installed:
             return None
-        figure = plt.figure()
+        nplayers = self.result_set.nplayers
+        width = max(nplayers / 3, 12)
+        height = width / 2
+        figure = plt.figure(figsize=(width, height))
         plt.boxplot(data)
         plt.xticks(self._boxplot_xticks_locations, names, rotation=90)
-        plt.tick_params(axis='both', which='both', labelsize=7)
+        plt.tick_params(axis='both', which='both', labelsize=8)
         if title:
             plt.title(title)
         return figure
@@ -45,7 +48,7 @@ class Plot(object):
                        showmedians=True, showextrema=False)
         plt.xticks(positions, names, rotation=90)
         plt.xlim(0, spacing * (nplayers + 1))
-        plt.tick_params(axis='both', which='both', labelsize=7)
+        plt.tick_params(axis='both', which='both', labelsize=8)
         if title:
             plt.title(title)
         return figure
@@ -189,13 +192,19 @@ class Plot(object):
         """Generic heatmap plot"""
         if not self.matplotlib_installed:
             return None
+
+        nplayers = self.result_set.nplayers
+        width = max(nplayers / 4, 12)
+        height = width
         figure, ax = plt.subplots()
+        figure.set_figwidth(width)
+        figure.set_figheight(height)
         mat = ax.matshow(data, cmap='YlGnBu')
         plt.xticks(range(self.result_set.nplayers))
         plt.yticks(range(self.result_set.nplayers))
         ax.set_xticklabels(names, rotation=90)
         ax.set_yticklabels(names)
-        plt.tick_params(axis='both', which='both', labelsize=6)
+        plt.tick_params(axis='both', which='both', labelsize=16)
         # Make the colorbar match up with the plot
         divider = make_axes_locatable(plt.gca())
         cax = divider.append_axes("right", "5%", pad="3%")

--- a/axelrod/plot.py
+++ b/axelrod/plot.py
@@ -180,7 +180,7 @@ class Plot(object):
     def _pdplot_dataset(self):
         # Order like the sdv_plot
         ordering = self._sd_ordering
-        pdm = self.result_set.payoff_diffs_matrix
+        pdm = self.result_set.payoff_diffs_means
         # Reorder and grab names
         matrix = [[pdm[r1][r2] for r2 in ordering]
                   for r1 in ordering]

--- a/axelrod/plot.py
+++ b/axelrod/plot.py
@@ -1,5 +1,5 @@
 
-import numpy # for numpy.linalg.linalg.LinAlgError
+from numpy.linalg import LinAlgError
 from numpy import arange, mean, median
 
 matplotlib_installed = True
@@ -82,7 +82,7 @@ class Plot(object):
         title = self._boxplot_title
         try:
             figure = self._violinplot(data, names, title=title)
-        except numpy.linalg.linalg.LinAlgError:
+        except LinAlgError:
             # Matplotlib doesn't handle single point distributions well
             # in violin plots. Should be fixed in next release:
             # https://github.com/matplotlib/matplotlib/pull/4816
@@ -119,7 +119,7 @@ class Plot(object):
         title = self._winplot_title
         try:
             figure = self._violinplot(data, names, title)
-        except numpy.linalg.linalg.LinAlgError:
+        except LinAlgError:
             # Matplotlib doesn't handle single point distributions well
             # in violin plots. Should be fixed in next release:
             # https://github.com/matplotlib/matplotlib/pull/4816

--- a/axelrod/plot.py
+++ b/axelrod/plot.py
@@ -1,6 +1,6 @@
-from operator import itemgetter
+#from operator import itemgetter
 
-from numpy import mean, median
+from numpy import arange, mean, median
 
 matplotlib_installed = True
 try:
@@ -59,7 +59,7 @@ class Plot(object):
         return figure
 
     @property
-    def _sdb_plot_title(self):
+    def _sdv_plot_title(self):
         return ("Distributions of payoff differences per stage game over {} "
                 "turns repeated {} times ({} strategies)").format(
             self.result_set.turns,
@@ -68,15 +68,18 @@ class Plot(object):
 
     @property
     def _sd_ordering(self):
-        # Sort by median then max
-        diffs = self.result_set.score_diffs
-        to_sort = [(median(d), max(d), i) for (i, d) in enumerate(diffs)]
-        to_sort.sort(reverse=True, key=itemgetter(0, 1))
-        ordering = [x[-1] for x in to_sort]
-        return ordering
+
+        return self.result_set.ranking
+
+        ## Sort by median then max
+        #diffs = self.result_set.score_diffs
+        #to_sort = [(median(d), max(d), i) for (i, d) in enumerate(diffs)]
+        #to_sort.sort(reverse=True, key=itemgetter(0, 1))
+        #ordering = [x[-1] for x in to_sort]
+        #return ordering
 
     @property
-    def _sdb_plot_dataset(self):
+    def _sdv_plot_dataset(self):
         ordering = self._sd_ordering
         diffs = self.result_set.score_diffs
         players = self.result_set.players
@@ -85,26 +88,79 @@ class Plot(object):
         ranked_names = [str(players[i]) for i in ordering]
         return diffs, ranked_names
 
-    def sdbplot(self):
-        """Score difference boxplots to visualize the distributions of how
+    def vplot(self, data, names):
+        if not self.matplotlib_installed:
+            return None
+        nplayers = self.result_set.nplayers
+        width = max(nplayers / 2, 12)
+        height = width / 4
+        figure = plt.figure(figsize=(width, height))
+        spacing = 4
+        positions = spacing * arange(1, nplayers + 1, 1)
+        plt.violinplot(data, positions=positions, widths=spacing / 2,
+                       showmedians=True)
+        plt.xticks(
+            positions,
+            names,
+            rotation=90)
+        plt.xlim(0, spacing * (nplayers + 1))
+        plt.tick_params(axis='both', which='both', labelsize=7)
+        plt.title(self._sdv_plot_title)
+        return figure
+
+    #def bplot(self, data, names):
+        #if not self.matplotlib_installed:
+            #return None
+
+        #figure = plt.figure()
+        #plt.boxplot(data)
+        #plt.xticks(
+            #self._boxplot_xticks_locations,
+            #names,
+            #rotation=90)
+        #plt.tick_params(axis='both', which='both', labelsize=7)
+        #plt.title(self._boxplot_title)
+        #return figure
+
+
+
+
+
+    def sdvplot(self):
+        """Score difference violinplots to visualize the distributions of how
         players attain their payoffs."""
 
         if not self.matplotlib_installed:
             return None
-        diffs, ranked_names = self._sdb_plot_dataset
-        figure = plt.figure()
-        plt.boxplot(diffs)
+
+        diffs, ranked_names = self._sdv_plot_dataset
+        figure = self.vplot(diffs, ranked_names)
+        return figure
+
+        if not self.matplotlib_installed:
+            return None
+        diffs, ranked_names = self._sdv_plot_dataset
+        nplayers = self.result_set.nplayers
+        width = max(nplayers / 2, 12)
+        height = width / 4
+        figure = plt.figure(figsize=(width, height))
+        spacing = 4
+        positions = spacing * arange(1, nplayers + 1, 1)
+        plt.violinplot(diffs, positions=positions, widths=spacing / 2,
+                       showmedians=True)
         plt.xticks(
-            self._boxplot_xticks_locations,
+            #self._boxplot_xticks_locations,
+            positions,
             ranked_names,
             rotation=90)
+        plt.xlim(0, spacing * (nplayers + 1))
         plt.tick_params(axis='both', which='both', labelsize=7)
-        plt.title(self._sdb_plot_title)
+        plt.title(self._sdv_plot_title)
         return figure
 
     @property
     def _pdplot_dataset(self):
-        # Order like the sdb_plot
+        # Order like the sdv_plot
         ordering = self._sd_ordering
         pdm = self.result_set.payoff_diffs_matrix
         # Reorder and grab names

--- a/axelrod/tests/unit/test_payoff.py
+++ b/axelrod/tests/unit/test_payoff.py
@@ -68,6 +68,18 @@ class TestPayoff(unittest.TestCase):
 
         cls.expected_wins = [[2, 0], [0, 0], [0, 2]]
 
+        cls.diff_means = [
+            [ 0. ,  0. ,  0.5],
+            [ 0. ,  0. , -0.5],
+            [-0.5,  0.5,  0. ]
+        ]
+
+        cls.expected_score_diffs = [
+            [0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, -1.0],
+            [-1.0, 0.0, 0.0, 1.0, 0.0, 0.0]
+        ]
+
     def test_payoff_matrix(self):
         payoff_matrix = ap.payoff_matrix(self.interactions, Game(), 3, 5)
         self.assertEqual(payoff_matrix, self.expected_payoff_matrix)
@@ -88,6 +100,19 @@ class TestPayoff(unittest.TestCase):
         ranked_names = ap.ranked_names(
             self.players, self.expected_ranking,)
         self.assertEqual(ranked_names, self.expected_ranked_names)
+
+
+
+    def test_payoff_diffs_means(self):
+        #payoff_matrix = ap.payoff_matrix(self.interactions, Game(), 3, 5)
+        diff_means = ap.payoff_diffs_means(self.expected_payoff, 3, 2, 5)
+        self.assertEqual(diff_means, self.diff_means)
+
+    def test_score_diffs(self):
+        #payoff_matrix = ap.payoff_matrix(self.interactions, Game(), 3, 5)
+        score_diffs = ap.score_diffs(self.expected_payoff, 3, 2, 5)
+        self.assertEqual(score_diffs, self.expected_score_diffs)
+
 
     @staticmethod
     def round_matrix(matrix, precision):

--- a/axelrod/tests/unit/test_payoff.py
+++ b/axelrod/tests/unit/test_payoff.py
@@ -80,14 +80,6 @@ class TestPayoff(unittest.TestCase):
         scores = ap.normalised_scores(self.expected_scores, 3, 5)
         self.assertEqual(scores, self.expected_normalised_scores)
 
-    def test_median(self):
-        median = ap.median([])
-        self.assertEqual(median, None)
-        median = ap.median([1, 2, 4, 6])
-        self.assertEqual(median, 3.0)
-        median = ap.median(self.expected_scores)
-        self.assertEqual(median, [27, 20])
-
     def test_ranking(self):
         ranking = ap.ranking(self.expected_scores, 3)
         self.assertEqual(ranking, self.expected_ranking)

--- a/axelrod/tournament_manager.py
+++ b/axelrod/tournament_manager.py
@@ -126,7 +126,8 @@ class TournamentManager(object):
             self._logger.error('The matplotlib library is not installed. '
                             'No plots will be produced')
             return
-        for plot_type in ('boxplot', 'payoff', 'winplot', 'sdvplot', 'pdplot'):
+        #for plot_type in ('boxplot', 'payoff', 'winplot', 'sdvplot', 'pdplot'):
+        for plot_type in ('boxplot', 'winplot', 'sdvplot', 'payoff', 'pdplot'):
             figure = getattr(plot, plot_type)()
             file_name = self._output_file_path(
                 tournament.name + '_' + plot_type, image_format)

--- a/axelrod/tournament_manager.py
+++ b/axelrod/tournament_manager.py
@@ -126,7 +126,7 @@ class TournamentManager(object):
             self._logger.error('The matplotlib library is not installed. '
                             'No plots will be produced')
             return
-        for plot_type in ('boxplot', 'payoff', 'winplot', 'sdbplot', 'pdplot'):
+        for plot_type in ('boxplot', 'payoff', 'winplot', 'sdvplot', 'pdplot'):
             figure = getattr(plot, plot_type)()
             file_name = self._output_file_path(
                 tournament.name + '_' + plot_type, image_format)

--- a/axelrod/tournament_manager.py
+++ b/axelrod/tournament_manager.py
@@ -126,7 +126,7 @@ class TournamentManager(object):
             self._logger.error('The matplotlib library is not installed. '
                             'No plots will be produced')
             return
-        for plot_type in ('boxplot', 'payoff', 'winplot'):
+        for plot_type in ('boxplot', 'payoff', 'winplot', 'sdbplot', 'pdplot'):
             figure = getattr(plot, plot_type)()
             file_name = self._output_file_path(
                 tournament.name + '_' + plot_type, image_format)

--- a/axelrod/tournament_manager.py
+++ b/axelrod/tournament_manager.py
@@ -126,8 +126,7 @@ class TournamentManager(object):
             self._logger.error('The matplotlib library is not installed. '
                             'No plots will be produced')
             return
-        #for plot_type in ('boxplot', 'payoff', 'winplot', 'sdvplot', 'pdplot'):
-        for plot_type in ('boxplot', 'winplot', 'sdvplot', 'payoff', 'pdplot'):
+        for plot_type in ('boxplot', 'payoff', 'winplot', 'sdvplot', 'pdplot'):
             figure = getattr(plot, plot_type)()
             file_name = self._output_file_path(
                 tournament.name + '_' + plot_type, image_format)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -322,7 +322,7 @@ This produces:
    :align: center
 
 In this case most of the strategies are deterministic, so there is not much
-variation in the distributions. See below for a more complex example.
+variation in the distributions. See below for a more complex example. Similarly, there are additional plots for the score differences.
 
 Noisy Tournaments
 ^^^^^^^^^^^^^^^^^

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -307,7 +307,7 @@ For any tournament, a plot of the distribution of wins is created, much like the
 plot for the distribution of mean scores. For the demo strategies we create the
 plot as follows::
 
-    import axelrod
+    import axelrodmean
     strategies = [s() for s in axelrod.demo_strategies]
     tournament = axelrod.Tournament(strategies, game=Game(30, 0, 50, 10))
     results = tournament.play()
@@ -322,7 +322,9 @@ This produces:
    :align: center
 
 In this case most of the strategies are deterministic, so there is not much
-variation in the distributions. See below for a more complex example. Similarly, there are additional plots for the score differences.
+variation in the distributions. See below for a more complex example. Similarly, there are additional plots for the score differences: `plot.sdvplot()` gives
+violin or boxplots for the score differences, and `plot.pdplot()` which
+gives a heatmap of the mean payoff differences (like the payoff image above).
 
 Noisy Tournaments
 ^^^^^^^^^^^^^^^^^

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -307,7 +307,7 @@ For any tournament, a plot of the distribution of wins is created, much like the
 plot for the distribution of mean scores. For the demo strategies we create the
 plot as follows::
 
-    import axelrodmean
+    import axelrod
     strategies = [s() for s in axelrod.demo_strategies]
     tournament = axelrod.Tournament(strategies, game=Game(30, 0, 50, 10))
     results = tournament.play()


### PR DESCRIPTION
Two new plots:
* "*_sdvplot.svg" -- the score difference distributions in a violin plot
* "*_pdplot.svg" -- the score difference means in a heat map (like the payoff plot)

![](http://i.imgur.com/y6YGJa5.png)
![](http://i.imgur.com/rGzvlav.png)

The new plots make it easier to see how a strategy is winning, either by mutual cooperation or successful defections. (Certainly the first one at least.)

Violin plots: these are a better representation of the actual distributions than boxplots in my opinion, so I updated the code to generate these instead. The downside is that matplotlib v1.4.3 doesn't handle them correctly in all cases, but there is a fix in for 1.5. So the code now catches an exception and falls back onto a boxplot if necessary.

Here's the noisy mean score distribution as a violin plot:
![](http://i.imgur.com/rezuutN.png)

I also made various improvements to the plot sizes and spacing. The score difference plots use the same ordering as the mean score plots -- there are a few commented out lines that use another sorting.

Unfortunately I did have to touch results_set (don't hate me @meatballs!) but the changes are fairly minor (mostly additions). If you all like the new plots, I'll update the docs and the tournament repository.