### PR TITLE
313 - Address terms that are interchangeably used in documentation

### DIFF
--- a/docs/reference/glossary.rst
+++ b/docs/reference/glossary.rst
@@ -56,6 +56,31 @@ A win
 A **win** is attributed to the player who has the higher total score at the end
 of a match. For the example above, :code:`Defector` would win that match.
 
+A strategy
+----------
+
+A **strategy** is a set of instructions that dictate how to play given one's own
+strategy and the strategy of an opponent. In the library these correspond to the
+strategy classes: `TitForTat`, `Grudger`, `Cooperator` etc...
+
+When appropriate to do so this will be used interchangeable with `A player`_.
+
+A player
+--------
+
+A **player** is a single agent using a given strategy. Players are the
+participants of tournament, usually they each represent one strategy but of
+course you can have multiple players choosing the same strategy. In the library
+these correspond to __instances__ of classes::
+
+    >>> p1, p2 = axl.Cooperator(), axl.Defector()
+    >>> p1
+    Cooperator
+    >>> p2
+    Defector
+
+When appropriate to do so this will be used interchangeable with `A strategy`_.
+
 A round robin
 -------------
 

--- a/docs/tutorials/contributing/index.rst
+++ b/docs/tutorials/contributing/index.rst
@@ -1,8 +1,3 @@
-.. Axelrod documentation master file, created by
-   sphinx-quickstart on Sat Mar  7 07:05:57 2015.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 Contributing
 ============
 

--- a/docs/tutorials/contributing/strategy/writing_the_new_strategy.rst
+++ b/docs/tutorials/contributing/strategy/writing_the_new_strategy.rst
@@ -110,8 +110,8 @@ sure that there is a :code:`reset` method that takes account of it.  An example
 of this is the :code:`ForgetfulGrudger` strategy.
 
 You can also modify the name of the strategy with the `__repr__` method, which
-is invoked when `str` is applied to a player instance. For example, the player
-`Random` takes a parameter `p` for how often it cooperates, and the `__repr__`
+is invoked when `str` is applied to a player instance. For example, the `Random`
+strategy takes a parameter `p` for how often it cooperates, and the `__repr__`
 method adds the value of this parameter to the name::
 
     def __repr__(self):

--- a/docs/tutorials/getting_started/getting_started.rst
+++ b/docs/tutorials/getting_started/getting_started.rst
@@ -1,3 +1,5 @@
+.. _getting-started:
+
 Getting started
 ===============
 

--- a/docs/tutorials/getting_started/getting_started.rst
+++ b/docs/tutorials/getting_started/getting_started.rst
@@ -23,7 +23,8 @@ If you do this you will need to also install the dependencies::
 Creating and running a simple tournament
 ----------------------------------------
 
-The following lines of code create a simple list of strategies::
+The following lines of code creates a list players playing simple
+strategies::
 
     >>> import axelrod as axl
     >>> strategies = [axl.Cooperator(), axl.Defector(),

--- a/docs/tutorials/getting_started/noisy_tournaments.rst
+++ b/docs/tutorials/getting_started/noisy_tournaments.rst
@@ -2,7 +2,7 @@ Noisy tournaments
 =================
 
 A common variation on iterated prisoner’s dilemma tournaments is to add
-stochasticity in the choice of plays, simply called noise. This noise is
+stochasticity in the choice of actions, simply called noise. This noise is
 introduced by flipping plays between ‘C’ and ‘D’ with some probability that is
 applied to all plays after they are delivered by the player.
 

--- a/docs/tutorials/getting_started/payoff_matrix.rst
+++ b/docs/tutorials/getting_started/payoff_matrix.rst
@@ -4,7 +4,7 @@ Accessing the payoff matrix
 This tutorial will show you briefly how to access the payoff matrix
 corresponding to the tournament.
 
-As shown in `Getting_started`_ let us create a tournament::
+As shown in :ref:`getting-started` let us create a tournament::
 
     >>> import axelrod as axl
     >>> strategies = [axl.Cooperator(), axl.Defector(),

--- a/docs/tutorials/getting_started/payoff_matrix.rst
+++ b/docs/tutorials/getting_started/payoff_matrix.rst
@@ -1,8 +1,6 @@
 Accessing the payoff matrix
 ===========================
 
-lipsum
-
 This tutorial will show you briefly how to access the payoff matrix
 corresponding to the tournament.
 

--- a/docs/tutorials/getting_started/visualising_results.rst
+++ b/docs/tutorials/getting_started/visualising_results.rst
@@ -8,7 +8,7 @@ This tutorial will show you briefly how to visualise some basic results
 Visualising the results of the tournament
 -----------------------------------------
 
-As shown in `Getting_started`_ let us create a tournament, but this time we will
+As shown in :ref:`getting-started` let us create a tournament, but this time we will
 include a strategy that acts randomly::
 
     >>> import axelrod as axl
@@ -31,7 +31,7 @@ We can view these results (which helps visualise the stochastic effects)::
 Visualising the distributions of wins
 -------------------------------------
 
-We can view the distributions of wins for each player::
+We can view the distributions of wins for each strategy::
 
     >>> p = plot.winplot()
     >>> p.show()


### PR DESCRIPTION
This fixes some bugs in docs but also (mainly) aims to try and address #313:

- Have added player/strategy to glossary
- Have gone through and tried to tweak as necessary