### PR TITLE
415 - Making HardGoByMajority explicit

### DIFF
--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -15,9 +15,11 @@ from .darwin import Darwin
 from .defector import Defector, TrickyDefector
 from .forgiver import Forgiver, ForgivingTitForTat
 from .geller import Geller, GellerCooperator, GellerDefector
-from .gobymajority import (
-    GoByMajority, GoByMajority10, GoByMajority20, GoByMajority40,
-    GoByMajority5)
+from .gobymajority import (GoByMajority,
+    GoByMajority10, GoByMajority20, GoByMajority40,
+    GoByMajority5,
+    HardGoByMajority, HardGoByMajority10, HardGoByMajority20, HardGoByMajority40,
+    HardGoByMajority5)
 from .grudger import Grudger, ForgetfulGrudger, OppositeGrudger, Aggravater
 from .grumpy import Grumpy
 from .hunter import (
@@ -93,6 +95,11 @@ strategies = [
     GoByMajority20,
     GoByMajority40,
     GoByMajority5,
+    HardGoByMajority,
+    HardGoByMajority10,
+    HardGoByMajority20,
+    HardGoByMajority40,
+    HardGoByMajority5,
     Golden,
     Grofman,
     Grudger,

--- a/axelrod/strategies/gobymajority.py
+++ b/axelrod/strategies/gobymajority.py
@@ -2,9 +2,15 @@ from axelrod import Player, Actions
 
 C, D = Actions.C, Actions.D
 
+
 class GoByMajority(Player):
     """A player examines the history of the opponent: if the opponent has more
     defections than cooperations then the player defects.
+
+    In case of equal
+    number of defections and cooperations this player will Cooperate. Passing
+    the `soft=False` keyword argument when initialising will create a
+    HardGoByMajority which Defects in case of equality.
 
     An optional memory attribute will limit the number of turns remembered (by
     default this is 0)
@@ -15,7 +21,7 @@ class GoByMajority(Player):
         'inspects_source': False,
         'manipulates_source': False,
         'manipulates_state': False,
-        'memory_depth': 0 # memory_depth may be altered by __init__
+        'memory_depth': 0  # memory_depth may be altered by __init__
     }
 
     def __init__(self, memory_depth=0, soft=True):
@@ -38,8 +44,9 @@ class GoByMajority(Player):
     def strategy(self, opponent):
         """This is affected by the history of the opponent.
 
-        As long as the opponent cooperates at least as often as they defect then the player will cooperate.
-        If at any point the opponent has more defections than cooperations in memory the player defects.
+        As long as the opponent cooperates at least as often as they defect then
+        the player will cooperate.  If at any point the opponent has more
+        defections than cooperations in memory the player defects.
         """
 
         memory = self.classifier['memory_depth']
@@ -73,7 +80,7 @@ class GoByMajority40(GoByMajority):
 
     def __init__(self, memory_depth=40, soft=True):
         super(GoByMajority40, self).__init__(memory_depth=memory_depth,
-                                             soft=soft)
+                                                 soft=soft)
 
 
 class GoByMajority20(GoByMajority):
@@ -83,7 +90,8 @@ class GoByMajority20(GoByMajority):
 
     def __init__(self, memory_depth=20, soft=True):
         super(GoByMajority20, self).__init__(memory_depth=memory_depth,
-                                             soft=soft)
+                                                 soft=soft)
+
 
 class GoByMajority10(GoByMajority):
     """
@@ -92,7 +100,8 @@ class GoByMajority10(GoByMajority):
 
     def __init__(self, memory_depth=10, soft=True):
         super(GoByMajority10, self).__init__(memory_depth=memory_depth,
-                                             soft=soft)
+                                                 soft=soft)
+
 
 class GoByMajority5(GoByMajority):
     """
@@ -101,4 +110,53 @@ class GoByMajority5(GoByMajority):
 
     def __init__(self, memory_depth=5, soft=True):
         super(GoByMajority5, self).__init__(memory_depth=memory_depth,
-                                             soft=soft)
+                                                soft=soft)
+
+
+class HardGoByMajority(GoByMajority):
+    """A player examines the history of the opponent: if the opponent has more
+    defections than cooperations then the player defects. In case of equal
+    number of defections and cooperations this player will Defect.
+
+    An optional memory attribute will limit the number of turns remembered (by
+    default this is 0)
+    """
+    def __init__(self, memory_depth=0, soft=False):
+        super(HardGoByMajority, self).__init__(memory_depth=memory_depth,
+                                               soft=soft)
+
+
+class HardGoByMajority40(HardGoByMajority):
+    """
+    HardGoByMajority player with a memory of 40.
+    """
+    def __init__(self, memory_depth=40, soft=False):
+        super(HardGoByMajority40, self).__init__(memory_depth=memory_depth,
+                                                 soft=soft)
+
+
+class HardGoByMajority20(HardGoByMajority):
+    """
+    HardGoByMajority player with a memory of 20.
+    """
+    def __init__(self, memory_depth=20, soft=False):
+        super(HardGoByMajority20, self).__init__(memory_depth=memory_depth,
+                                                 soft=soft)
+
+
+class HardGoByMajority10(HardGoByMajority):
+    """
+    HardGoByMajority player with a memory of 10.
+    """
+    def __init__(self, memory_depth=10, soft=False):
+        super(HardGoByMajority10, self).__init__(memory_depth=memory_depth,
+                                                 soft=soft)
+
+
+class HardGoByMajority5(HardGoByMajority):
+    """
+    HardGoByMajority player with a memory of 5.
+    """
+    def __init__(self, memory_depth=5, soft=False):
+        super(HardGoByMajority5, self).__init__(memory_depth=memory_depth,
+                                                soft=soft)

--- a/axelrod/strategies/gobymajority.py
+++ b/axelrod/strategies/gobymajority.py
@@ -21,10 +21,10 @@ class GoByMajority(Player):
         'inspects_source': False,
         'manipulates_source': False,
         'manipulates_state': False,
-        'memory_depth': 0  # memory_depth may be altered by __init__
+        'memory_depth': float('inf')  # memory_depth may be altered by __init__
     }
 
-    def __init__(self, memory_depth=0, soft=True):
+    def __init__(self, memory_depth=float('inf'), soft=True):
         """
         Parameters
         ----------
@@ -39,6 +39,10 @@ class GoByMajority(Player):
         Player.__init__(self)
         self.soft = soft
         self.classifier['memory_depth'] = memory_depth
+        if self.classifier['memory_depth'] < float('inf'):
+            self.memory = self.classifier['memory_depth']
+        else:
+            self.memory = 0
         self.init_args = (memory_depth, soft)
 
     def strategy(self, opponent):
@@ -49,8 +53,7 @@ class GoByMajority(Player):
         defections than cooperations in memory the player defects.
         """
 
-        memory = self.classifier['memory_depth']
-        history = opponent.history[-memory:]
+        history = opponent.history[-self.memory:]
         defections = sum([s == D for s in history])
         cooperations = sum([s == C for s in history])
         if defections > cooperations:
@@ -64,8 +67,7 @@ class GoByMajority(Player):
 
     def __repr__(self):
         """The string method for the strategy."""
-        memory = self.classifier['memory_depth']
-        name = 'Go By Majority' + (memory > 0) * (": %i" % memory)
+        name = 'Go By Majority' + (self.memory > 0) * (": %i" % self.memory)
         if self.soft:
             name = "Soft " + name
         else:
@@ -80,7 +82,7 @@ class GoByMajority40(GoByMajority):
 
     def __init__(self, memory_depth=40, soft=True):
         super(GoByMajority40, self).__init__(memory_depth=memory_depth,
-                                                 soft=soft)
+                                             soft=soft)
 
 
 class GoByMajority20(GoByMajority):
@@ -121,7 +123,7 @@ class HardGoByMajority(GoByMajority):
     An optional memory attribute will limit the number of turns remembered (by
     default this is 0)
     """
-    def __init__(self, memory_depth=0, soft=False):
+    def __init__(self, memory_depth=float('inf'), soft=False):
         super(HardGoByMajority, self).__init__(memory_depth=memory_depth,
                                                soft=soft)
 

--- a/axelrod/tests/unit/test_classification.py
+++ b/axelrod/tests/unit/test_classification.py
@@ -105,7 +105,6 @@ class TestClassification(unittest.TestCase):
                        axelrod.Bully,
                        axelrod.Cooperator,
                        axelrod.Defector,
-                       axelrod.GoByMajority,
                        axelrod.SuspiciousTitForTat,
                        axelrod.TitForTat,
                        axelrod.WinStayLoseShift]

