### PR TITLE
Refactors payoff.py

### DIFF
--- a/axelrod/payoff.py
+++ b/axelrod/payoff.py
@@ -318,7 +318,7 @@ def wins(payoff):
     return wins
 
 
-def payoff_diffs_means(payoff, nplayers, repetitions, turns):
+def payoff_diffs_means(payoff, turns):
     """
     Parameters
     ----------
@@ -352,7 +352,8 @@ def payoff_diffs_means(payoff, nplayers, repetitions, turns):
         normalized by the number of turns. I.e. the nplayers x nplayers
         matrix of mean payoff differences between each player and opponent.
     """
-
+    nplayers = len(payoff)
+    repetitions = len(payoff[0][0])
     diffs_matrix = [[0] * nplayers for _ in range(nplayers)]
     for player in range(nplayers):
         for opponent in range(nplayers):

--- a/axelrod/payoff.py
+++ b/axelrod/payoff.py
@@ -46,10 +46,11 @@ def payoff_matrix(interactions, game):
     nplayers = len(interactions)
     payoffs = [[0 for i in range(nplayers)] for j in range(nplayers)]
     for p1 in range(nplayers):
-        for p2 in range(nplayers):
+        for p2 in range(p1, nplayers):
             payoff = interaction_payoff(interactions[p1][p2], game)
             payoffs[p1][p2] += payoff[0]
-            payoffs[p2][p1] += payoff[1]
+            if p1 != p2:
+                payoffs[p2][p1] += payoff[1]
     return payoffs
 
 

--- a/axelrod/payoff.py
+++ b/axelrod/payoff.py
@@ -201,7 +201,7 @@ def ranked_names(players, ranking):
     return ranked_names
 
 
-def normalised_payoff(payoff_matrix, turns, repetitions):
+def normalised_payoff(payoff_matrix, turns):
     """
     Parameters
     ----------
@@ -227,6 +227,7 @@ def normalised_payoff(payoff_matrix, turns, repetitions):
     list
         A per-turn averaged payoff matrix and its standard deviations.
     """
+    repetitions = len(payoff_matrix[0][0])
     averages = []
     stddevs = []
     for res in payoff_matrix:

--- a/axelrod/payoff.py
+++ b/axelrod/payoff.py
@@ -1,7 +1,5 @@
 import math
-
-import numpy
-from numpy import median, mean, std
+from numpy import median, mean
 
 
 def payoff_matrix(interactions, game, nplayers, turns):

--- a/axelrod/payoff.py
+++ b/axelrod/payoff.py
@@ -161,7 +161,7 @@ def normalised_scores(scores, turns):
         [1.0 * s / normalisation for s in r] for r in scores]
 
 
-def ranking(scores, nplayers):
+def ranking(scores):
     """
     Parameters
     ----------
@@ -176,6 +176,7 @@ def ranking(scores, nplayers):
         A list of players (their index within the players list rather than
         a player instance) ordered by median score
     """
+    nplayers = len(scores)
     ranking = sorted(
         range(nplayers),
         key=lambda i: -median(scores[i]))

--- a/axelrod/payoff.py
+++ b/axelrod/payoff.py
@@ -57,6 +57,31 @@ def payoff_matrix(interactions, game, nplayers, turns):
     return payoff
 
 
+def interaction_payoff(actions, game):
+    """
+    Parameters
+    ----------
+    actions : list
+        A list of tuples of the form:
+
+        [(C, C), (C, C)], [(C, D), (C, D)]
+
+    game : axelrod.Game
+        The game object to score the actions.
+
+    Returns
+    -------
+    tuple
+        A pair of payoffs for each of the two players in the interaction.
+    """
+    player1_payoff, player2_payoff = 0, 0
+    for turn in actions:
+        score = game.score(turn)
+        player1_payoff += score[0]
+        player2_payoff += score[1]
+    return (player1_payoff, player2_payoff)
+
+
 def scores(payoff, nplayers, repetitions):
     """
     Parameters

--- a/axelrod/payoff.py
+++ b/axelrod/payoff.py
@@ -53,6 +53,7 @@ def payoff_matrix(interactions, game, nplayers, turns):
                 payoff[p2][p1] += score[1]
     return payoff
 
+
 def scores(payoff, nplayers, repetitions):
     """
     Parameters
