### PR TITLE
Metafix

### DIFF
--- a/axelrod/strategies/meta.py
+++ b/axelrod/strategies/meta.py
@@ -143,7 +143,7 @@ class MetaWinner(MetaPlayer):
         bestscore = max(scores)
         beststrategies = [i for i, pl in enumerate(self.team) if pl.score == bestscore]
         bestproposals = [results[i] for i in beststrategies]
-        bestresult = "C" if "C" in bestproposals else "D"
+        bestresult = C if C in bestproposals else D
 
         # Update each player's proposed history with his proposed result, but always after
         # the new result has been settled based on scores accumulated until now.

--- a/axelrod/strategies/meta.py
+++ b/axelrod/strategies/meta.py
@@ -36,8 +36,6 @@ class MetaPlayer(Player):
         for key in ['stochastic', 'inspects_source', 'manipulates_source',
                     'manipulates_state']:
             self.classifier[key] = (any([t.classifier[key] for t in self.team]))
-        self.classifier['memory_depth'] = max([t.classifier['memory_depth'] for
-                                               t in self.team])
 
     def strategy(self, opponent):
 
@@ -75,6 +73,7 @@ class MetaMajority(MetaPlayer):
             self.team = ordinary_strategies
         super(MetaMajority, self).__init__()
         self.init_args = (team,)
+        self.classifier['memory_depth'] = float('inf')
 
     def meta_strategy(self, results, opponent):
         if results.count(D) > results.count(C):
@@ -95,6 +94,7 @@ class MetaMinority(MetaPlayer):
             self.team = ordinary_strategies
         super(MetaMinority, self).__init__()
         self.init_args = (team,)
+        self.classifier['memory_depth'] = float('inf')
 
     def meta_strategy(self, results, opponent):
         if results.count(D) < results.count(C):
@@ -132,7 +132,8 @@ class MetaWinner(MetaPlayer):
         if len(self.history):
             for player in self.team:
                 game = self.tournament_attributes["game"]
-                s = game.scores[(player.proposed_history[-1], opponent.history[-1])][0]
+                last_round = (player.proposed_history[-1], opponent.history[-1])
+                s = game.scores[last_round][0]
                 player.score += s
         return super(MetaWinner, self).strategy(opponent)
 

--- a/axelrod/strategies/meta.py
+++ b/axelrod/strategies/meta.py
@@ -140,7 +140,7 @@ class MetaWinner(MetaPlayer):
     def meta_strategy(self, results, opponent):
 
         scores = [pl.score for pl in self.team]
-        bestscore = min(scores)
+        bestscore = max(scores)
         beststrategies = [i for i, pl in enumerate(self.team) if pl.score == bestscore]
         bestproposals = [results[i] for i in beststrategies]
         bestresult = "C" if "C" in bestproposals else "D"

--- a/axelrod/tests/unit/test_meta.py
+++ b/axelrod/tests/unit/test_meta.py
@@ -18,7 +18,7 @@ class TestMetaPlayer(TestPlayer):
     name = "Meta Player"
     player = axelrod.MetaPlayer
     expected_classifier = {
-        'memory_depth': 0,
+        'memory_depth': float('inf'),
         'stochastic': False,
         'manipulates_source': False,
         'inspects_source': False,
@@ -31,8 +31,8 @@ class TestMetaPlayer(TestPlayer):
         for key in ['stochastic', 'inspects_source', 'manipulates_source',
                     'manipulates_state']:
             classifier[key] = (any([t.classifier[key] for t in player.team]))
-        classifier['memory_depth'] = max([t.classifier['memory_depth']
-                                          for t in player.team])
+        classifier['memory_depth'] = float('inf')
+
         for key in classifier:
             self.assertEqual(player.classifier[key],
                              classifier[key],
@@ -174,7 +174,7 @@ class TestMetaMajorityMemoryOne(TestMetaPlayer):
     name = "Meta Majority Memory One"
     player = axelrod.MetaMajorityMemoryOne
     expected_classifier = {
-        'memory_depth': 1,  # Long memory
+        'memory_depth': float('inf'),  # Long memory
         'stochastic' : True,
         'inspects_source': False,
         'manipulates_source': False,
@@ -189,7 +189,7 @@ class TestMetaWinnerMemoryOne(TestMetaPlayer):
     name = "Meta Winner Memory One"
     player = axelrod.MetaWinnerMemoryOne
     expected_classifier = {
-        'memory_depth': 1,  # Long memory
+        'memory_depth': float('inf'),  # Long memory
         'stochastic' : True,
         'inspects_source': False,
         'manipulates_source': False,
@@ -204,7 +204,7 @@ class TestMetaMajorityFiniteMemory(TestMetaPlayer):
     name = "Meta Majority Finite Memory"
     player = axelrod.MetaMajorityFiniteMemory
     expected_classifier = {
-        'memory_depth': 200,  # Long memory
+        'memory_depth': float('inf'),  # Long memory
         'stochastic' : True,
         'inspects_source': False,
         'manipulates_source': False,
@@ -219,7 +219,7 @@ class TestMetaWinnerFiniteMemory(TestMetaPlayer):
     name = "Meta Winner Finite Memory"
     player = axelrod.MetaWinnerFiniteMemory
     expected_classifier = {
-        'memory_depth': 200,  # Long memory
+        'memory_depth': float('inf'),  # Long memory
         'stochastic' : True,
         'inspects_source': False,
         'manipulates_source': False,

--- a/axelrod/tests/unit/test_meta.py
+++ b/axelrod/tests/unit/test_meta.py
@@ -137,6 +137,23 @@ class TestMetaWinner(TestMetaPlayer):
         P1.team[1].score = 1
         self.assertEqual(P1.strategy(P2), C)
 
+        opponent = axelrod.Cooperator()
+        player = axelrod.MetaWinner(team = [axelrod.Cooperator, axelrod.Defector])
+        for _ in range(5):
+            player.play(opponent)
+        self.assertEqual(player.history[-1], C)
+
+        opponent = axelrod.Defector()
+        player = axelrod.MetaWinner(team = [axelrod.Defector])
+        for _ in range(20):
+            player.play(opponent)
+        self.assertEqual(player.history[-1], D)
+
+        opponent = axelrod.Defector()
+        player = axelrod.MetaWinner(team = [axelrod.Cooperator, axelrod.Defector])
+        for _ in range(20):
+            player.play(opponent)
+        self.assertEqual(player.history[-1], D)
 
 class TestMetaHunter(TestMetaPlayer):
 


### PR DESCRIPTION
There is a bug in MetaWinner, a hold-over from before we switched the game matrix (!). (It was actually MetaLoser!)

Also the `memory_depth` calculation for the meta strategies was not correct. They are typically of depth `float('inf')`.