--- a/axelrod/tests/unit/test_gobymajority.py
+++ b/axelrod/tests/unit/test_gobymajority.py
@@ -14,7 +14,7 @@ class TestGoByMajority(TestPlayer):
 
     expected_classifier = {
         'stochastic': False,
-        'memory_depth': 0,
+        'memory_depth': float('inf'),
         'inspects_source': False,
         'manipulates_source': False,
         'manipulates_state': False

--- a/axelrod/tests/unit/test_gobymajority.py
+++ b/axelrod/tests/unit/test_gobymajority.py
@@ -26,7 +26,8 @@ class TestGoByMajority(TestPlayer):
 
     def test_strategy(self):
         """
-        If opponent cooperates at least as often as they defect then the player cooperates
+        If opponent cooperates at least as often as they defect then the player
+        cooperates
         """
         self.responses_test([C, D, D, D], [D, D, C, C], [C])
         self.responses_test([C, C, D, D, C], [D, D, C, C, D], [D])
@@ -45,7 +46,30 @@ class TestGoByMajority(TestPlayer):
         self.assertEqual(name, "Hard Go By Majority")
 
 
-def factory_TestGoByRecentMajority(L):
+class TestHardGoByMajority(TestGoByMajority):
+
+    name = "Hard Go By Majority"
+    player = axelrod.HardGoByMajority
+
+    def test_initial_strategy(self):
+        """Starts by defecting"""
+        self.first_play_test(D)
+
+    def test_strategy(self):
+        """
+        If opponent cooperates strictly more often as they defect then the
+        player cooperates
+        """
+        self.responses_test([C, D, D, D], [D, D, C, C], [D])
+        self.responses_test([C, C, D, D, C], [D, D, C, C, D], [D])
+
+        # Test tie break rule for soft=True
+        player = self.player(soft=True)
+        opponent = axelrod.Cooperator()
+        self.assertEqual('C', player.strategy(opponent))
+
+
+def factory_TestGoByRecentMajority(L, soft=True):
 
     class TestGoByRecentMajority(TestPlayer):
 
@@ -65,7 +89,8 @@ def factory_TestGoByRecentMajority(L):
             self.first_play_test(C)
 
         def test_strategy(self):
-            """If opponent cooperates at least as often as they defect then the player cooperates."""
+            """If opponent cooperates at least as often as they defect then the
+            player cooperates."""
             P1 = self.player()
             P2 = axelrod.Player()
             P1.history = [D] * int(1.5 * L)
@@ -75,9 +100,23 @@ def factory_TestGoByRecentMajority(L):
             P2.history = [C] * (L - 1) + [D] * (L // 2 + 1)
             self.assertEqual(P1.strategy(P2), D)
 
+    if not soft:  # Overwrite test class
+
+        class TestGoByRecentMajority(TestGoByRecentMajority):
+            name = "Hard Go By Majority: %i" % L
+            player = getattr(axelrod, 'HardGoByMajority%i' % L)
+
+            def test_initial_strategy(self):
+                """Starts by defecting."""
+                self.first_play_test(D)
+
     return TestGoByRecentMajority
 
 TestGoByMajority5 = factory_TestGoByRecentMajority(5)
 TestGoByMajority10 = factory_TestGoByRecentMajority(10)
 TestGoByMajority20 = factory_TestGoByRecentMajority(20)
 TestGoByMajority40 = factory_TestGoByRecentMajority(40)
+TestHardGoByMajority5 = factory_TestGoByRecentMajority(5, soft=False)
+TestHardGoByMajority10 = factory_TestGoByRecentMajority(10, soft=False)
+TestHardGoByMajority20 = factory_TestGoByRecentMajority(20, soft=False)
+TestHardGoByMajority40 = factory_TestGoByRecentMajority(40, soft=False)

--- a/docs/reference/overview_of_strategies.rst
+++ b/docs/reference/overview_of_strategies.rst
@@ -546,7 +546,7 @@ The following classical strategies are included in the library:
 +--------------+----------------------+--------------------------+
 | `EXTORT-2`_  | Extort-2             | :code:`ZDExtort2`        |
 +--------------+----------------------+--------------------------+
-| `HARD_MAJO`_ | Hard majority        | :code:`GoByMajority`     |
+| `HARD_MAJO`_ | Hard majority        | :code:`HardGoByMajority` |
 +--------------+----------------------+--------------------------+
 | `HARD_JOSS`_ | Hard Joss            | :code:`Joss`             |
 +--------------+----------------------+--------------------------+
@@ -808,17 +808,18 @@ Implementation
 HARD_MAJO is implemented in the library::
 
     >>> import axelrod
-    >>> p1 = axelrod.GoByMajority()  # Create a HARD_TFT player
+    >>> p1 = axelrod.HardGoByMajority()  # Create a Hard Go By Majority Player
     >>> p2 = axelrod.Random()  # Create a player that plays randomly
     >>> for round in range(5):
     ...     p1.play(p2)
     >>> p2.history  # doctest: +SKIP
     ['D', 'C', 'C', 'D', 'D']
     >>> p1.history  # doctest: +SKIP
-    ['C', 'D', 'C', 'C', 'C']
+    ['C', 'D', 'D', 'C', 'D']
 
 we see that following the third round (at which point the opponent has
-cooperated a lot), :code:`GoByMajority` cooperates.
+cooperated a lot), :code:`GoByMajority` cooperates but in every instance where
+the number of cooperations and defections is equal it defects.
 
 HARD_TFT
 ^^^^^^^^


### PR DESCRIPTION
This addresses #415:

- Adds `HardGoByMajority`
- Including docs
- Also fixes memory depth for `GoByMajority` base player (was 0, should be inf).