### PR TITLE
Add decorator for init_args

### DIFF
--- a/axelrod/__init__.py
+++ b/axelrod/__init__.py
@@ -5,7 +5,7 @@ from .actions import Actions, flip_action
 from .random_ import random_choice
 from .plot import Plot
 from .game import DefaultGame, Game
-from .player import is_basic, obey_axelrod, update_history, Player
+from .player import init_args, is_basic, obey_axelrod, update_history, Player
 from .mock_player import MockPlayer, simulate_play
 from .round_robin import RoundRobin
 from .strategies import *

--- a/axelrod/__init__.py
+++ b/axelrod/__init__.py
@@ -5,7 +5,7 @@ from .actions import Actions, flip_action
 from .random_ import random_choice
 from .plot import Plot
 from .game import DefaultGame, Game
-from .player import is_basic, obey_axelrod, update_histories, Player
+from .player import is_basic, obey_axelrod, update_history, Player
 from .mock_player import MockPlayer, simulate_play
 from .round_robin import RoundRobin
 from .strategies import *

--- a/axelrod/mock_player.py
+++ b/axelrod/mock_player.py
@@ -2,7 +2,7 @@ import copy
 
 import axelrod
 
-from axelrod import Player, update_histories, Actions
+from axelrod import Player, update_history, Actions
 
 C, D = Actions.C, Actions.D
 
@@ -38,11 +38,13 @@ def simulate_play(P1, P2, h1=None, h2=None):
         s2 = P2.strategy(MockPlayer(P1, h1))
         # Record intended history
         # Update Cooperation / Defection counts
-        update_histories(P1, P2, h1, h2)
+        update_history(P1, h1)
+        update_history(P2, h2)
         return (h1, h2)
     else:
         s1 = P1.strategy(P2)
         s2 = P2.strategy(P1)
         # Record history
-        update_histories(P1, P2, s1, s2)
+        update_history(P1, s1)
+        update_history(P2, s2)
         return (s1, s2)

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -31,20 +31,15 @@ def obey_axelrod(s):
            classifier['manipulates_source'] or\
            classifier['manipulates_state'])
 
-def update_histories(player1, player2, move1, move2):
+def update_history(player, move):
     """Updates histories and cooperation / defections counts following play."""
     # Update histories
-    player1.history.append(move1)
-    player2.history.append(move2)
+    player.history.append(move)
     # Update player counts of cooperation and defection
-    if move1 == C:
-        player1.cooperations += 1
-    elif move1 == D:
-        player1.defections += 1
-    if move2 == C:
-        player2.cooperations += 1
-    elif move2 == D:
-        player2.defections += 1
+    if move == C:
+        player.cooperations += 1
+    elif move == D:
+        player.defections += 1
 
 
 class Player(object):
@@ -114,7 +109,8 @@ class Player(object):
         s1, s2 = self.strategy(opponent), opponent.strategy(self)
         if noise:
             s1, s2 = self._add_noise(noise, s1, s2)
-        update_histories(self, opponent, s1, s2)
+        update_history(self, s1)
+        update_history(opponent, s2)
 
     def clone(self):
         """Clones the player without history, reapplying configuration

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -1,3 +1,4 @@
+from functools import wraps
 import inspect
 import random
 import copy
@@ -40,6 +41,21 @@ def update_history(player, move):
         player.cooperations += 1
     elif move == D:
         player.defections += 1
+
+def init_args(func):
+    """Decorator to simplify the handling of init_args. Use whenever overriding
+    Player.__init__ in subclasses of Player that require arguments as follows:
+
+    @init_args
+    def __init__(self, myarg1, ...)
+    """
+
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        r = func(self, *args, **kwargs)
+        self.init_args = args
+        return r
+    return wrapper
 
 
 class Player(object):

--- a/axelrod/strategies/alternator.py
+++ b/axelrod/strategies/alternator.py
@@ -1,4 +1,4 @@
-from axelrod import Player, Actions
+from axelrod import Actions, Player
 
 
 class Alternator(Player):

--- a/axelrod/strategies/apavlov.py
+++ b/axelrod/strategies/apavlov.py
@@ -1,4 +1,4 @@
-from axelrod import Player, Actions, flip_action
+from axelrod import Actions, Player, flip_action
 
 C, D = Actions.C, Actions.D
 

--- a/axelrod/strategies/appeaser.py
+++ b/axelrod/strategies/appeaser.py
@@ -1,4 +1,4 @@
-from axelrod import Player, Actions
+from axelrod import Actions, Player
 
 C, D = Actions.C, Actions.D
 

--- a/axelrod/strategies/averagecopier.py
+++ b/axelrod/strategies/averagecopier.py
@@ -1,5 +1,6 @@
-from axelrod import Player, random_choice, Actions
 import random
+
+from axelrod import Actions, Player, random_choice
 
 
 class AverageCopier(Player):

--- a/axelrod/strategies/axelrod_first.py
+++ b/axelrod/strategies/axelrod_first.py
@@ -1,11 +1,11 @@
 """