@@ -102,6 +103,7 @@ def scores(payoff, nplayers, repetitions):
                     scores[-1][-1] += res[ip][irep]
     return scores
 
+
 def normalised_scores(scores, nplayers, turns):
     """
     Parameters
@@ -127,6 +129,7 @@ def normalised_scores(scores, nplayers, turns):
     return [
         [1.0 * s / normalisation for s in r] for r in scores]
 
+
 def ranking(scores, nplayers):
     """
     Parameters
@@ -147,6 +150,7 @@ def ranking(scores, nplayers):
         key=lambda i: -median(scores[i]))
     return ranking
 
+
 def ranked_names(players, ranking):
     """
     Parameters
@@ -163,6 +167,7 @@ def ranked_names(players, ranking):
     """
     ranked_names = [str(players[i]) for i in ranking]
     return ranked_names
+
 
 def normalised_payoff(payoff_matrix, turns, repetitions):
     """
@@ -204,6 +209,7 @@ def normalised_payoff(payoff_matrix, turns, repetitions):
             stddevs[-1].append(dev)
     return averages, stddevs
 
+
 def winning_player(players, payoffs):
     """
     Parameters
@@ -225,6 +231,7 @@ def winning_player(players, payoffs):
         winning_payoff_index = payoffs.index(winning_payoff)
         winner = players[winning_payoff_index]
         return winner
+
 
 def wins(payoff, nplayers, repetitions):
     """

--- a/axelrod/payoff.py
+++ b/axelrod/payoff.py
@@ -82,7 +82,7 @@ def interaction_payoff(actions, game):
     return (player1_payoff, player2_payoff)
 
 
-def scores(payoff, nplayers, repetitions):
+def scores(payoff):
     """
     Parameters
     ----------
@@ -121,6 +121,8 @@ def scores(payoff, nplayers, repetitions):
         (e.g. player 1 versus player 1) and so these are also excluded from the
         scores here by the condition on ip and ires.
     """
+    nplayers = len(payoff)
+    repetitions = len(payoff[0][0])
     scores = []
     for ires, res in enumerate(payoff):
         scores.append([])

--- a/axelrod/payoff.py
+++ b/axelrod/payoff.py
@@ -266,7 +266,7 @@ def winning_player(players, payoffs):
         return winner
 
 
-def wins(payoff, nplayers, repetitions):
+def wins(payoff):
     """
     Parameters
     ----------
@@ -301,6 +301,8 @@ def wins(payoff, nplayers, repetitions):
         i.e. one row per player which lists the total wins for that player
         in each repetition.
     """
+    nplayers = len(payoff)
+    repetitions = len(payoff[0][0])
     wins = [
         [0 for r in range(repetitions)] for p in range(nplayers)]
     for player in range(nplayers):

--- a/axelrod/payoff.py
+++ b/axelrod/payoff.py
@@ -47,14 +47,13 @@ def payoff_matrix(interactions, game, nplayers, turns):
         and column (j) represents an individual player and the the value Pij
         is the payoff value for player (i) versus player (j).
     """
-    payoff = [[0 for i in range(nplayers)] for j in range(nplayers)]
+    payoffs = [[0 for i in range(nplayers)] for j in range(nplayers)]
     for p1 in range(nplayers):
         for p2 in range(nplayers):
-            for turn in range(turns):
-                score = game.score(interactions[p1][p2][turn])
-                payoff[p1][p2] += score[0]
-                payoff[p2][p1] += score[1]
-    return payoff
+            payoff = interaction_payoff(interactions[p1][p2], game)
+            payoffs[p1][p2] += payoff[0]
+            payoffs[p2][p1] += payoff[1]
+    return payoffs
 
 
 def interaction_payoff(actions, game):

--- a/axelrod/payoff.py
+++ b/axelrod/payoff.py
@@ -1,5 +1,8 @@
 import math
 from numpy import median, mean
+from axelrod import Actions
+
+C, D = Actions.C, Actions.D
 
 
 def payoff_matrix(interactions, game, nplayers, turns):
