### PR TITLE
Fix deprecated stackplot calls

### DIFF
--- a/axelrod/tournament_manager.py
+++ b/axelrod/tournament_manager.py
@@ -132,7 +132,7 @@ class TournamentManager(object):
                 tournament.name + '_' + plot_type, image_format)
             self._save_plot(figure, file_name)
         if ecosystem is not None:
-            figure = plot.stackplot(ecosystem.population_sizes)
+            figure = plot.stackplot(ecosystem)
             file_name = self._output_file_path(
                     tournament.name + '_reproduce', image_format)
             self._save_plot(figure, file_name)

--- a/docs/tutorials/getting_started/usage.old
+++ b/docs/tutorials/getting_started/usage.old
@@ -461,7 +461,7 @@ We can see how this differs when the initial population contains a large number 
     eco = axelrod.Ecosystem(results, population=[.1, .05, .7, .1, .05])
     eco.reproduce(50) # Evolve the population over 50 time steps
     plot = axelrod.Plot(results)
-    p = plot.stackplot(eco.population_sizes)
+    p = plot.stackplot(eco)
     p.show()
 
 We see the output here:
@@ -479,7 +479,7 @@ Here is a with an even larger initial number of :code:`Defector` (note that it t
     eco = axelrod.Ecosystem(results, population=[.1, .05, 7, .1, .05])
     eco.reproduce(140) # Evolve the population over 140 time steps
     plot = axelrod.Plot(results)
-    p = plot.stackplot(eco.population_sizes)
+    p = plot.stackplot(eco)
     p.show()
 
 The output is shown here:


### PR DESCRIPTION
stackplot should be called with the ecosystem object and not its list
this commit fixes the test and some documentation.

Change made due to these commits:
c965e249ebb8fac64e23618e80ab19deb8a6dc30
a75c52f356b1dd50910974f1bbc52b3c429dbabf