-Additional strategies from Axelrod's two tournaments.
+Additional strategies from Axelrod's first tournament.
 """
 
 from math import sqrt
 import random
 
-from axelrod import Game, Player, Actions, random_choice, flip_action
+from axelrod import Actions, Game, Player, init_args, flip_action, random_choice
 
 from.memoryone import MemoryOnePlayer
 
@@ -25,6 +25,7 @@ class Davis(Player):
         'manipulates_state': False
     }
 
+    @init_args
     def __init__(self, rounds_to_cooperate=10):
         """
         Parameters
@@ -34,7 +35,6 @@ class Davis(Player):
         """
         Player.__init__(self)
         self._rounds_to_cooperate = rounds_to_cooperate
-        self.init_args = (self._rounds_to_cooperate,)
 
     def strategy(self, opponent):
         """Begins by playing C, then plays D for the remaining rounds if the
@@ -62,6 +62,7 @@ class RevisedDowning(Player):
         'manipulates_state': False
     }
 
+    @init_args
     def __init__(self, revised=True):
         Player.__init__(self)
         self.revised = revised
@@ -71,7 +72,6 @@ class RevisedDowning(Player):
         self.nice2 = 0
         self.total_C = 0 # note the same as self.cooperations
         self.total_D = 0 # note the same as self.defections
-        self.init_args = (revised,)
 
     def strategy(self, opponent):
         round_number = len(self.history) + 1
@@ -137,6 +137,7 @@ class Feld(Player):
         'manipulates_state': False
     }
 
+    @init_args
     def __init__(self, start_coop_prob=1.0, end_coop_prob=0.5,
                  rounds_of_decay=200):
         """
@@ -154,9 +155,6 @@ class Feld(Player):
         self._start_coop_prob = start_coop_prob
         self._end_coop_prob = end_coop_prob
         self._rounds_of_decay = rounds_of_decay
-        self.init_args = (start_coop_prob,
-                          end_coop_prob,
-                          rounds_of_decay)
 
     def _cooperation_probability(self):
         """It's not clear what the interpolating function is, so we'll do
@@ -213,6 +211,7 @@ class Joss(MemoryOnePlayer):
 
     name = "Joss"
 
+    @init_args
     def __init__(self, p=0.9):
         """
         Parameters
@@ -224,7 +223,6 @@ class Joss(MemoryOnePlayer):
         four_vector = (p, 0, p, 0)
         self.p = p
         super(Joss, self).__init__(four_vector)
-        self.init_args = (p,)
 
     def __repr__(self):
         return "%s: %s" % (self.name, round(self.p, 2))
@@ -369,6 +367,7 @@ class Tullock(Player):
         'manipulates_state': False
     }
 
+    @init_args
     def __init__(self, rounds_to_cooperate=11):
         """
         Parameters
@@ -379,7 +378,6 @@ class Tullock(Player):
         Player.__init__(self)
         self._rounds_to_cooperate = rounds_to_cooperate
         self.__class__.memory_depth = rounds_to_cooperate
-        self.init_args = (rounds_to_cooperate,)
 
     def strategy(self, opponent):
         rounds = self._rounds_to_cooperate

--- a/axelrod/strategies/axelrod_second.py
+++ b/axelrod/strategies/axelrod_second.py
@@ -1,14 +1,12 @@
 """
-Additional strategies from Axelrod's two tournaments.
+Additional strategies from Axelrod's second tournament.
 """
 
 import random
 
-from axelrod import Player, Actions, random_choice
+from axelrod import Actions, Player, flip_action, random_choice
 
 C, D = Actions.C, Actions.D
-
-flip_dict = {C: D, D: C}
 
 
 class Champion(Player):
@@ -109,7 +107,7 @@ class Tester(Player):
             if len(self.history) in [1, 2]:
                 return C
             # Alternate C and D
-            return flip_dict[self.history[-1]]
+            return flip_action(self.history[-1])
 
     def reset(self):
         Player.reset(self)