@@ -14,8 +17,8 @@ def payoff_matrix(interactions, game, nplayers, turns):
         e.g. for a tournament between Cooperator and Defector with 2 turns per
         round:
         [
-            [('C', 'C'), ('C', 'C')], [('C', 'D'), ('C', 'D')],
-            [('D', 'C'), ('D', 'C')], [('D', 'D'), ('D', 'D')]
+            [(C, C), (C, C)], [(C, D), (C, D)],
+            [(D, C), (D, C)], [(D, D), (D, D)]
         ]
 
         i.e. one list per player, containing one list per opponent (in order of

--- a/axelrod/payoff.py
+++ b/axelrod/payoff.py
@@ -69,6 +69,10 @@ def interaction_payoff(actions, game):
     -------
     tuple
         A pair of payoffs for each of the two players in the interaction.
+
+        i.e. for the actions list quoted above, the resulting payoff returned
+        would be:
+            (6, 16)
     """
     player1_payoff, player2_payoff = 0, 0
     for turn in actions:

--- a/axelrod/payoff.py
+++ b/axelrod/payoff.py
@@ -346,7 +346,7 @@ def payoff_diffs_means(payoff, turns):
     return diffs_matrix
 
 
-def score_diffs(payoff, nplayers, repetitions, turns):
+def score_diffs(payoff, turns):
     """
     Parameters
     ----------
@@ -362,10 +362,6 @@ def score_diffs(payoff, nplayers, repetitions, turns):
         i.e. one row per player, containing one element per opponent (in
         order of player index) which lists payoffs for each repetition.
 
-    nplayers : integer
-        The number of players in the tournament.
-    repetitions : integer
-        The number of repetitions in the tournament.
     turns : integer
         The number of turns in each round robin.
 
@@ -377,6 +373,8 @@ def score_diffs(payoff, nplayers, repetitions, turns):
         where the payoffs have been normalized by the number of turns and summed
         over the repititions.
     """
+    nplayers = len(payoff)
+    repetitions = len(payoff[0][0])
     diffs = [
         [] for p in range(nplayers)]
     for player in range(nplayers):

--- a/axelrod/payoff.py
+++ b/axelrod/payoff.py
@@ -134,7 +134,7 @@ def scores(payoff):
     return scores
 
 
-def normalised_scores(scores, nplayers, turns):
+def normalised_scores(scores, turns):
     """
     Parameters
     ----------
@@ -155,6 +155,7 @@ def normalised_scores(scores, nplayers, turns):
         where t is the total number of turns played per repetition for a given
         player excluding self-interactions.
     """
+    nplayers = len(scores)
     normalisation = turns * (nplayers - 1)
     return [
         [1.0 * s / normalisation for s in r] for r in scores]

--- a/axelrod/payoff.py
+++ b/axelrod/payoff.py
@@ -5,7 +5,7 @@ from axelrod import Actions
 C, D = Actions.C, Actions.D
 
 
-def payoff_matrix(interactions, game, nplayers, turns):
+def payoff_matrix(interactions, game):
     """
     The payoff matrix from a single round robin.
 
@@ -27,10 +27,6 @@ def payoff_matrix(interactions, game, nplayers, turns):
 
     game : axelrod.Game
         The game object to score the tournament.
-    nplayers : integer
-        The number of players in the tournament.
-    turns : integer
-        The number of turns in each round robin.
 
     Returns
     -------
@@ -47,6 +43,7 @@ def payoff_matrix(interactions, game, nplayers, turns):
         and column (j) represents an individual player and the the value Pij
         is the payoff value for player (i) versus player (j).
     """
+    nplayers = len(interactions)
     payoffs = [[0 for i in range(nplayers)] for j in range(nplayers)]
     for p1 in range(nplayers):
         for p2 in range(nplayers):

--- a/axelrod/payoff.py
+++ b/axelrod/payoff.py
@@ -98,11 +98,6 @@ def scores(payoff):
         i.e. one row per player, containing one element per opponent (in
         order of player index) which lists payoffs for each repetition.
 
-    nplayers : integer
-        The number of players in the tournament.
-    repetitions : integer
-        The number of repetitions in the tournament.
-
     Returns
     -------
     list
@@ -140,8 +135,6 @@ def normalised_scores(scores, turns):
     ----------
     scores : list
         A scores matrix (S) of the form returned by the scores function.
-    nplayers : integer
-        The number of players in the tournament.
     turns : integer
         The number of turns in each round robin.
 
@@ -167,8 +160,6 @@ def ranking(scores):
     ----------
     scores : list
         A scores matrix (S) of the form returned by the scores function.
-    nplayers : integer
-        The number of players in the tournament.
 
     Returns
     -------
@@ -219,8 +210,6 @@ def normalised_payoff(payoff_matrix, turns):
 
     turns : integer
         The number of turns in each round robin.
-    repetitions : integer
-        The number of repetitions in the tournament.
 
     Returns
     -------
@@ -282,11 +271,6 @@ def wins(payoff):
         i.e. one row per player, containing one element per opponent (in
         order of player index) which lists payoffs for each repetition.
 
-    nplayers : integer
-        The number of players in the tournament.
-    repetitions : integer
-        The number of repetitions in the tournament.
-
     Returns
     -------
     list
@@ -334,10 +318,6 @@ def payoff_diffs_means(payoff, turns):
         i.e. one row per player, containing one element per opponent (in
         order of player index) which lists payoffs for each repetition.
 
-    nplayers : integer
-        The number of players in the tournament.
-    repetitions : integer
-        The number of repetitions in the tournament.
     turns : integer
         The number of turns in each round robin.
 

--- a/axelrod/result_set.py
+++ b/axelrod/result_set.py
@@ -52,7 +52,7 @@ class ResultSet(object):
             payoff = self.results['payoff']
             self.scores = ap.scores(payoff)
             self.normalised_scores = ap.normalised_scores(self.scores, turns)
-            self.ranking = ap.ranking(self.scores, len(players))
+            self.ranking = ap.ranking(self.scores)
             self.ranked_names = ap.ranked_names(players, self.ranking)
             self.payoff_matrix, self.payoff_stddevs = (ap.normalised_payoff(
                 payoff, turns, repetitions))

--- a/axelrod/result_set.py
+++ b/axelrod/result_set.py
@@ -57,8 +57,7 @@ class ResultSet(object):
             self.payoff_matrix, self.payoff_stddevs = (ap.normalised_payoff(
                 payoff, turns))
             self.wins = ap.wins(payoff)
-            self.payoff_diffs_means = ap.payoff_diffs_means(payoff, len(players),
-                                                            repetitions, turns)
+            self.payoff_diffs_means = ap.payoff_diffs_means(payoff, turns)
             self.score_diffs = ap.score_diffs(payoff, len(players), repetitions,
                                               turns)
 

--- a/axelrod/result_set.py
+++ b/axelrod/result_set.py
@@ -55,7 +55,7 @@ class ResultSet(object):
             self.ranking = ap.ranking(self.scores)
             self.ranked_names = ap.ranked_names(players, self.ranking)
             self.payoff_matrix, self.payoff_stddevs = (ap.normalised_payoff(
-                payoff, turns, repetitions))
+                payoff, turns))
             self.wins = ap.wins(payoff, len(players), repetitions)
             self.payoff_diffs_means = ap.payoff_diffs_means(payoff, len(players),
                                                             repetitions, turns)

--- a/axelrod/result_set.py
+++ b/axelrod/result_set.py
@@ -51,8 +51,7 @@ class ResultSet(object):
         if 'payoff' in self.results:
             payoff = self.results['payoff']
             self.scores = ap.scores(payoff)
-            self.normalised_scores = ap.normalised_scores(
-                self.scores, len(players), turns)
+            self.normalised_scores = ap.normalised_scores(self.scores, turns)
             self.ranking = ap.ranking(self.scores, len(players))
             self.ranked_names = ap.ranked_names(players, self.ranking)
             self.payoff_matrix, self.payoff_stddevs = (ap.normalised_payoff(

--- a/axelrod/result_set.py
+++ b/axelrod/result_set.py
@@ -56,7 +56,7 @@ class ResultSet(object):
             self.ranked_names = ap.ranked_names(players, self.ranking)
             self.payoff_matrix, self.payoff_stddevs = (ap.normalised_payoff(
                 payoff, turns))
-            self.wins = ap.wins(payoff, len(players), repetitions)
+            self.wins = ap.wins(payoff)
             self.payoff_diffs_means = ap.payoff_diffs_means(payoff, len(players),
                                                             repetitions, turns)
             self.score_diffs = ap.score_diffs(payoff, len(players), repetitions,

--- a/axelrod/result_set.py
+++ b/axelrod/result_set.py
@@ -50,7 +50,7 @@ class ResultSet(object):
 
         if 'payoff' in self.results:
             payoff = self.results['payoff']
-            self.scores = ap.scores(payoff, len(players), repetitions)
+            self.scores = ap.scores(payoff)
             self.normalised_scores = ap.normalised_scores(
                 self.scores, len(players), turns)
             self.ranking = ap.ranking(self.scores, len(players))

--- a/axelrod/result_set.py
+++ b/axelrod/result_set.py
@@ -58,8 +58,6 @@ class ResultSet(object):
                 payoff, turns))
             self.wins = ap.wins(payoff)
             self.payoff_diffs_means = ap.payoff_diffs_means(payoff, turns)
-            self.score_diffs = ap.score_diffs(payoff, len(players), repetitions,
-                                              turns)
 
         if 'cooperation' in self.results and with_morality:
             self.cooperation = ac.cooperation_matrix(

--- a/axelrod/result_set.py
+++ b/axelrod/result_set.py
@@ -58,6 +58,7 @@ class ResultSet(object):
                 payoff, turns))
             self.wins = ap.wins(payoff)
             self.payoff_diffs_means = ap.payoff_diffs_means(payoff, turns)
+            self.score_diffs = ap.score_diffs(payoff, turns)
 
         if 'cooperation' in self.results and with_morality:
             self.cooperation = ac.cooperation_matrix(

--- a/axelrod/tests/unit/test_payoff.py
+++ b/axelrod/tests/unit/test_payoff.py
@@ -109,7 +109,7 @@ class TestPayoff(unittest.TestCase):
 
     def test_payoff_diffs_means(self):
         #payoff_matrix = ap.payoff_matrix(self.interactions, Game(), 3, 5)
-        diff_means = ap.payoff_diffs_means(self.expected_payoff, 3, 2, 5)
+        diff_means = ap.payoff_diffs_means(self.expected_payoff, 5)
         self.assertEqual(diff_means, self.diff_means)
 
     def test_score_diffs(self):

--- a/axelrod/tests/unit/test_payoff.py
+++ b/axelrod/tests/unit/test_payoff.py
@@ -24,16 +24,16 @@ class TestPayoff(unittest.TestCase):
                 [(C, D), (D, D), (D, C), (C, D), (D, C)]
             ],
             [
-                [(D, C), (C, D), (C, C), (C, D), (D, C)],
-                [(D, C), (D, D), (D, D), (C, D), (D, C)],
+                [(C, C), (C, D), (D, C), (C, D), (D, C)],
+                [(D, C), (D, D), (C, D), (D, C), (C, D)],
                 [(D, C), (D, D), (D, C), (D, D), (D, D)]
             ]
         ]
 
         cls.expected_payoff_matrix = [
-            [22, 26, 26],
-            [26, 30, 18],
-            [26, 23, 16]
+            [11, 13, 13],
+            [13, 15, 11],
+            [13, 11, 13]
         ]
 
         cls.expected_payoff = [

--- a/axelrod/tests/unit/test_payoff.py
+++ b/axelrod/tests/unit/test_payoff.py
@@ -95,7 +95,7 @@ class TestPayoff(unittest.TestCase):
         self.assertEqual(scores, self.expected_scores)
 
     def test_normalised_scores(self):
-        scores = ap.normalised_scores(self.expected_scores, 3, 5)
+        scores = ap.normalised_scores(self.expected_scores, 5)
         self.assertEqual(scores, self.expected_normalised_scores)
 
     def test_ranking(self):

--- a/axelrod/tests/unit/test_payoff.py
+++ b/axelrod/tests/unit/test_payoff.py
@@ -114,7 +114,7 @@ class TestPayoff(unittest.TestCase):
 
     def test_score_diffs(self):
         #payoff_matrix = ap.payoff_matrix(self.interactions, Game(), 3, 5)
-        score_diffs = ap.score_diffs(self.expected_payoff, 3, 2, 5)
+        score_diffs = ap.score_diffs(self.expected_payoff, 5)
         self.assertEqual(score_diffs, self.expected_score_diffs)
 
     @staticmethod

--- a/axelrod/tests/unit/test_payoff.py
+++ b/axelrod/tests/unit/test_payoff.py
@@ -91,7 +91,7 @@ class TestPayoff(unittest.TestCase):
         self.assertEqual(payoff, (13, 3))
 
     def test_scores(self):
-        scores = ap.scores(self.expected_payoff, 3, 2)
+        scores = ap.scores(self.expected_payoff)
         self.assertEqual(scores, self.expected_scores)
 
     def test_normalised_scores(self):

--- a/axelrod/tests/unit/test_payoff.py
+++ b/axelrod/tests/unit/test_payoff.py
@@ -141,5 +141,5 @@ class TestPayoff(unittest.TestCase):
         self.assertEqual(winner, None)
 
     def test_wins(self):
-        wins = ap.wins(self.expected_payoff, 3, 2)
+        wins = ap.wins(self.expected_payoff)
         self.assertEqual(wins, self.expected_wins)

--- a/axelrod/tests/unit/test_payoff.py
+++ b/axelrod/tests/unit/test_payoff.py
@@ -83,7 +83,7 @@ class TestPayoff(unittest.TestCase):
         ]
 
     def test_payoff_matrix(self):
-        payoff_matrix = ap.payoff_matrix(self.interactions, Game(), 3, 5)
+        payoff_matrix = ap.payoff_matrix(self.interactions, Game())
         self.assertEqual(payoff_matrix, self.expected_payoff_matrix)
 
     def test_interaction_payoff(self):

--- a/axelrod/tests/unit/test_payoff.py
+++ b/axelrod/tests/unit/test_payoff.py
@@ -86,6 +86,10 @@ class TestPayoff(unittest.TestCase):
         payoff_matrix = ap.payoff_matrix(self.interactions, Game(), 3, 5)
         self.assertEqual(payoff_matrix, self.expected_payoff_matrix)
 
+    def test_interaction_payoff(self):
+        payoff = ap.interaction_payoff(self.interactions[2][2], Game())
+        self.assertEqual(payoff, (13, 3))
+
     def test_scores(self):
         scores = ap.scores(self.expected_payoff, 3, 2)
         self.assertEqual(scores, self.expected_scores)
@@ -103,8 +107,6 @@ class TestPayoff(unittest.TestCase):
             self.players, self.expected_ranking,)
         self.assertEqual(ranked_names, self.expected_ranked_names)
 
-
-
     def test_payoff_diffs_means(self):
         #payoff_matrix = ap.payoff_matrix(self.interactions, Game(), 3, 5)
         diff_means = ap.payoff_diffs_means(self.expected_payoff, 3, 2, 5)
@@ -114,7 +116,6 @@ class TestPayoff(unittest.TestCase):
         #payoff_matrix = ap.payoff_matrix(self.interactions, Game(), 3, 5)
         score_diffs = ap.score_diffs(self.expected_payoff, 3, 2, 5)
         self.assertEqual(score_diffs, self.expected_score_diffs)
-
 
     @staticmethod
     def round_matrix(matrix, precision):

--- a/axelrod/tests/unit/test_payoff.py
+++ b/axelrod/tests/unit/test_payoff.py
@@ -122,7 +122,7 @@ class TestPayoff(unittest.TestCase):
         return [[round(x, precision) for x in row] for row in matrix]
 
     def test_normalised_payoff(self):
-        averages, stddevs = ap.normalised_payoff(self.expected_payoff, 5, 2)
+        averages, stddevs = ap.normalised_payoff(self.expected_payoff, 5)
         self.assertEqual(
             self.round_matrix(averages, 2), self.expected_normalised_payoff)
         self.assertEqual(

--- a/axelrod/tests/unit/test_payoff.py
+++ b/axelrod/tests/unit/test_payoff.py
@@ -99,7 +99,7 @@ class TestPayoff(unittest.TestCase):
         self.assertEqual(scores, self.expected_normalised_scores)
 
     def test_ranking(self):
-        ranking = ap.ranking(self.expected_scores, 3)
+        ranking = ap.ranking(self.expected_scores)
         self.assertEqual(ranking, self.expected_ranking)
 
     def test_ranked_names(self):


### PR DESCRIPTION
1) Splits the payoff_matrix function into two, creating a new function: interaction_payoff which it then calls.
This gives us a function which can be used to obtain the scores for a single interaction of n turns between two players

2) Removes redundant parameters from various payoff functions where they can be derived from the payoff matrix.