### PR TITLE
Plotting: New colormaps and image format passthrough

### DIFF
--- a/axelrod/plot.py
+++ b/axelrod/plot.py
@@ -5,11 +5,21 @@ from warnings import warn
 
 matplotlib_installed = True
 try:
+    import matplotlib
     import matplotlib.pyplot as plt
     import matplotlib.transforms as transforms
     from mpl_toolkits.axes_grid1 import make_axes_locatable
 except ImportError:
     matplotlib_installed = False
+
+
+def default_cmap():
+    """Sets a default matplotlib colormap based on the version."""
+    s = matplotlib.__version__.split('.')
+    if int(s[0]) >= 1 and int(s[1]) >= 5:
+        return "viridis"
+    else:
+        return 'YlGnBu'
 
 
 class Plot(object):
@@ -200,7 +210,8 @@ class Plot(object):
         figure, ax = plt.subplots()
         figure.set_figwidth(width)
         figure.set_figheight(height)
-        mat = ax.matshow(data, cmap='YlGnBu')
+        cmap = default_cmap()
+        mat = ax.matshow(data, cmap=cmap)
         plt.xticks(range(self.result_set.nplayers))
         plt.yticks(range(self.result_set.nplayers))
         ax.set_xticklabels(names, rotation=90)

--- a/axelrod/tournament_manager.py
+++ b/axelrod/tournament_manager.py
@@ -13,7 +13,7 @@ class TournamentManager(object):
 
     def __init__(self, output_directory, with_ecological,
                  pass_cache=True, load_cache=True, save_cache=False,
-                 cache_file='./cache.txt'):
+                 cache_file='./cache.txt', image_format="svg"):
         self._tournaments = []
         self._ecological_variants = []
         self._logger = logging.getLogger(__name__)
@@ -25,6 +25,7 @@ class TournamentManager(object):
         self._deterministic_cache = {}
         self._cache_valid_for_turns = None
         self._load_cache = False
+        self._image_format=image_format
 
         if load_cache and not save_cache:
             self.load_cache = self._load_cache_from_file(cache_file)
@@ -110,7 +111,8 @@ class TournamentManager(object):
 
     def _generate_output_files(self, tournament, ecosystem=None):
         self._save_csv(tournament)
-        self._save_plots(tournament, ecosystem)
+        self._save_plots(tournament, ecosystem,
+                         image_format=self._image_format)
 
     def _save_csv(self, tournament):
         csv = tournament.result_set.csv()

--- a/axelrod/tournament_manager_factory.py
+++ b/axelrod/tournament_manager_factory.py
@@ -19,20 +19,22 @@ class TournamentManagerFactory(object):
             processes,
             turns,
             repetitions,
-            noise):
+            noise,
+            image_format="svg"):
 
         kwargs = {
             'processes': processes,
             'turns': turns,
             'repetitions': repetitions,
-            'noise': noise
+            'noise': noise,
         }
 
         manager = axelrod.TournamentManager(
             output_directory=output_directory,
             with_ecological=not no_ecological,
             save_cache=rebuild_cache,
-            cache_file=cache_file)
+            cache_file=cache_file,
+            image_format=image_format)
 
         cls._add_tournaments(manager, exclusions, kwargs)
 

--- a/axelrod/utils.py
+++ b/axelrod/utils.py
@@ -45,7 +45,8 @@ def run_tournaments(cache_file='./cache.txt',
                     exclude_basic=False,
                     exclude_cheating=False,
                     exclude_ordinary=False,
-                    noise=0):
+                    noise=0,
+                    image_format="svg"):
 
     exclusions_dict = {
         'basic_strategies': exclude_basic,
@@ -64,6 +65,7 @@ def run_tournaments(cache_file='./cache.txt',
         processes=processes,
         turns=turns,
         repetitions=repetitions,
-        noise=noise)
+        noise=noise,
+        image_format=image_format)
 
     manager.run_tournaments()

--- a/docs/tutorials/getting_started/command_line.rst
+++ b/docs/tutorials/getting_started/command_line.rst
@@ -26,6 +26,7 @@ Particular parameters can also be changed:
 
 - The output directory for the plot and csv files.
 - The number of turns and repetitions for the tournament.
+- The format of created images
 
 Here is a command that will run the whole tournament, excluding the strategies
 that do not obey Axelrod's original rules and using all available CPUS (this can

--- a/run_axelrod
+++ b/run_axelrod
@@ -100,6 +100,12 @@ if __name__ == "__main__":
         default=0,
         help='Noise level')
 
+    parser.add_argument(
+        '-i', '--image_format',
+        type=str,
+        default="svg",
+        help='Image format for matplotlib, e.g. svg, jpeg, png')
+
     args = parser.parse_args()
 
     if all([args.exclude_basic,


### PR DESCRIPTION
Closes #420.

This is a hard one to write tests for, so here are some images that I produced. For matplotlib < 1.5:

![](http://s7.postimg.org/56z838j97/plot.png)

For 1.5+

![](http://s12.postimg.org/e90susnzx/plot.png)

You can also now pass `-i png` (or other format) to run_axelrod down through to TournamentManager.