--- a/axelrod/strategies/backstabber.py
+++ b/axelrod/strategies/backstabber.py
@@ -1,8 +1,8 @@
-from axelrod import Player, Actions
-
+from axelrod import Actions, Player
 from axelrod.strategy_transformers import FinalTransformer
 
 C, D = Actions.C, Actions.D
+
 
 @FinalTransformer([D, D]) # End with two defections
 class BackStabber(Player):

--- a/axelrod/strategies/calculator.py
+++ b/axelrod/strategies/calculator.py
@@ -1,6 +1,6 @@
 import itertools
 
-from axelrod import Player, Actions
+from axelrod import Actions, Player
 from .axelrod_first import Joss
 from .hunter import detect_cycle
 

--- a/axelrod/strategies/cooperator.py
+++ b/axelrod/strategies/cooperator.py
@@ -1,4 +1,4 @@
-from axelrod import Player, Actions
+from axelrod import Actions, Player
 
 C, D = Actions.C, Actions.D
 

--- a/axelrod/strategies/cycler.py
+++ b/axelrod/strategies/cycler.py
@@ -1,5 +1,4 @@
-
-from axelrod import Player, Actions
+from axelrod import Actions, Player, init_args
 
 
 class AntiCycler(Player):
@@ -49,6 +48,7 @@ class Cycler(Player):
         'manipulates_state': False
     }
 
+    @init_args
     def __init__(self, cycle="CCD"):
         """This strategy will repeat the parameter `cycle` endlessly,
         e.g. C C D C C D C C D ...
@@ -64,7 +64,6 @@ class Cycler(Player):
         self.cycle = cycle
         self.name += " " + cycle
         self.classifier['memory_depth'] = len(cycle) - 1
-        self.init_args = (cycle,)
 
     def strategy(self, opponent):
         curent_round = len(self.history)
@@ -73,15 +72,18 @@ class Cycler(Player):
 
 
 class CyclerCCD(Cycler):
+    @init_args
     def __init__(self, cycle="CCD"):
         Cycler.__init__(self, cycle=cycle)
 
 
 class CyclerCCCD(Cycler):
+    @init_args
     def __init__(self, cycle="CCCD"):
         Cycler.__init__(self, cycle=cycle)
 
 
 class CyclerCCCCCD(Cycler):
+    @init_args
     def __init__(self, cycle="CCCCCD"):
         Cycler.__init__(self, cycle=cycle)

--- a/axelrod/strategies/darwin.py
+++ b/axelrod/strategies/darwin.py
@@ -1,5 +1,5 @@
 import inspect
-from axelrod import Player, Actions
+from axelrod import Actions, Player
 
 C, D = Actions.C, Actions.D
 

--- a/axelrod/strategies/defector.py
+++ b/axelrod/strategies/defector.py
@@ -1,4 +1,4 @@
-from axelrod import Player, Actions
+from axelrod import Actions, Player
 
 C, D = Actions.C, Actions.D
 

--- a/axelrod/strategies/forgiver.py
+++ b/axelrod/strategies/forgiver.py
@@ -1,4 +1,4 @@
-from axelrod import Player, Actions
+from axelrod import Actions, Player
 
 C, D = Actions.C, Actions.D
 

--- a/axelrod/strategies/geller.py
+++ b/axelrod/strategies/geller.py
@@ -21,7 +21,7 @@ spirit of the 'competition' :-)
 
 import inspect
 
-from axelrod import Player, Actions, random_choice
+from axelrod import Actions, Player, random_choice
 
 C, D = Actions.C, Actions.D
 

--- a/axelrod/strategies/gobymajority.py
+++ b/axelrod/strategies/gobymajority.py
@@ -1,4 +1,4 @@
-from axelrod import Player, Actions
+from axelrod import Actions, Player, init_args
 
 C, D = Actions.C, Actions.D
 
@@ -24,6 +24,7 @@ class GoByMajority(Player):
         'memory_depth': float('inf')  # memory_depth may be altered by __init__
     }
 
+    @init_args
     def __init__(self, memory_depth=float('inf'), soft=True):
         """
         Parameters
@@ -43,7 +44,6 @@ class GoByMajority(Player):
             self.memory = self.classifier['memory_depth']
         else:
             self.memory = 0
-        self.init_args = (memory_depth, soft)
 
     def strategy(self, opponent):
         """This is affected by the history of the opponent.
@@ -80,6 +80,7 @@ class GoByMajority40(GoByMajority):
     GoByMajority player with a memory of 40.
     """
 
+    @init_args
     def __init__(self, memory_depth=40, soft=True):
         super(GoByMajority40, self).__init__(memory_depth=memory_depth,
                                              soft=soft)
