### PR TITLE
Some necessary changes for transformers to be applied to all strategies; additional test to catch implementation issues for new strategies.

### DIFF
--- a/axelrod/strategies/axelrod_first.py
+++ b/axelrod/strategies/axelrod_first.py
@@ -223,7 +223,7 @@ class Joss(MemoryOnePlayer):
         """
         four_vector = (p, 0, p, 0)
         self.p = p
-        super(self.__class__, self).__init__(four_vector)
+        super(Joss, self).__init__(four_vector)
         self.init_args = (p,)
 
     def __repr__(self):
@@ -265,7 +265,7 @@ class Nydegger(Player):
                           (C, D): 2,
                           (D, C): 1,
                           (D, D): 3}
-        super(self.__class__, self).__init__()
+        super(Nydegger, self).__init__()
 
     @staticmethod
     def score_history(my_history, opponent_history, score_map):

--- a/axelrod/strategies/gobymajority.py
+++ b/axelrod/strategies/gobymajority.py
@@ -72,7 +72,7 @@ class GoByMajority40(GoByMajority):
     """
 
     def __init__(self, memory_depth=40, soft=True):
-        super(self.__class__, self).__init__(memory_depth=memory_depth,
+        super(GoByMajority40, self).__init__(memory_depth=memory_depth,
                                              soft=soft)
 
 
@@ -82,7 +82,7 @@ class GoByMajority20(GoByMajority):
     """
 
     def __init__(self, memory_depth=20, soft=True):
-        super(self.__class__, self).__init__(memory_depth=memory_depth,
+        super(GoByMajority20, self).__init__(memory_depth=memory_depth,
                                              soft=soft)
 
 class GoByMajority10(GoByMajority):
@@ -91,7 +91,7 @@ class GoByMajority10(GoByMajority):
     """
 
     def __init__(self, memory_depth=10, soft=True):
-        super(self.__class__, self).__init__(memory_depth=memory_depth,
+        super(GoByMajority10, self).__init__(memory_depth=memory_depth,
                                              soft=soft)
 
 class GoByMajority5(GoByMajority):
@@ -100,5 +100,5 @@ class GoByMajority5(GoByMajority):
     """
 
     def __init__(self, memory_depth=5, soft=True):
-        super(self.__class__, self).__init__(memory_depth=memory_depth,
+        super(GoByMajority5, self).__init__(memory_depth=memory_depth,
                                              soft=soft)

--- a/axelrod/strategies/memoryone.py
+++ b/axelrod/strategies/memoryone.py
@@ -95,7 +95,7 @@ class GTFT(MemoryOnePlayer):
         TitForTat is equivalent to GTFT(0)
         """
         self.p = p
-        super(self.__class__, self).__init__()
+        super(GTFT, self).__init__()
         self.init_args = (p,)
 
     def receive_tournament_attributes(self):
@@ -141,7 +141,7 @@ class StochasticWSLS(MemoryOnePlayer):
 
         self.ep = ep
         four_vector = (1.-ep, ep, ep, 1.-ep)
-        super(self.__class__, self).__init__(four_vector)
+        super(StochasticWSLS, self).__init__(four_vector)
         self.init_args = (ep,)
         self.set_four_vector(four_vector)
 
@@ -199,13 +199,13 @@ class ZDGTFT2(ZeroDeterminantPlayer):
         """
         self.phi = phi
         self.s = s
-        super(self.__class__, self).__init__()
+        super(ZDGTFT2, self).__init__()
         self.init_args = (phi, s)
 
     def receive_tournament_attributes(self):
         (R, P, S, T) = self.tournament_attributes["game"].RPST()
         self.l = R
-        super(self.__class__, self).receive_tournament_attributes(self.phi,
+        super(ZDGTFT2, self).receive_tournament_attributes(self.phi,
                                                                   self.s,
                                                                   self.l)
 
@@ -224,13 +224,13 @@ class ZDExtort2(ZeroDeterminantPlayer):
         """
         self.phi = phi
         self.s = s
-        super(self.__class__, self).__init__()
+        super(ZDExtort2, self).__init__()
         self.init_args = (phi, s)
 
     def receive_tournament_attributes(self):
         (R, P, S, T) = self.tournament_attributes["game"].RPST()
         self.l = P
-        super(self.__class__, self).receive_tournament_attributes(self.phi,
+        super(ZDExtort2, self).receive_tournament_attributes(self.phi,
                                                                   self.s,
                                                                   self.l)
 
@@ -260,7 +260,7 @@ class SoftJoss(MemoryOnePlayer):
         """
         self.q = q
         four_vector = (1., 1 - q, 1, 1 - q)
-        super(self.__class__, self).__init__(four_vector)
+        super(SoftJoss, self).__init__(four_vector)
         self.init_args = (q,)
 
     def __repr__(self):

--- a/axelrod/strategies/retaliate.py
+++ b/axelrod/strategies/retaliate.py
@@ -55,7 +55,7 @@ class Retaliate2(Retaliate):
     """
 
     def __init__(self, retaliation_threshold=0.08):
-        super(self.__class__, self).__init__(
+        super(Retaliate2, self).__init__(
             retaliation_threshold=retaliation_threshold)
 
 
@@ -65,7 +65,7 @@ class Retaliate3(Retaliate):
     """
 
     def __init__(self, retaliation_threshold=0.05):
-        super(self.__class__, self).__init__(
+        super(Retaliate3, self).__init__(
             retaliation_threshold=retaliation_threshold)
 
 
@@ -151,7 +151,7 @@ class LimitedRetaliate2(LimitedRetaliate):
     """
 
     def __init__(self, retaliation_threshold=0.08, retaliation_limit=15):
-        super(self.__class__, self).__init__(
+        super(LimitedRetaliate2, self).__init__(
             retaliation_threshold=retaliation_threshold,
             retaliation_limit=retaliation_limit)
 
@@ -163,6 +163,6 @@ class LimitedRetaliate3(LimitedRetaliate):
     """
 
     def __init__(self, retaliation_threshold=0.05, retaliation_limit=20):
-        super(self.__class__, self).__init__(
+        super(LimitedRetaliate3, self).__init__(
             retaliation_threshold=retaliation_threshold,
             retaliation_limit=retaliation_limit)

--- a/axelrod/strategy_transformers.py
+++ b/axelrod/strategy_transformers.py
@@ -6,6 +6,7 @@ strategy.
 See the various Meta strategies for another type of transformation.
 """
 
+import inspect
 import random
 from types import FunctionType
 
@@ -74,10 +75,12 @@ def StrategyTransformerFactory(strategy_wrapper, name_prefix=None):
             # with `strategy_wrapper`
             def strategy(self, opponent):
                 # Is the original strategy method a static method?
-                if isinstance(PlayerClass.__dict__["strategy"], staticmethod):
-                    proposed_action = PlayerClass.strategy(opponent)
-                else:
+                argspec = inspect.getargspec(getattr(PlayerClass, "strategy"))
+                if 'self' in argspec.args:
+                    # it's not a static method
                     proposed_action = PlayerClass.strategy(self, opponent)
+                else:
+                    proposed_action = PlayerClass.strategy(opponent)
                 # Apply the wrapper
                 return strategy_wrapper(self, opponent, proposed_action,
                                         *args, **kwargs)

--- a/axelrod/tests/unit/test_strategy_transformers.py
+++ b/axelrod/tests/unit/test_strategy_transformers.py
@@ -10,6 +10,14 @@ C, D = axelrod.Actions.C, axelrod.Actions.D
 
 class TestTransformers(unittest.TestCase):
 
+    def test_all_strategies(self):
+        # Attempt to transform each strategy to ensure that implemenation
+        # choices (like use of super) do not cause issues
+        for s in axelrod.ordinary_strategies:
+            opponent = axelrod.Cooperator()
+            player = IdentityTransformer(s)()
+            player.play(opponent)
+
     def test_naming(self):
         """Tests that the player and class names are properly modified."""
         cls = FlipTransformer(axelrod.Cooperator)


### PR DESCRIPTION
We've been fast and loose with how we use `super` (myself included), and in some cases we hit the usual infinite recursion issue when a transformer is applied to a class that uses super in particular ways.

This PR corrects these issues, makes a change to the `staticmethod` testing of transformers to be more robust, and adds in a test to try to apply a transform to every strategy in the library to catch future strategy issues.

Needs to go in after #399 (for `IdentityTransformer`), tests should pass then. I did not add it to #399 since it's already got a :+1: