### PR TITLE
remove self.init_args

### DIFF
--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -73,7 +73,6 @@ class Player(object):
                 self.classifier[dimension] = self.default_classifier[dimension]
         self.cooperations = 0
         self.defections = 0
-        self.init_args = ()
         self.set_tournament_attributes()
 
     def receive_tournament_attributes(self):
@@ -119,9 +118,8 @@ class Player(object):
         """Clones the player without history, reapplying configuration
         parameters as necessary."""
 
-        cls = self.__class__
-        new_player = cls(*self.init_args)
-        new_player.tournament_attributes = copy.copy(self.tournament_attributes)
+        new_player = copy.copy(self)
+        new_player.reset()
         return new_player
 
     def reset(self):

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -119,7 +119,7 @@ class Player(object):
         parameters as necessary."""
 
         new_player = copy.copy(self)
-        new_player.reset()
+        new_player.tournament_attributes = copy.copy(self.tournament_attributes)
         return new_player
 
     def reset(self):

--- a/axelrod/strategies/axelrod_tournaments.py
+++ b/axelrod/strategies/axelrod_tournaments.py
@@ -35,7 +35,6 @@ class Davis(Player):
         """
         Player.__init__(self)
         self._rounds_to_cooperate = rounds_to_cooperate
-        self.init_args = (self._rounds_to_cooperate,)
 
     def strategy(self, opponent):
         """Begins by playing C, then plays D for the remaining rounds if the
@@ -79,9 +78,6 @@ class Feld(Player):
         self._start_coop_prob = start_coop_prob
         self._end_coop_prob = end_coop_prob
         self._rounds_of_decay = rounds_of_decay
-        self.init_args = (start_coop_prob,
-                          end_coop_prob,
-                          rounds_of_decay)
 
     def _cooperation_probability(self):
         """It's not clear what the interpolating function is, so we'll do
@@ -116,7 +112,6 @@ class Grofman(MemoryOnePlayer):
         p = float(2) / 7
         four_vector = (p, p, p, p)
         super(self.__class__, self).__init__(four_vector)
-        self.init_args = ()
 
 
 class Joss(MemoryOnePlayer):
@@ -138,7 +133,6 @@ class Joss(MemoryOnePlayer):
         four_vector = (p, 0, p, 0)
         self.p = p
         super(self.__class__, self).__init__(four_vector)
-        self.init_args = (p,)
 
     def __repr__(self):
         return "%s: %s" % (self.name, round(self.p, 2))
@@ -228,7 +222,6 @@ class Tullock(Player):
         Player.__init__(self)
         self._rounds_to_cooperate = rounds_to_cooperate
         self.__class__.memory_depth = rounds_to_cooperate
-        self.init_args = (rounds_to_cooperate,)
 
     def strategy(self, opponent):
         rounds = self._rounds_to_cooperate

--- a/axelrod/strategies/cycler.py
+++ b/axelrod/strategies/cycler.py
@@ -56,7 +56,6 @@ class Cycler(Player):
         self.cycle = cycle
         self.name += " " + cycle
         self.classifier['memory_depth'] = len(cycle) - 1
-        self.init_args = (cycle,)
 
     def strategy(self, opponent):
         curent_round = len(self.history)

--- a/axelrod/strategies/gobymajority.py
+++ b/axelrod/strategies/gobymajority.py
@@ -32,7 +32,6 @@ class GoByMajority(Player):
         Player.__init__(self)
         self.soft = soft
         self.classifier['memory_depth'] = memory_depth
-        self.init_args = (memory_depth, soft)
 
     def strategy(self, opponent):
         """This is affected by the history of the opponent.

--- a/axelrod/strategies/grumpy.py
+++ b/axelrod/strategies/grumpy.py
@@ -34,7 +34,6 @@ class Grumpy(Player):
         self.starting_state = starting_state
         self.grumpy_threshold = grumpy_threshold
         self.nice_threshold = nice_threshold
-        self.init_args = (starting_state, grumpy_threshold, nice_threshold)
 
     def strategy(self, opponent):
         """A player that gets grumpier the more the opposition defects,