@@ -90,6 +91,7 @@ class GoByMajority20(GoByMajority):
     GoByMajority player with a memory of 20.
     """
 
+    @init_args
     def __init__(self, memory_depth=20, soft=True):
         super(GoByMajority20, self).__init__(memory_depth=memory_depth,
                                                  soft=soft)
@@ -100,6 +102,7 @@ class GoByMajority10(GoByMajority):
     GoByMajority player with a memory of 10.
     """
 
+    @init_args
     def __init__(self, memory_depth=10, soft=True):
         super(GoByMajority10, self).__init__(memory_depth=memory_depth,
                                                  soft=soft)
@@ -110,6 +113,7 @@ class GoByMajority5(GoByMajority):
     GoByMajority player with a memory of 5.
     """
 
+    @init_args
     def __init__(self, memory_depth=5, soft=True):
         super(GoByMajority5, self).__init__(memory_depth=memory_depth,
                                                 soft=soft)
@@ -123,6 +127,8 @@ class HardGoByMajority(GoByMajority):
     An optional memory attribute will limit the number of turns remembered (by
     default this is 0)
     """
+
+    @init_args
     def __init__(self, memory_depth=float('inf'), soft=False):
         super(HardGoByMajority, self).__init__(memory_depth=memory_depth,
                                                soft=soft)
@@ -132,6 +138,8 @@ class HardGoByMajority40(HardGoByMajority):
     """
     HardGoByMajority player with a memory of 40.
     """
+
+    @init_args
     def __init__(self, memory_depth=40, soft=False):
         super(HardGoByMajority40, self).__init__(memory_depth=memory_depth,
                                                  soft=soft)
@@ -141,6 +149,8 @@ class HardGoByMajority20(HardGoByMajority):
     """
     HardGoByMajority player with a memory of 20.
     """
+
+    @init_args
     def __init__(self, memory_depth=20, soft=False):
         super(HardGoByMajority20, self).__init__(memory_depth=memory_depth,
                                                  soft=soft)
@@ -150,6 +160,8 @@ class HardGoByMajority10(HardGoByMajority):
     """
     HardGoByMajority player with a memory of 10.
     """
+
+    @init_args
     def __init__(self, memory_depth=10, soft=False):
         super(HardGoByMajority10, self).__init__(memory_depth=memory_depth,
                                                  soft=soft)
@@ -159,6 +171,8 @@ class HardGoByMajority5(HardGoByMajority):
     """
     HardGoByMajority player with a memory of 5.
     """
+
+    @init_args
     def __init__(self, memory_depth=5, soft=False):
         super(HardGoByMajority5, self).__init__(memory_depth=memory_depth,
                                                 soft=soft)

--- a/axelrod/strategies/grudger.py
+++ b/axelrod/strategies/grudger.py
@@ -1,4 +1,4 @@
-from axelrod import Player, Actions
+from axelrod import Actions, Player
 
 C, D = Actions.C, Actions.D
 

--- a/axelrod/strategies/grumpy.py
+++ b/axelrod/strategies/grumpy.py
@@ -1,6 +1,7 @@
-from axelrod import Player, Actions
+from axelrod import Actions, Player, init_args
 
 C, D = Actions.C, Actions.D
+
 
 class Grumpy(Player):
     """A player that defects after a ceratin level of grumpiness.
@@ -16,6 +17,7 @@ class Grumpy(Player):
         'manipulates_state': False
     }
 
+    @init_args
     def __init__(self, starting_state='Nice', grumpy_threshold=10,
                  nice_threshold=-10):
         """
@@ -35,7 +37,6 @@ class Grumpy(Player):
         self.starting_state = starting_state
         self.grumpy_threshold = grumpy_threshold
         self.nice_threshold = nice_threshold
