### PR TITLE
New transformers: Apologizing, Retaliating variant, Deadlock Breaking, Grudging

### DIFF
--- a/axelrod/strategy_transformers.py
+++ b/axelrod/strategy_transformers.py
@@ -265,18 +265,15 @@ class RetaliationUntilApologyWrapper(object):
 RetaliateUntilApologyTransformer = StrategyTransformerFactory(
     RetaliationUntilApologyWrapper(), name_prefix="RUA")()
 
-
-# Strategy wrapper as a class example
-class ApologyWrapper(object):
-    """Apologies with a single C after a round of (D, C)"""
-    def __call__(self, player, opponent, action):
-        if len(player.history) == 0:
-            return action
-        last_round = (player.history[-1], opponent.history[-1])
-        if last_round == (D, C):
-            return C
+def apology_wrapper(player, opponent, action, myseq, opseq):
+    length = len(myseq)
+    if len(player.history) < length:
         return action
+    if (myseq == player.history[-length:]) and \
+        (opseq == opponent.history[-length:]):
+        return C
+    return action
 
-ApologyTransformer = StrategyTransformerFactory(ApologyWrapper(),
-                                                name_prefix="Apologizing")()
+ApologyTransformer = StrategyTransformerFactory(apology_wrapper,
+                                                name_prefix="Apologizing")
 

--- a/axelrod/tests/unit/test_strategy_transformers.py
+++ b/axelrod/tests/unit/test_strategy_transformers.py
@@ -189,12 +189,18 @@ class TestTransformers(unittest.TestCase):
 
     def test_apology(self):
         """Tests the ApologyTransformer."""
-        ApologizingDefector = ApologyTransformer(axelrod.Defector)
+        ApologizingDefector = ApologyTransformer([D], [C])(axelrod.Defector)
         p1 = ApologizingDefector()
         p2 = axelrod.Cooperator()
         for _ in range(5):
             p1.play(p2)
         self.assertEqual(p1.history, [D, C, D, C, D])
+        ApologizingDefector = ApologyTransformer([D, D], [C, C])(axelrod.Defector)
+        p1 = ApologizingDefector()
+        p2 = axelrod.Cooperator()
+        for _ in range(6):
+            p1.play(p2)
+        self.assertEqual(p1.history, [D, D, C, D, D, C])
 
     def test_deadlock(self):
         """Test the DeadlockBreakingTransformer."""
@@ -238,7 +244,6 @@ class TestTransformers(unittest.TestCase):
                                 FinalTransformer([D]),
                                 FlipTransformer,
                                 RetaliateUntilApologyTransformer,
-                                ApologyTransformer,
                                 RetaliationTransformer(1),
                                 ]:
                 player = PlayerClass()

--- a/axelrod/tests/unit/test_strategy_transformers.py
+++ b/axelrod/tests/unit/test_strategy_transformers.py
@@ -142,8 +142,32 @@ class TestTransformers(unittest.TestCase):
         self.assertEqual(p1.history, [D, D, C, C, C, C, D, D])
 
     def test_retailiation(self):
-        """Tests the RetailiateUntilApologyTransformer."""
-        TFT = RetailiateUntilApologyTransformer(axelrod.Cooperator)
+        """Tests the RetaliateTransformer."""
+        p1 = RetaliationTransformer(1)(axelrod.Cooperator)()
+        p2 = axelrod.Defector()
+        for _ in range(5):
+            p1.play(p2)
+        self.assertEqual(p1.history, [C, D, D, D, D])
+        self.assertEqual(p2.history, [D, D, D, D, D])
+
+        p1 = RetaliationTransformer(1)(axelrod.Cooperator)()
+        p2 = axelrod.Alternator()
+        for _ in range(5):
+            p1.play(p2)
+        self.assertEqual(p1.history, [C, C, D, C, D])
+        self.assertEqual(p2.history, [C, D, C, D, C])
+
+        TwoTitsForTat = RetaliationTransformer(2)(axelrod.Cooperator)
+        p1 = TwoTitsForTat()
+        p2 = axelrod.CyclerCCD()
+        for _ in range(9):
+            p1.play(p2)
+        self.assertEqual(p1.history, [C, C, C, D, D, C, D, D, C])
+        self.assertEqual(p2.history, [C, C, D, C, C, D, C, C, D])
+
+    def test_retaliation_until_apology(self):
+        """Tests the RetaliateUntilApologyTransformer."""
+        TFT = RetaliateUntilApologyTransformer(axelrod.Cooperator)
         p1 = TFT()
         p2 = axelrod.Cooperator()
         p1.play(p2)