--- a/axelrod/strategies/memoryone.py
+++ b/axelrod/strategies/memoryone.py
@@ -27,7 +27,6 @@ class WinStayLoseShift(Player):
         }
         self.classifier['stochastic'] = False
         self._initial = initial
-        self.init_args = (initial,)
 
     def strategy(self, opponent):
         """Switches if it doesn't get the best payout, traditionally equivalent
@@ -68,7 +67,6 @@ class MemoryOnePlayer(Player):
         self._initial = initial
         if four_vector:
             self.set_four_vector(four_vector)
-        self.init_args = (four_vector, initial)
 
     def set_four_vector(self, four_vector):
         self._four_vector = dict(zip([('C', 'C'), ('C', 'D'), ('D', 'C'), ('D', 'D')], map(float, four_vector)))
@@ -102,7 +100,6 @@ class GTFT(MemoryOnePlayer):
         """
         self.p = p
         super(self.__class__, self).__init__()
-        self.init_args = (p,)
 
     def receive_tournament_attributes(self):
         (R, P, S, T) = self.tournament_attributes["game"].RPST()
@@ -123,7 +120,6 @@ class StochasticCooperator(MemoryOnePlayer):
     def __init__(self):
         four_vector = (0.935, 0.229, 0.266, 0.42)
         super(self.__class__, self).__init__(four_vector)
-        self.init_args = ()
         self.set_four_vector(four_vector)
 
 
@@ -144,7 +140,6 @@ class StochasticWSLS(MemoryOnePlayer):
         self.ep = ep
         four_vector = (1.-ep, ep, ep, 1.-ep)
         super(self.__class__, self).__init__(four_vector)
-        self.init_args = (ep,)
         self.set_four_vector(four_vector)
 
 
@@ -202,7 +197,6 @@ class ZDGTFT2(ZeroDeterminantPlayer):
         self.phi = phi
         self.s = s
         super(self.__class__, self).__init__()
-        self.init_args = (phi, s)
 
     def receive_tournament_attributes(self):
         (R, P, S, T) = self.tournament_attributes["game"].RPST()
@@ -227,7 +221,6 @@ class ZDExtort2(ZeroDeterminantPlayer):
         self.phi = phi
         self.s = s
         super(self.__class__, self).__init__()
-        self.init_args = (phi, s)
 
     def receive_tournament_attributes(self):
         (R, P, S, T) = self.tournament_attributes["game"].RPST()
@@ -258,7 +251,6 @@ class SoftJoss(MemoryOnePlayer):
         self.q = q
         four_vector = (1., 1 - q, 1, 1 - q)
         super(self.__class__, self).__init__(four_vector)
-        self.init_args = (q,)
 
     def __repr__(self):
         return "%s: %s" % (self.name, round(self.q, 2))

--- a/axelrod/strategies/meta.py
+++ b/axelrod/strategies/meta.py
@@ -74,7 +74,6 @@ class MetaMajority(MetaPlayer):
             # Needs to be computed manually to prevent circular dependency
             self.team = ordinary_strategies
         super(MetaMajority, self).__init__()
-        self.init_args = (team,)
 
     def meta_strategy(self, results, opponent):
         if results.count('D') > results.count('C'):
@@ -94,7 +93,6 @@ class MetaMinority(MetaPlayer):
             # Needs to be computed manually to prevent circular dependency
             self.team = ordinary_strategies
         super(MetaMinority, self).__init__()
-        self.init_args = (team,)
 
     def meta_strategy(self, results, opponent):
         if results.count('D') < results.count('C'):
@@ -118,7 +116,6 @@ class MetaWinner(MetaPlayer):
             self.team = ordinary_strategies
 
         super(MetaWinner, self).__init__()