-        self.init_args = (starting_state, grumpy_threshold, nice_threshold)
 
     def strategy(self, opponent):
         """A player that gets grumpier the more the opposition defects,

--- a/axelrod/strategies/hunter.py
+++ b/axelrod/strategies/hunter.py
@@ -1,9 +1,4 @@
-from __future__ import absolute_import
-
-import itertools
-
-from axelrod import Player, Actions
-
+from axelrod import Actions, Player
 
 C, D = Actions.C, Actions.D
 
@@ -155,7 +150,6 @@ class MathConstantHunter(Player):
 
         n = len(self.history)
         if n >= 8 and opponent.cooperations and opponent.defections:
-
             start1, end1 = 0, n // 2
             start2, end2 = n // 4, 3 * n // 4
             start3, end3 = n // 2, n
@@ -167,7 +161,6 @@ class MathConstantHunter(Player):
             ratio3 = 0.5 * count3 / (end3 - start3)
             if abs(ratio1 - ratio2) < 0.2 and abs(ratio1 - ratio3) < 0.2:
                 return D
-
         return C
 
 
@@ -202,5 +195,4 @@ class RandomHunter(Player):
 
             if probabilities and all([abs(p - 0.5) < 0.25 for p in probabilities]):
                 return D
-
         return C

--- a/axelrod/strategies/inverse.py
+++ b/axelrod/strategies/inverse.py
@@ -1,4 +1,4 @@
-from axelrod import Player, Actions, random_choice
+from axelrod import Actions, Player, random_choice
 
 C, D = Actions.C, Actions.D
 

--- a/axelrod/strategies/lookerup.py
+++ b/axelrod/strategies/lookerup.py
@@ -1,7 +1,8 @@
-from axelrod import Player, Actions
+from axelrod import Actions, Player, init_args
 from itertools import product
 
 C, D = Actions.C, Actions.D
+
 
 class LookerUp(Player):
     """
@@ -71,6 +72,7 @@ class LookerUp(Player):
         'manipulates_state': False
     }
 
+    @init_args
     def __init__(self, lookup_table=None):
         """
         If no lookup table is provided to the constructor, then use the TFT one.
@@ -97,7 +99,6 @@ class LookerUp(Player):
         # then the memory classification is adjusted
         if self.opponent_start_plays == 0:
             self.classifier['memory_depth'] = self.plays
-        self.init_args = (lookup_table,)
 
         # Ensure that table is well-formed
         for k, v in lookup_table.items():
@@ -132,7 +133,7 @@ class EvolvedLookerUp(LookerUp):
 
     name = "EvolvedLookerUp"
 
-    def __init__(self, lookup_table=None):
+    def __init__(self):
         plays = 2
         opponent_start_plays = 2
 

--- a/axelrod/strategies/mathematicalconstants.py
+++ b/axelrod/strategies/mathematicalconstants.py
@@ -1,5 +1,6 @@
-from axelrod import Player, Actions
-from math import sqrt, pi, e
+from math import e, pi, sqrt
+
+from axelrod import Actions, Player
 
 
 class CotoDeRatio(Player):
@@ -15,15 +16,12 @@ class CotoDeRatio(Player):
     }
 
     def strategy(self, opponent):
-
         # Initially cooperate
         if len(opponent.history) == 0:
             return Actions.C
-
         # Avoid initial division by zero
         if not opponent.defections:
             return Actions.D
-
         # Otherwise compare ratio to golden mean
         cooperations = opponent.cooperations + self.cooperations
         defections = float(opponent.defections + self.defections)

--- a/axelrod/strategies/memoryone.py
+++ b/axelrod/strategies/memoryone.py
@@ -1,4 +1,4 @@
-from axelrod import Player, Actions, random_choice
+from axelrod import Actions, Player, init_args, random_choice
 
 """IPD Strategies: http://www.prisoners-dilemma.com/strategies.html"""
 
@@ -19,6 +19,7 @@ class MemoryOnePlayer(Player):
         'manipulates_state': False
     }
 
+    @init_args
     def __init__(self, four_vector=None, initial=C):
         """
         Parameters
@@ -46,7 +47,6 @@ class MemoryOnePlayer(Player):
         self._initial = initial
         if four_vector:
             self.set_four_vector(four_vector)
-        self.init_args = (four_vector, initial)
 
     def set_four_vector(self, four_vector):
         if not all(0 <= p <= 1 for p in four_vector):
@@ -71,11 +71,11 @@ class WinStayLoseShift(MemoryOnePlayer):
 
     name = 'Win-Stay Lose-Shift'
 
+    @init_args
     def __init__(self, initial=C):
         Player.__init__(self)
         self.set_four_vector([1,0,0,1])
         self._initial = initial
-        self.init_args = (initial,)
 
 
 class GTFT(MemoryOnePlayer):
@@ -114,10 +114,10 @@ class StochasticCooperator(MemoryOnePlayer):
 
     name = 'Stochastic Cooperator'
 
+    @init_args
     def __init__(self):
         four_vector = (0.935, 0.229, 0.266, 0.42)
         super(StochasticCooperator, self).__init__(four_vector)
-        self.init_args = ()
         self.set_four_vector(four_vector)
 
 
@@ -126,6 +126,7 @@ class StochasticWSLS(MemoryOnePlayer):
 
     name = 'Stochastic WSLS'
 
+    @init_args
     def __init__(self, ep=0.05):
         """
         Parameters
