### PR TITLE
Ensure `doctest` runner doesn't always exit 0

### DIFF
--- a/doctest
+++ b/doctest
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+set -e
+
 python -m doctest docs/tutorials/getting_started/*rst
 python -m doctest docs/tutorials/further_topics/*rst
 python -m doctest docs/reference/*rst


### PR DESCRIPTION
Note that this does mean they're run serially; there's probably a better way to do this, but this should be an improvement over "always succeed"!