-        self.init_args = (team,)
 
         # For each player, we will keep the history of proposed moves and
         # a running score since the beginning of the game.
@@ -202,7 +199,6 @@ class MetaMajorityMemoryOne(MetaMajority):
     def __init__(self):
         team = [s for s in ordinary_strategies if s().classifier['memory_depth'] <= 1]
         super(MetaMajorityMemoryOne, self).__init__(team=team)
-        self.init_args = ()
 
 
 class MetaWinnerMemoryOne(MetaWinner):
@@ -213,7 +209,6 @@ class MetaWinnerMemoryOne(MetaWinner):
     def __init__(self):
         team = [s for s in ordinary_strategies if s().classifier['memory_depth'] <= 1]
         super(MetaWinnerMemoryOne, self).__init__(team=team)
-        self.init_args = ()
 
 
 class MetaMajorityFiniteMemory(MetaMajority):
@@ -224,7 +219,6 @@ class MetaMajorityFiniteMemory(MetaMajority):
         team = [s for s in ordinary_strategies if s().classifier['memory_depth']
                 < float('inf')]
         super(MetaMajorityFiniteMemory, self).__init__(team=team)
-        self.init_args = ()
 
 
 class MetaWinnerFiniteMemory(MetaWinner):
@@ -235,7 +229,6 @@ class MetaWinnerFiniteMemory(MetaWinner):
         team = [s for s in ordinary_strategies if s().classifier['memory_depth']
                 < float('inf')]
         super(MetaWinnerFiniteMemory, self).__init__(team=team)
-        self.init_args = ()
 
 
 class MetaMajorityLongMemory(MetaMajority):
@@ -246,7 +239,6 @@ class MetaMajorityLongMemory(MetaMajority):
         team = [s for s in ordinary_strategies if s().classifier['memory_depth']
                 == float('inf')]
         super(MetaMajorityLongMemory, self).__init__(team=team)
-        self.init_args = ()
 
 
 class MetaWinnerLongMemory(MetaWinner):
@@ -257,4 +249,3 @@ class MetaWinnerLongMemory(MetaWinner):
         team = [s for s in ordinary_strategies if s().classifier['memory_depth']
                 == float('inf')]
         super(MetaWinnerLongMemory, self).__init__(team=team)
-        self.init_args = ()

--- a/axelrod/strategies/oncebitten.py
+++ b/axelrod/strategies/oncebitten.py
@@ -106,7 +106,6 @@ class ForgetfulFoolMeOnce(Player):
         self.D_count = 0
         self._initial = 'C'
         self.forget_probability = forget_probability
-        self.init_args = (forget_probability,)
 
     def strategy(self, opponent):
         r = random.random()

--- a/axelrod/strategies/rand.py
+++ b/axelrod/strategies/rand.py
@@ -23,7 +23,6 @@ class Random(Player):
         """
         Player.__init__(self)
         self.p = p
-        self.init_args = (p,)
 
     def strategy(self, opponent):
         r = random.random()

--- a/axelrod/strategies/retaliate.py
+++ b/axelrod/strategies/retaliate.py
@@ -27,7 +27,6 @@ class Retaliate(Player):
             'Retaliate (' +
             str(self.retaliation_threshold) + ')')
         self.play_counts = defaultdict(int)
-        self.init_args = (retaliation_threshold,)
 
     def strategy(self, opponent):
         """
@@ -101,7 +100,6 @@ class LimitedRetaliate(Player):
         self.retaliation_threshold = retaliation_threshold
         self.retaliation_limit = retaliation_limit
         self.play_counts = defaultdict(int)
-        self.init_args = (retaliation_threshold, retaliation_limit)
 
         self.name = (
             'Limited Retaliate (' +


### PR DESCRIPTION
Correct me if I am wrong, but I don't think `self.init_args` is needed everywhere. `copy.copy` should transfer the properties over. This improves the maintainability of the code, and makes adding strategies easier. 

For review @meatballs et al.