@@ -142,7 +143,6 @@ class StochasticWSLS(MemoryOnePlayer):
         self.ep = ep
         four_vector = (1.-ep, ep, ep, 1.-ep)
         super(StochasticWSLS, self).__init__(four_vector)
-        self.init_args = (ep,)
         self.set_four_vector(four_vector)
 
 
@@ -194,6 +194,7 @@ class ZDExtort2(LRPlayer):
 
     name = 'ZD-Extort-2'
 
+    @init_args
     def __init__(self, phi=1./9, s=0.5):
         """
         Parameters
@@ -205,7 +206,6 @@ class ZDExtort2(LRPlayer):
         self.phi = phi
         self.s = s
         super(ZDExtort2, self).__init__()
-        self.init_args = (phi, s)
 
     def receive_tournament_attributes(self):
         (R, P, S, T) = self.tournament_attributes["game"].RPST()
@@ -219,6 +219,7 @@ class ZDExtort2v2(LRPlayer):
 
     name = 'ZD-Extort-2 v2'
 
+    @init_args
     def __init__(self, phi=1./8, s=0.5, l=1):
         """
         Parameters
@@ -231,7 +232,6 @@ class ZDExtort2v2(LRPlayer):
         self.s = s
         self.l = l
         super(ZDExtort2v2, self).__init__()
