### PR TITLE
Add .mailmap file so that `git shortlog` groups names correctly

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,11 @@
+Vincent Knight <vincent.knight@gmail.com> Vince Knight <vincent.knight@gmail.com>
+Vincent Knight <vincent.knight@gmail.com> vince <vincent.knight@gmail.com>
+Karol M. Langner <karol.langner@gmail.com> Karol M. Langner <langner@users.noreply.github.com>
+Karol M. Langner <karol.langner@gmail.com> Karol M. Langner <langner@google.com>
+Jason Young <Jas.young314@gmail.com> jasonyoung <jas.young314@gmail.com>
+Marc Harper <marc.harper@gmail.com> Marc Harper, PhD <marc.harper@gmail.com>
+Owen Campbell <owen.campbell@tanti.org.uk> Owen Campbell <owen.campbell@empiria.co.uk>
+Geraint Palmer <palmer.geraint@googlemail.com> geraint <palmer.geraint@googlemail.com>
+Paul Slavin <pmslavin@gmail.com> slavinp <slavinp@cs.man.ac.uk>
+Paul Slavin <pmslavin@gmail.com> Paul Slavin <slavinp@cs.man.ac.uk>
+Martin Chorley <martin.chorley@gmail.com> Martin Chorley <m.j.chorley@cs.cardiff.ac.uk>


### PR DESCRIPTION
This allows us to use tools like gitinspector to analyze the repository:

[Python contributions] (http://marcharper.codes/axelrod/axelrod_py.html)
* Owen Campbell 39.77%
* Marc Harper 23.47%
* Vincent Knight	 15.48%
* Karol M. Langner 10.75%

[Documentation Contributions](http://marcharper.codes/axelrod/axelrod_rst.html)
* Vincent Knight	 71.46%
* Marc Harper 21.76%
* Owen Campbell 3.01%
* Luis Visintini 2.19%