### PR TITLE
Improved doctest discovery / runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,6 @@ script:
   - coverage run --source=axelrod -m unittest discover
   - coverage report -m
   # Run the doctests
-  #- sh doctest
-  - python -m doctest docs/tutorials/getting_started/*rst
-  - python -m doctest docs/tutorials/further_topics/*rst
-  - python -m doctest docs/reference/*rst
-  - python -m doctest docs/tutorials/contributing/strategy/*rst
-  - python -m doctest docs/tutorials/advanced/strategy_transformers.rst
+  - python doctests.py
 after_success:
   - coveralls

--- a/doctest
+++ b/doctest
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-python -m doctest docs/tutorials/getting_started/*rst
-python -m doctest docs/tutorials/further_topics/*rst
-python -m doctest docs/reference/*rst
-python -m doctest docs/tutorials/contributing/strategy/*rst
-python -m doctest docs/tutorials/advanced/strategy_transformers.rst

--- a/doctests.py
+++ b/doctests.py
@@ -1,0 +1,16 @@
+import doctest
+import os
+import unittest
+
+
+def load_tests(loader, tests, ignore):
+    for root, dirs, files in os.walk("./docs"):
+        for f in files:
+            if f.endswith(".rst"):
+                 tests.addTests(doctest.DocFileSuite(os.path.join(root, f)))
+
+    return tests
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
@drvinceknight Think #439 but better - NOW it aggregates failures

This isn't _much_ more than a cosmetic fix, but it does mean there's One True Command to run doctests, AND it just finds all the `rst` files, rather than a dir-by-dir enumeration