-        self.init_args = (phi, s, l)
 
     def receive_tournament_attributes(self):
         super(ZDExtort2v2, self).receive_tournament_attributes(
@@ -244,6 +244,7 @@ class ZDExtort4(LRPlayer):
 
     name = 'ZD-Extort-4'
 
+    @init_args
     def __init__(self, phi=4./17, s=0.25, l=1):
         """
         Parameters
@@ -256,7 +257,6 @@ class ZDExtort4(LRPlayer):
         self.s = s
         self.l = l
         super(ZDExtort4, self).__init__()
-        self.init_args = (phi, s, l)
 
     def receive_tournament_attributes(self):
         super(ZDExtort4, self).receive_tournament_attributes(
@@ -268,6 +268,7 @@ class ZDGen2(LRPlayer):
 
     name = 'ZD-GEN-2'
 
+    @init_args
     def __init__(self, phi=1./8, s=0.5, l=3):
         """
         Parameters
@@ -280,7 +281,6 @@ class ZDGen2(LRPlayer):
         self.s = s
         self.l = l
         super(ZDGen2, self).__init__()
-        self.init_args = (phi, s, l)
 
     def receive_tournament_attributes(self):
         super(ZDGen2, self).receive_tournament_attributes(
@@ -317,6 +317,7 @@ class ZDSet2(LRPlayer):
 
     name = 'ZD-SET-2'
 
+    @init_args
     def __init__(self, phi=1./4, s=0., l=2):
         """
         Parameters
@@ -329,7 +330,6 @@ class ZDSet2(LRPlayer):
         self.s = s
         self.l = l
         super(ZDSet2, self).__init__()
-        self.init_args = (phi, s, l)
 
     def receive_tournament_attributes(self):
         super(ZDSet2, self).receive_tournament_attributes(
@@ -347,6 +347,7 @@ class SoftJoss(MemoryOnePlayer):
 
     name = "Soft Joss"
 
+    @init_args
     def __init__(self, q=0.9):
         """
         Parameters
@@ -362,7 +363,6 @@ class SoftJoss(MemoryOnePlayer):
         self.q = q
         four_vector = (1., 1 - q, 1, 1 - q)
         super(SoftJoss, self).__init__(four_vector)
-        self.init_args = (q,)
 
     def __repr__(self):
         return "%s: %s" % (self.name, round(self.q, 2))

--- a/axelrod/strategies/meta.py
+++ b/axelrod/strategies/meta.py
@@ -1,4 +1,4 @@
-from axelrod import Player, obey_axelrod, Actions
+from axelrod import Actions, Player, obey_axelrod
 from ._strategies import strategies
 from .hunter import DefectorHunter, AlternatorHunter, RandomHunter, MathConstantHunter, CycleHunter, EventualCycleHunter
 from .cooperator import Cooperator

--- a/axelrod/strategies/mindcontrol.py
+++ b/axelrod/strategies/mindcontrol.py
@@ -1,4 +1,4 @@
-from axelrod import Player, Actions
+from axelrod import Actions, Player
 
 C, D = Actions.C, Actions.D
 
@@ -23,7 +23,6 @@ class MindController(Player):
         """
 
         opponent.strategy = lambda opponent: C
-
         return D
 
 

--- a/axelrod/strategies/mindreader.py
+++ b/axelrod/strategies/mindreader.py
@@ -1,7 +1,7 @@
 import copy
 import inspect
 
-from axelrod import Player, RoundRobin, update_histories, Actions
+from axelrod import Player, RoundRobin, update_history, Actions
 
 C, D = Actions.C, Actions.D
 
@@ -10,7 +10,8 @@ def simulate_match(player_1, player_2, strategy, rounds=10):
     for match in range(rounds):
         play_1, play_2 = strategy, player_2.strategy(player_1)
         # Update histories and counts
-        update_histories(player_1, player_2, play_1, play_2)
+        update_history(player_1, play_1)
+        update_history(player_2, play_2)
 
 def roll_back_history(player, rounds):
     """Undo the last `rounds` rounds as sufficiently as possible."""

--- a/axelrod/strategies/mindreader.py
+++ b/axelrod/strategies/mindreader.py
@@ -1,7 +1,7 @@
 import copy
 import inspect
 
-from axelrod import Player, RoundRobin, update_history, Actions
+from axelrod import Actions, Player, RoundRobin, update_history
 
 C, D = Actions.C, Actions.D
 

--- a/axelrod/strategies/oncebitten.py
+++ b/axelrod/strategies/oncebitten.py
@@ -1,5 +1,5 @@
 import random
-from axelrod import Player, Actions
+from axelrod import Actions, Player, init_args
 
 C, D = Actions.C, Actions.D
 
@@ -64,10 +64,6 @@ class FoolMeOnce(Player):
         'manipulates_state': False
     }
 
-    def __init__(self):
-        Player.__init__(self)
-        self.classifier['stochastic'] = False
-
     def strategy(self, opponent):
         if not opponent.history:
             return C
@@ -91,6 +87,7 @@ class ForgetfulFoolMeOnce(Player):
         'manipulates_state': False
     }
 
+    @init_args
     def __init__(self, forget_probability = 0.05):
         """
         Parameters
@@ -102,7 +99,6 @@ class ForgetfulFoolMeOnce(Player):
         self.D_count = 0
         self._initial = C
         self.forget_probability = forget_probability
-        self.init_args = (forget_probability,)
 
     def strategy(self, opponent):
         r = random.random()

--- a/axelrod/strategies/prober.py
+++ b/axelrod/strategies/prober.py
@@ -1,6 +1,7 @@
-from axelrod import Player, Actions
+from axelrod import Actions, Player
 
 C, D = Actions.C, Actions.D
+
 
 class Prober(Player):
     """

--- a/axelrod/strategies/punisher.py
+++ b/axelrod/strategies/punisher.py
@@ -1,4 +1,4 @@
-from axelrod import Player, Actions
+from axelrod import Actions, Player
 
 C, D = Actions.C, Actions.D
 

--- a/axelrod/strategies/qlearner.py
+++ b/axelrod/strategies/qlearner.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 import random
 
-from axelrod import Player, random_choice, Actions
+from axelrod import Actions, Player, random_choice
 
 C, D = Actions.C, Actions.D
 

--- a/axelrod/strategies/rand.py
+++ b/axelrod/strategies/rand.py
@@ -1,4 +1,4 @@
-from axelrod import Player, Actions, random_choice
+from axelrod import Actions, Player, init_args, random_choice
 
 
 class Random(Player):
@@ -13,6 +13,7 @@ class Random(Player):
         'manipulates_state': False
     }
 
+    @init_args
     def __init__(self, p=0.5):
         """
         Parameters
@@ -27,7 +28,6 @@ class Random(Player):
         """
         Player.__init__(self)
         self.p = p
-        self.init_args = (p,)
 
     def strategy(self, opponent):
         return random_choice(self.p)

--- a/axelrod/strategies/retaliate.py
+++ b/axelrod/strategies/retaliate.py
@@ -1,8 +1,9 @@
 from collections import defaultdict
 
-from axelrod import Player, Actions
+from axelrod import Actions, Player, init_args
 
 C, D = Actions.C, Actions.D
+
 
 class Retaliate(Player):
     """
@@ -17,6 +18,7 @@ class Retaliate(Player):
         'manipulates_state': False
     }
 
+    @init_args
     def __init__(self, retaliation_threshold=0.1):
         """
         Uses the basic init from the Player class, but also set the name to
@@ -28,7 +30,6 @@ class Retaliate(Player):
             'Retaliate (' +
             str(self.retaliation_threshold) + ')')
         self.play_counts = defaultdict(int)
-        self.init_args = (retaliation_threshold,)
 
     def strategy(self, opponent):
         """
@@ -85,6 +86,7 @@ class LimitedRetaliate(Player):
         'manipulates_state': False
     }
 