@@ -163,17 +187,69 @@ class TestTransformers(unittest.TestCase):
             p1.play(p2)
         self.assertEqual(p1.history, [C, C, D, D, C])
 
+    def test_apology(self):
+        """Tests the ApologyTransformer."""
+        ApologizingDefector = ApologyTransformer(axelrod.Defector)
+        p1 = ApologizingDefector()
+        p2 = axelrod.Cooperator()
+        for _ in range(5):
+            p1.play(p2)
+        self.assertEqual(p1.history, [D, C, D, C, D])
+
+    def test_deadlock(self):
+        """Test the DeadlockBreakingTransformer."""
+        # We can induce a deadlock by alterting TFT to defect first
+        p1 = axelrod.TitForTat()
+        p2 = InitialTransformer([D])(axelrod.TitForTat)()
+        for _ in range(4):
+            p1.play(p2)
+        self.assertEqual(p1.history, [C, D, C, D])
+        self.assertEqual(p2.history, [D, C, D, C])
+
+        # Now let's use the transformer to break the deadlock to achieve
+        # Mutual cooperation
+        p1 = axelrod.TitForTat()
+        p2 = DeadlockBreakingTransformer(InitialTransformer([D])(axelrod.TitForTat))()
+        for _ in range(4):
+            p1.play(p2)
+        self.assertEqual(p1.history, [C, D, C, C])
+        self.assertEqual(p2.history, [D, C, C, C])
+
+    def test_grudging(self):
+        """Test the GrudgeTransformer."""
+        p1 = axelrod.Defector()
+        p2 = GrudgeTransformer(1)(axelrod.Cooperator)()
+        for _ in range(4):
+            p1.play(p2)
+        self.assertEqual(p1.history, [D, D, D, D])
+        self.assertEqual(p2.history, [C, C, D, D])
+
+        p1 = InitialTransformer([C])(axelrod.Defector)()
+        p2 = GrudgeTransformer(2)(axelrod.Cooperator)()
+        for _ in range(8):
+            p1.play(p2)
+        self.assertEqual(p1.history, [C, D, D, D, D, D, D, D])
+        self.assertEqual(p2.history, [C, C, C, C, D, D, D, D])
+
     def test_idempotency(self):
-        """Show that some of the transformers are idempotent."""
+        """Show that some of the transformers are (sometimes) idempotent."""
         for PlayerClass in [axelrod.Cooperator, axelrod.Defector]:
             for transformer in [FinalTransformer([C]),
                                 FinalTransformer([D]),
-                                FlipTransformer]:
+                                FlipTransformer,
+                                RetaliateUntilApologyTransformer,
+                                ApologyTransformer,
+                                RetaliationTransformer(1),
+                                ]:
                 player = PlayerClass()
-                third_player = axelrod.Cooperator()
+                third_player = PlayerClass()
                 transformed = transformer(transformer(PlayerClass))()
