### PR TITLE
Adaptive Pavlov, two versions

### DIFF
--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from .alternator import Alternator
+from .apavlov import APavlov2006, APavlov2011
 from .appeaser import Appeaser
 from .averagecopier import AverageCopier, NiceAverageCopier
 from .axelrod_first import (Davis, RevisedDowning, Feld, Grofman, Nydegger,
@@ -50,6 +51,8 @@ strategies = [
     AlternatorHunter,
     AntiCycler,
     AntiTitForTat,
+    APavlov2006,
+    APavlov2011,
     Appeaser,
     ArrogantQLearner,
     AverageCopier,

--- a/axelrod/strategies/apavlov.py
+++ b/axelrod/strategies/apavlov.py
@@ -1,0 +1,108 @@
+from axelrod import Player, Actions, flip_action
+
+C, D = Actions.C, Actions.D
+
+
+class APavlov2006(Player):
+    """
+    APavlov as defined in http://www.cs.nott.ac.uk/~pszjl/index_files/chapter4.pdf (pages 10-11).
+    """
+
+    name = "Adapative Pavlov 2006"
+    classifier = {
+        'memory_depth': float('inf'),
+        'stochastic': False,
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+
+    def __init__(self):
+        Player.__init__(self)
+        self.opponent_class = None
+
+    def strategy(self, opponent):
+        # TFT for six rounds
+        if len(self.history) < 6:
+            return D if opponent.history[-1:] == [D] else C
+        # Classify opponent
+        if len(self.history) % 6 == 0:
+            if opponent.history[-6:] == [C] * 6:
+                self.opponent_class = "Cooperative"
+            if opponent.history[-6:] == [D] * 6:
+                self.opponent_class = "ALLD"
+            if opponent.history[-6:] == [D, C, D, C, D, C]:
+                self.opponent_class = "STFT"
+            if opponent.history[-6:] == [D, D, C, D, D, C]:
+                self.opponent_class = "PavlovD"
+            if not self.opponent_class:
+                self.opponent_class = "Random"
+
+        # Play according to classification
+        if self.opponent_class in ["Random", "ALLD"]:
+            return D
+        if self.opponent_class == "STFT":
+            if len(self.history) % 6 in [0, 1]:
+                return C
+            #TFT
+            return D if opponent.history[-1:] == [D] else C
+        if self.opponent_class == "PavlovD":
+            # Return D then C for the period
+            if len(self.history) % 6 == 0:
+                return D
+            return C
+        if self.opponent_class == "Cooperative":
+            #TFT
+            return D if opponent.history[-1:] == [D] else C
+
+    def reset(self):
+        Player.reset(self)
+        self.opponent_class = None
+
+
+class APavlov2011(Player):
+    """
+    APavlov as defined in http://www.graham-kendall.com/papers/lhk2011.pdf, as
+    closely as can be determined.
+    """
+
+    name = "Adapative Pavlov 2011"
+    classifier = {
+        'memory_depth': float('inf'),
+        'stochastic': False,
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+
+    def __init__(self):
+        Player.__init__(self)
+        self.opponent_class = None
+
+    def strategy(self, opponent):
+        # TFT for six rounds
+        if len(self.history) < 6:
+            return D if opponent.history[-1:] == [D] else C
+        if len(self.history) % 6 == 0:
+            # Classify opponent
+            if opponent.history[-6:] == [C] * 6:
+                self.opponent_class = "Cooperative"
+            if opponent.history[-6:].count(D) >= 4:
+                self.opponent_class = "ALLD"
+            if opponent.history[-6:].count(D) == 3:
+                self.opponent_class = "STFT"
+            if not self.opponent_class:
+                self.opponent_class = "Random"
+        # Play according to classification
+        if self.opponent_class in ["Random", "ALLD"]:
+            return D
+        if self.opponent_class == "STFT":
+            #TFTT
+            return D if opponent.history[-2:] == [D, D] else C
+        if self.opponent_class == "Cooperative":
+            #TFT
+            return D if opponent.history[-1:] == [D] else C
+
+    def reset(self):
+        Player.reset(self)
+        self.opponent_class = None

--- a/axelrod/strategies/apavlov.py
+++ b/axelrod/strategies/apavlov.py
@@ -5,7 +5,13 @@ C, D = Actions.C, Actions.D
 
 class APavlov2006(Player):
     """
-    APavlov as defined in http://www.cs.nott.ac.uk/~pszjl/index_files/chapter4.pdf (pages 10-11).
+    APavlov as defined in http://www.cs.nott.ac.uk/~pszjl/index_files/chapter4.pdf
+    (pages 10-11).
+
+    APavlov attempts to classify its opponent as one of five strategies:
+    Cooperative, ALLD, STFT, PavlovD, or Random. APavlov then responds in a
+    manner intended to achieve mutual cooperation or to defect against
+    uncooperative opponents.
     """
 
     name = "Adapative Pavlov 2006"
@@ -64,6 +70,11 @@ class APavlov2011(Player):
     """
     APavlov as defined in http://www.graham-kendall.com/papers/lhk2011.pdf, as
     closely as can be determined.
+
+    APavlov attempts to classify its opponent as one of four strategies:
+    Cooperative, ALLD, STFT, or Random. APavlov then responds in a manner
+    intended to achieve mutual cooperation or to defect against
+    uncooperative opponents.
     """
 
     name = "Adapative Pavlov 2011"

--- a/axelrod/tests/unit/test_apavlov.py
+++ b/axelrod/tests/unit/test_apavlov.py
@@ -1,0 +1,87 @@
+"""Test APavlov."""
+
+import axelrod
+from .test_player import TestPlayer
+
+C, D = axelrod.Actions.C, axelrod.Actions.D
+
+
+class TestAPavlov2006(TestPlayer):
+    name = "Adapative Pavlov 2006"
+    player = axelrod.APavlov2006
+
+    expected_classifier = {
+        'memory_depth': float('inf'),
+        'stochastic': False,
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+
+    def test_strategy(self):
+        self.first_play_test(C)
+        self.responses_test([C] * 6, [C] * 6, [C],
+                            attrs={"opponent_class": "cooperative"})
+        self.responses_test([C, D, D, D, D, D], [D] * 6, [D],
+                            attrs={"opponent_class": "ALLD"})
+        self.responses_test([C, D, C, D, C, D], [D, C, D, C, D, C], [C, C],
+                            attrs={"opponent_class": "STFT"})
+        self.responses_test([C, D, D, C, D, D], [D, D, C, D, D, C], [D],
+                            attrs={"opponent_class": "PavlovD"})
+        self.responses_test([C, D, D, C, D, D, C], [D, D, C, D, D, C, D], [C],
+                            attrs={"opponent_class": "PavlovD"})
+        self.responses_test([C, D, D, C, D, D], [C, C, C, D, D, D], [D],
+                            attrs={"opponent_class": "Random"})
+        self.responses_test([C, D, D, D, C, C], [D, D, D, C, C, C], [D],
+                            attrs={"opponent_class": "Random"})
+
+    def test_reset(self):
+        player = self.player()
+        opponent = axelrod.Cooperator()
+        [player.play(opponent) for _ in range(10)]
+        player.reset()
+        self.assertEqual(player.opponent_class, None)
+
+class TestAPavlov2011(TestPlayer):
+    name = "Adapative Pavlov 2011"
+    player = axelrod.APavlov2011
+
+    expected_classifier = {
+        'memory_depth': float('inf'),
+        'stochastic': False,
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+
+    def test_strategy(self):
+        self.first_play_test(C)
+        self.responses_test([C] * 6, [C] * 6, [C],
+                            attrs={"opponent_class": "Cooperative"})
+        self.responses_test([C, D, D, D, D, D], [D] * 6, [D],
+                            attrs={"opponent_class": "ALLD"})
+        self.responses_test([C, C, D, D, D, D], [C] + [D] * 5, [D],
+                            attrs={"opponent_class": "ALLD"})
+        self.responses_test([C, C, C, D, D, D], [C, C] + [D] * 4, [D],
+                            attrs={"opponent_class": "ALLD"})
+        self.responses_test([C, C, D, D, C, D], [C, D, D, C, D, D], [D],
+                            attrs={"opponent_class": "ALLD"})
+
+        self.responses_test([C, C, D, D, D, C], [C, D, D, C, C, D], [C],
+                            attrs={"opponent_class": "STFT"})
+        self.responses_test([C, C, D, C, D, C], [C, D, C, D, C, D], [C],
+                            attrs={"opponent_class": "STFT"})
+        self.responses_test([C, D, D, D, C, C], [D, D, D, C, C, C], [C],
+                            attrs={"opponent_class": "STFT"})
+
+        self.responses_test([C, C, C, C, C, D], [C, C, C, C, D, D], [D],
+                            attrs={"opponent_class": "Random"})
+        self.responses_test([C, D, D, C, C, C], [D, D, C, C, C, C], [D],
+                            attrs={"opponent_class": "Random"})
+
+    def test_reset(self):
+        player = self.player()
+        opponent = axelrod.Cooperator()
+        [player.play(opponent) for _ in range(10)]
+        player.reset()
+        self.assertEqual(player.opponent_class, None)

--- a/axelrod/tests/unit/test_player.py
+++ b/axelrod/tests/unit/test_player.py
@@ -70,7 +70,7 @@ class TestPlayerClass(unittest.TestCase):
 
 
 def test_responses(test_class, P1, P2, history_1, history_2,
-                   responses, random_seed=None):
+                   responses, random_seed=None, attrs=None):
     """
     Test responses to arbitrary histories. Used for the following tests
     in TestPlayer: first_play_test, markov_test, and responses_test.
@@ -91,6 +91,9 @@ def test_responses(test_class, P1, P2, history_1, history_2,
     for response in responses:
         s1, s2 = simulate_play(P1, P2)
         test_class.assertEqual(s1, response)
+    if attrs:
+        for attr, value in attrs.items():
+            test_class.assertTrue(getattr(P1, attr), value)
 
 
 class TestOpponent(Player):
@@ -181,7 +184,8 @@ class TestPlayer(unittest.TestCase):
                            random_seed=random_seed)
 
     def responses_test(self, history_1, history_2, responses,
-                       random_seed=None, tournament_length=200):
+                       random_seed=None, tournament_length=200,
+                       attrs=None):
         """Test responses to arbitrary histories. Input response_list is a
         list of lists, each of which consists of a list for the history of
         player 1, a list for the history of player 2, and a list for the
@@ -193,7 +197,7 @@ class TestPlayer(unittest.TestCase):
         P2.tournament_attributes['length'] = tournament_length
         test_responses(
             self, P1, P2, history_1, history_2, responses,
-            random_seed=random_seed)
+            random_seed=random_seed, attrs=attrs)
 
     def classifier_test(self):
         """Test that the keys in the expected_classifier dictionary give the

--- a/docs/reference/overview_of_strategies.rst
+++ b/docs/reference/overview_of_strategies.rst
@@ -690,7 +690,7 @@ Random is a strategy that was defined in `Axelrod's first tournament`_, note tha
 *RANDOM came 8th in average score and 8th in wins in S&P's tournament.*
 
 ZDGTFT-2
-^^^^^^^
+^^^^^^^^
 
 This memory-one strategy is defined by the following four conditional
 probabilities based on the last round of play:
@@ -1066,3 +1066,18 @@ Anti-Cycler
 AntiCycler plays a sequence that contains no cycles::
 
     C CD CCD CCCD CCCCD CCCCCD ...
+
+APavlov2006
+^^^^^^^^^^^
+
+Also called [Adaptive Pavlov](http://www.cs.nott.ac.uk/~pszjl/index_files/chapter4.pdf),
+this strategy that attempts to classify opponents and respond in a manner that
+encourages cooperation. Winner of a 2005 tournament.
+
+
+APavlov2011
+^^^^^^^^^^^
+
+A [variant of APavlov](http://www.graham-kendall.com/papers/lhk2011.pdf)
+that attempts to classify opponents and respond in a manner that encourages
+cooperation.

--- a/docs/tutorials/contributing/strategy/writing_the_new_strategy.rst
+++ b/docs/tutorials/contributing/strategy/writing_the_new_strategy.rst
@@ -4,12 +4,6 @@ Writing the new strategy
 Identify a new strategy
 -----------------------
 
-The library has a large number of strategies::
-
-    >>> import axelrod as axl
-    >>> len(axl.strategies) # doctest: +SKIP
-    103
-
 If you're not sure if you have a strategy that has already been implemented
 please get in touch: `via the gitter room
 <https://gitter.im/Axelrod-Python/Axelrod>`_ or `open an issue

--- a/docs/tutorials/contributing/strategy/writing_the_new_strategy.rst
+++ b/docs/tutorials/contributing/strategy/writing_the_new_strategy.rst
@@ -7,8 +7,8 @@ Identify a new strategy
 The library has a large number of strategies::
 
     >>> import axelrod as axl
-    >>> len(axl.strategies)
-    104
+    >>> len(axl.strategies) # doctest: +SKIP
+    103
 
 If you're not sure if you have a strategy that has already been implemented
 please get in touch: `via the gitter room


### PR DESCRIPTION
Two new strategies, both variants of APavlov that won a 2005 IPD tournament.

Also added a kwarg `attrs` to test_responses, which is a dictionary of attributes to check at the end of testing the sequence of plays. This simplifies the testing of internal variables of strategies in significant situations, and should useful in many other places in the library.