+    @init_args
     def __init__(self, retaliation_threshold=0.1, retaliation_limit=20):
         """
         Parameters

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -1,4 +1,4 @@
-from axelrod import Player, Actions, flip_action
+from axelrod import Actions, Player, init_args, flip_action
 
 C, D = Actions.C, Actions.D
 
@@ -212,10 +212,11 @@ class OmegaTFT(Player):
         'manipulates_state': False
     }
 
-    def __init__(self):
+    @init_args
+    def __init__(self, deadlock_threshold=3, randomness_threshold=8):
         Player.__init__(self)
-        self.deadlock_threshold = 3
-        self.randomness_threshold = 8
+        self.deadlock_threshold = deadlock_threshold
+        self.randomness_threshold = randomness_threshold
         self.randomness_counter = 0
         self.deadlock_counter = 0
 

--- a/axelrod/tests/unit/test_mock_player.py
+++ b/axelrod/tests/unit/test_mock_player.py
@@ -1,7 +1,7 @@
 import unittest
 import axelrod
 
-from axelrod import MockPlayer, simulate_play, update_histories
+from axelrod import MockPlayer, simulate_play, update_history
 from axelrod.tests.unit.test_player import TestOpponent
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
@@ -38,7 +38,8 @@ class TestUpdateHistories(unittest.TestCase):
     def test_various(self):
         p1 = TestOpponent()
         p2 = TestOpponent()
-        update_histories(p1, p2, C, C)
+        update_history(p1, C)
+        update_history(p2, C)
         self.assertEqual(p1.history, [C])
         self.assertEqual(p2.history, [C])
         self.assertEqual(p1.cooperations, 1)
@@ -46,7 +47,8 @@ class TestUpdateHistories(unittest.TestCase):
         self.assertEqual(p1.defections, 0)
         self.assertEqual(p2.defections, 0)
 
-        update_histories(p1, p2, D, D)
+        update_history(p1, D)
+        update_history(p2, D)
         self.assertEqual(p1.history, [C, D])
         self.assertEqual(p2.history, [C, D])
         self.assertEqual(p1.cooperations, 1)
@@ -91,6 +93,3 @@ class TestSimulatePlay(unittest.TestCase):
 
         self.assertEqual(p1.history, [C] * 2)
         self.assertEqual(p2.history, [D] * 2)
-
-
-

--- a/axelrod/tests/unit/test_player.py
+++ b/axelrod/tests/unit/test_player.py
@@ -150,10 +150,17 @@ class TestPlayer(unittest.TestCase):
 
     def test_clone(self):
         # Make sure that self.init_args has the right number of arguments
-        p1 = self.player()
-        argspec = inspect.getargspec(p1.__init__)
-        self.assertEqual(len(argspec.args) - 1, len(p1.init_args))
+        PlayerClass = self.player
+        argspec = inspect.getargspec(PlayerClass.__init__)
+        # Does the class use the init_args decorator?
+        if argspec.varargs == "args":
+            self.assertEqual(len(argspec.args), 1)
+        else:
+            player = PlayerClass()
+            self.assertEqual(len(argspec.args) - 1, len(player.init_args))
+
         # Test that the player is cloned correctly
+        p1 = self.player()
         p2 = p1.clone()
         self.assertEqual(len(p2.history), 0)
         self.assertEqual(p2.cooperations, 0)

--- a/docs/tutorials/contributing/strategy/writing_the_new_strategy.rst
+++ b/docs/tutorials/contributing/strategy/writing_the_new_strategy.rst
@@ -125,6 +125,10 @@ This helps distinguish players in tournaments that have multiple instances of th
 same strategy. If you modify the `__repr__` method of player, be sure to add an
 appropriate test.
 
+Similarly, if your strategy's `__init__` method takes any parameters other than
+`self`, you can decorate it with `@init_args` to ensure that when it is cloned that
+the correct parameter values will be applied. (This will trip a test if ommitted.)
+
 There are various examples of helpful functions and properties that make
 writing strategies easier. Do not hesitate to get in touch with the
 Axelrod-Python team for guidance.


### PR DESCRIPTION
In attempt to make adding new strategies easier, I added a decorator so you can do this:

```
    @init_args
    def __init__(self, p=0.5):
        ...
```
and not have to put `self.init_args = (p,)` in the `__init__` method (or understand why).

I also did some various PEP8 while I was looking over all the strategies.