### PR TITLE
Adding travis notifications to gitter chat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,8 @@ script:
   - python doctests.py
 after_success:
   - coveralls
+notifications:
+    webhooks:
+        urls:
+            - https://webhooks.gitter.im/e/3cc093037c0df458209d
+


### PR DESCRIPTION
Travis build notifcations should now appear in the activity bar in the Gitter chat room