### PR TITLE
Pin dependency versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,7 @@ before_install:
   - sh -e /etc/init.d/xvfb start
 install:
   - pip install -r requirements.txt
-  - pip install sphinx
-  - pip install coverage
-  - pip install coveralls
+  - pip install -r requirements-test.txt
 script:
   # Build the documentation
   - cd docs; make html

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+Sphinx==1.3.1
+coverage==4.0.3
+coveralls==1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-numpy>=1.9.2
-matplotlib>=1.4.2
+numpy==1.10.1
+matplotlib==1.5.0
 cloudpickle==0.1.1


### PR DESCRIPTION
Because explicit version pins mean consistently reproducible builds, and consistently reproducible builds are A Good Thing, and "hm suddenly the build is breaking, oh it's because a new backwards-incompatible version of numpy was released" is A Bad Thing

I'd suggest also pointing requires.io at this, and then you'll get notified of dependency updates.