-                self.assertEqual(player.strategy(third_player),
-                                 transformed.strategy(third_player))
+                for _ in range(5):
+                    self.assertEqual(player.strategy(third_player),
+                                     transformed.strategy(third_player))
+                    player.play(third_player)
+                    third_player.history.pop(-1)
+                    transformed.play(third_player)
 
     def test_implementation(self):
         """A test that demonstrates the difference in outcomes if
@@ -203,7 +279,7 @@ class TestTransformers(unittest.TestCase):
 ## this alters Cooperator's class variable, and causes its test to fail
 ## So for now this is commented out.
 
-#RUA = RetailiateUntilApologyTransformer()
+#RUA = RetaliateUntilApologyTransformer()
 #TFT = RUA(axelrod.Cooperator)
 #TFT.name = "Tit For Tat"
 #TFT.classifier["memory_depth"] = 1

--- a/docs/tutorials/advanced/strategy_transformers.rst
+++ b/docs/tutorials/advanced/strategy_transformers.rst
@@ -101,7 +101,15 @@ The library includes the following transformers:
 
     >>> import axelrod
     >>> from axelrod.strategy_transformers import ApologyTransformer
-    >>> ApologizingDefector = ApologyTransformer(axelrod.Defector)
+    >>> ApologizingDefector = ApologyTransformer([D], [C])(axelrod.Defector)
+    >>> player = ApologizingDefector()
+
+You can pass any two sequences in. In this example the player would apologize
+after two consequtive rounds of `(D, C)`::
+
+    >>> import axelrod
+    >>> from axelrod.strategy_transformers import ApologyTransformer
+    >>> ApologizingDefector = ApologyTransformer([D, D], [C, C])(axelrod.Defector)
     >>> player = ApologizingDefector()
 
 * :code:`DeadlockBreakingTransformer`: Attempts to break :code:`(D, C) -> (C, D)`

--- a/docs/tutorials/advanced/strategy_transformers.rst
+++ b/docs/tutorials/advanced/strategy_transformers.rst
@@ -120,6 +120,13 @@ deadlocks by cooperating::
     >>> DeadlockBreakingTFT = DeadlockBreakingTransformer(axelrod.TitForTat)
     >>> player = DeadlockBreakingTFT()
 
+* :code:`GrudgeTransformer(N)`: Defections unconditionally after more than N defections::
+
+    >>> import axelrod
+    >>> from axelrod.strategy_transformers import GrudgeTransformer
+    >>> GrudgingCooperator = GrudgeTransformer(2)(axelrod.Cooperator)
+    >>> player = GrudgingCooperator()
+
 * :code:`TrackHistoryTransformer`: Tracks History internally in the :code:`Player` instance in a variable :code:`_recorded_history`. This allows a player to e.g. detect noise.::
 
     >>> import axelrod

--- a/docs/tutorials/advanced/strategy_transformers.rst
+++ b/docs/tutorials/advanced/strategy_transformers.rst
@@ -83,12 +83,34 @@ The library includes the following transformers:
     >>> FinallyDefectingCooperator = FinalTransformer([D, D])(axelrod.Cooperator)
     >>> player = FinallyDefectingCooperator()
 
-* :code:`RetailiateUntilApologyTransformer()`: adds TitForTat-style retaliation::
+* :code:`RetaliateTransformer(N)`: Retaliation N times after a defection::
 
     >>> import axelrod
-    >>> from axelrod.strategy_transformers import RetailiateUntilApologyTransformer
-    >>> TFT = RetailiateUntilApologyTransformer(axelrod.Cooperator)
+    >>> from axelrod.strategy_transformers import RetaliationTransformer
+    >>> TwoTitsForTat = RetaliationTransformer(2)(axelrod.Cooperator)
+    >>> player = TwoTitsForTat()
+
+* :code:`RetaliateUntilApologyTransformer()`: adds TitForTat-style retaliation::
+
+    >>> import axelrod
+    >>> from axelrod.strategy_transformers import RetaliateUntilApologyTransformer
+    >>> TFT = RetaliateUntilApologyTransformer(axelrod.Cooperator)
     >>> player = TFT()
+
+* :code:`ApologizingTransformer`: Apologizes after a round of :code:`(D, C)`::
+
+    >>> import axelrod
+    >>> from axelrod.strategy_transformers import ApologyTransformer
+    >>> ApologizingDefector = ApologyTransformer(axelrod.Defector)
+    >>> player = ApologizingDefector()
+
+* :code:`DeadlockBreakingTransformer`: Attempts to break :code:`(D, C) -> (C, D)`
+deadlocks by cooperating::
+
+    >>> import axelrod
+    >>> from axelrod.strategy_transformers import DeadlockBreakingTransformer
+    >>> DeadlockBreakingTFT = DeadlockBreakingTransformer(axelrod.TitForTat)
+    >>> player = DeadlockBreakingTFT()
 
 * :code:`TrackHistoryTransformer`: Tracks History internally in the :code:`Player` instance in a variable :code:`_recorded_history`. This allows a player to e.g. detect noise.::
 


### PR DESCRIPTION
`RetaliateTransformer(N)`: Retaliation N times after a defection:
```
    >>> import axelrod
    >>> from axelrod.strategy_transformers import RetaliationTransformer
    >>> TwoTitsForTat = RetaliationTransformer(2)(axelrod.Cooperator)
    >>> player = TwoTitsForTat()
```

`ApologizingTransformer`: Apologizes after a round of `(D, C)`:
```
    >>> import axelrod
    >>> from axelrod.strategy_transformers import ApologyTransformer
    >>> ApologizingDefector = ApologyTransformer([D], [C])(axelrod.Defector)
    >>> player = ApologizingDefector()
```
`DeadlockBreakingTransformer`: Attempts to break `(D, C) -> (C, D)` deadlocks by cooperating:
```
    >>> import axelrod
    >>> from axelrod.strategy_transformers import DeadlockBreakingTransformer
    >>> DeadlockBreakingTFT = DeadlockBreakingTransformer(axelrod.TitForTat)
    >>> player = DeadlockBreakingTFT()
```