### PR TITLE
447 - Adding a Mixed decorator **and** metaplayer

### DIFF
--- a/axelrod/strategies/__init__.py
+++ b/axelrod/strategies/__init__.py
@@ -9,13 +9,13 @@ from .meta import (
     MetaPlayer, MetaMajority, MetaMinority, MetaWinner, MetaHunter,
     MetaMajorityMemoryOne, MetaWinnerMemoryOne, MetaMajorityFiniteMemory,
     MetaWinnerFiniteMemory, MetaMajorityLongMemory, MetaWinnerLongMemory,
-    MetaMutater
+    MetaMixer
     )
 
 strategies.extend((MetaHunter, MetaMajority, MetaMinority, MetaWinner,
                    MetaMajorityMemoryOne, MetaWinnerMemoryOne,
                    MetaMajorityFiniteMemory, MetaWinnerFiniteMemory,
-                   MetaMajorityLongMemory, MetaWinnerLongMemory, MetaMutater))
+                   MetaMajorityLongMemory, MetaWinnerLongMemory, MetaMixer))
 
 # Distinguished strategy collections in addition to
 # `strategies` from _strategies.py

--- a/axelrod/strategies/__init__.py
+++ b/axelrod/strategies/__init__.py
@@ -8,13 +8,14 @@ from ._strategies import *
 from .meta import (
     MetaPlayer, MetaMajority, MetaMinority, MetaWinner, MetaHunter,
     MetaMajorityMemoryOne, MetaWinnerMemoryOne, MetaMajorityFiniteMemory,
-    MetaWinnerFiniteMemory, MetaMajorityLongMemory, MetaWinnerLongMemory
+    MetaWinnerFiniteMemory, MetaMajorityLongMemory, MetaWinnerLongMemory,
+    MetaMutater
     )
 
 strategies.extend((MetaHunter, MetaMajority, MetaMinority, MetaWinner,
                    MetaMajorityMemoryOne, MetaWinnerMemoryOne,
                    MetaMajorityFiniteMemory, MetaWinnerFiniteMemory,
-                   MetaMajorityLongMemory, MetaWinnerLongMemory))
+                   MetaMajorityLongMemory, MetaWinnerLongMemory, MetaMutater))
 
 # Distinguished strategy collections in addition to
 # `strategies` from _strategies.py

--- a/axelrod/strategies/meta.py
+++ b/axelrod/strategies/meta.py
@@ -269,10 +269,12 @@ class MetaWinnerLongMemory(MetaWinner):
         self.init_args = ()
 
 
-class MetaMutater(MetaPlayer):
-    """A player who randomly switch between a team of players.
+class MetaMixer(MetaPlayer):
+    """A player who randomly switches between a team of players.
     If no distribution is passed then the player will uniformly choose between
     sub players.
+
+    In essence this is creating a Mixed strategy.
 
     Parameters
     ----------
@@ -284,7 +286,7 @@ class MetaMutater(MetaPlayer):
         If none is passed will select uniformly.
     """
 
-    name = "Meta Mutater"
+    name = "Meta Mixer"
 
     def __init__(self, team=None, distribution=None):
 
@@ -298,7 +300,7 @@ class MetaMutater(MetaPlayer):
 
         self.distribution = distribution
 
-        super(MetaMutater, self).__init__()
+        super(MetaMixer, self).__init__()
         self.init_args = (team, distribution)
 
     def meta_strategy(self, results, opponent):

--- a/axelrod/strategy_transformers.py
+++ b/axelrod/strategy_transformers.py
@@ -249,12 +249,12 @@ def mixed_wrapper(player, opponent, action, probability, m_player):
     """
 
     # If a single probability, player is passed
-    if type(probability) in [float, int]:
+    if isinstance(probability, float) or isinstance(probability, int):
         m_player = [m_player]
         probability = [probability]
 
     # If a probability distribution, players is passed
-    if type(probability) == type(m_player) is list:
+    if isinstance(probability, list) and isinstance(m_player, list):
         mutate_prob = sum(probability)  # Prob of mutation
         if mutate_prob > 0:
             # Distribution of choice of mutation:

--- a/axelrod/strategy_transformers.py
+++ b/axelrod/strategy_transformers.py
@@ -9,6 +9,7 @@ See the various Meta strategies for another type of transformation.
 import inspect
 import random
 from types import FunctionType
+from numpy.random import choice
 
 from .actions import Actions, flip_action
 from .random_ import random_choice
@@ -239,6 +240,31 @@ def apology_wrapper(player, opponent, action, myseq, opseq):
 ApologyTransformer = StrategyTransformerFactory(apology_wrapper,
                                                 name_prefix="Apologizing")
 
+
+def mutate_wrapper(player, opponent, action, probability, m_player):
+    """"""
+
+    # If a single probability, player is passed
+    if type(probability) in [float, int]:
+        m_player = [m_player]
+        probability = [probability]
+
+    # If a probability distribution, players is passed
+    if type(probability) == type(m_player) is list:
+        mutate_prob = sum(probability)  # Prob of mutation
+        if mutate_prob > 0:
+            # Distribution of choice of mutation:
+            normalised_prob = [prob / float(mutate_prob)
+                               for prob in probability]
+            if random.random() < mutate_prob:
+                p = choice(m_player, p=normalised_prob)()
+                p.history = player.history
+                return p.strategy(opponent)
+
+    return action
+
+MutateTransformer = StrategyTransformerFactory(mutate_wrapper, name_prefix="Mutated")
+
 # Strategy wrappers as classes
 
 class RetaliationWrapper(object):
@@ -259,6 +285,7 @@ class RetaliationWrapper(object):
 
 RetaliationTransformer = StrategyTransformerFactory(
     RetaliationWrapper(), name_prefix="Retaliating")
+
 
 class RetaliationUntilApologyWrapper(object):
     """Enforces the TFT rule that the opponent pay back a defection with a

--- a/axelrod/strategy_transformers.py
+++ b/axelrod/strategy_transformers.py
@@ -8,7 +8,7 @@ See the various Meta strategies for another type of transformation.
 
 import inspect
 import random
-from types import FunctionType
+import collections
 from numpy.random import choice
 
 from .actions import Actions, flip_action
@@ -246,6 +246,16 @@ def mixed_wrapper(player, opponent, action, probability, m_player):
     of players or a single player.
 
     In essence creating a mixed strategy.
+
+    Parameters
+    ----------
+
+    probability: a float (or integer: 0 or 1) OR an iterable representing a
+        an incomplete probability distribution (entries to do not have to sum to
+        1). Eg: 0, 1, [.5,.5], (.5,.3)
+    m_players: a single player class or iterable representing set of player
+        classes to mix from.
+        Eg: axelrod.TitForTat, [axelod.Cooperator, axelrod.Defector]
     """
 
     # If a single probability, player is passed
@@ -254,14 +264,15 @@ def mixed_wrapper(player, opponent, action, probability, m_player):
         probability = [probability]
 
     # If a probability distribution, players is passed
-    if isinstance(probability, list) and isinstance(m_player, list):
+    if isinstance(probability, collections.Iterable) and \
+            isinstance(m_player, collections.Iterable):
         mutate_prob = sum(probability)  # Prob of mutation
         if mutate_prob > 0:
             # Distribution of choice of mutation:
             normalised_prob = [prob / float(mutate_prob)
                                for prob in probability]
             if random.random() < mutate_prob:
-                p = choice(m_player, p=normalised_prob)()
+                p = choice(list(m_player), p=normalised_prob)()
                 p.history = player.history
                 return p.strategy(opponent)
 

--- a/axelrod/strategy_transformers.py
+++ b/axelrod/strategy_transformers.py
@@ -241,9 +241,12 @@ ApologyTransformer = StrategyTransformerFactory(apology_wrapper,
                                                 name_prefix="Apologizing")
 
 
-def mutate_wrapper(player, opponent, action, probability, m_player):
+def mixed_wrapper(player, opponent, action, probability, m_player):
     """Randomly picks a strategy to play, either from a distribution on a list
-    of players or a single player."""
+    of players or a single player.
+
+    In essence creating a mixed strategy.
+    """
 
     # If a single probability, player is passed
     if type(probability) in [float, int]:
@@ -264,7 +267,7 @@ def mutate_wrapper(player, opponent, action, probability, m_player):
 
     return action
 
-MutateTransformer = StrategyTransformerFactory(mutate_wrapper, name_prefix="Mutated")
+MixedTransformer = StrategyTransformerFactory(mixed_wrapper, name_prefix="Mutated")
 
 # Strategy wrappers as classes
 

--- a/axelrod/strategy_transformers.py
+++ b/axelrod/strategy_transformers.py
@@ -242,7 +242,8 @@ ApologyTransformer = StrategyTransformerFactory(apology_wrapper,
 
 
 def mutate_wrapper(player, opponent, action, probability, m_player):
-    """"""
+    """Randomly picks a strategy to play, either from a distribution on a list
+    of players or a single player."""
 
     # If a single probability, player is passed
     if type(probability) in [float, int]:

--- a/axelrod/tests/unit/test_meta.py
+++ b/axelrod/tests/unit/test_meta.py
@@ -286,10 +286,10 @@ class TestMetaWinnerLongMemory(TestMetaPlayer):
         self.first_play_test(C)
 
 
-class TestMetaMutater(TestMetaPlayer):
+class TestMetaMixer(TestMetaPlayer):
 
-    name = "Meta Mutater"
-    player = axelrod.MetaMutater
+    name = "Meta Mixer"
+    player = axelrod.MetaMixer
     expected_classifier = {
         'memory_depth': float('inf'),  # Long memory
         'stochastic': True,
@@ -303,7 +303,7 @@ class TestMetaMutater(TestMetaPlayer):
         team = [axelrod.TitForTat, axelrod.Cooperator, axelrod.Grudger]
         distribution = [.2, .5, .3]
 
-        P1 = axelrod.MetaMutater(team, distribution)
+        P1 = axelrod.MetaMixer(team, distribution)
         P2 = axelrod.Cooperator()
 
         for k in range(100):
@@ -312,14 +312,14 @@ class TestMetaMutater(TestMetaPlayer):
         team.append(axelrod.Defector)
         distribution = [.2, .5, .3, 0]  # If add a defector but does not occur
 
-        P1 = axelrod.MetaMutater(team, distribution)
+        P1 = axelrod.MetaMixer(team, distribution)
 
         for k in range(100):
             self.assertEqual(P1.strategy(P2), C)
 
         distribution = [0, 0, 0, 1]  # If defector is only one that is played
 
-        P1 = axelrod.MetaMutater(team, distribution)
+        P1 = axelrod.MetaMixer(team, distribution)
 
         for k in range(100):
             self.assertEqual(P1.strategy(P2), D)
@@ -328,7 +328,7 @@ class TestMetaMutater(TestMetaPlayer):
         team = [axelrod.TitForTat, axelrod.Cooperator, axelrod.Grudger]
         distribution = [.2, .5, .5]  # Not a valid probability distribution
 
-        P1 = axelrod.MetaMutater(team, distribution)
+        P1 = axelrod.MetaMixer(team, distribution)
         P2 = axelrod.Cooperator()
 
         self.assertRaises(ValueError, P1.strategy, P2)

--- a/axelrod/tests/unit/test_meta.py
+++ b/axelrod/tests/unit/test_meta.py
@@ -284,3 +284,51 @@ class TestMetaWinnerLongMemory(TestMetaPlayer):
 
     def test_strategy(self):
         self.first_play_test(C)
+
+
+class TestMetaMutater(TestMetaPlayer):
+
+    name = "Meta Mutater"
+    player = axelrod.MetaMutater
+    expected_classifier = {
+        'memory_depth': float('inf'),  # Long memory
+        'stochastic': True,
+        'manipulates_source': False,
+        'inspects_source': False,
+        'manipulates_state': False
+    }
+
+    def test_strategy(self):
+
+        team = [axelrod.TitForTat, axelrod.Cooperator, axelrod.Grudger]
+        distribution = [.2, .5, .3]
+
+        P1 = axelrod.MetaMutater(team, distribution)
+        P2 = axelrod.Cooperator()
+
+        for k in range(100):
+            self.assertEqual(P1.strategy(P2), C)
+
+        team.append(axelrod.Defector)
+        distribution = [.2, .5, .3, 0]  # If add a defector but does not occur
+
+        P1 = axelrod.MetaMutater(team, distribution)
+
+        for k in range(100):
+            self.assertEqual(P1.strategy(P2), C)
+
+        distribution = [0, 0, 0, 1]  # If defector is only one that is played
+
+        P1 = axelrod.MetaMutater(team, distribution)
+
+        for k in range(100):
+            self.assertEqual(P1.strategy(P2), D)
+
+    def test_raise_error_in_distribution(self):
+        team = [axelrod.TitForTat, axelrod.Cooperator, axelrod.Grudger]
+        distribution = [.2, .5, .5]  # Not a valid probability distribution
+
+        P1 = axelrod.MetaMutater(team, distribution)
+        P2 = axelrod.Cooperator()
+
+        self.assertRaises(ValueError, P1.strategy, P2)

--- a/axelrod/tests/unit/test_strategy_transformers.py
+++ b/axelrod/tests/unit/test_strategy_transformers.py
@@ -13,7 +13,7 @@ C, D = axelrod.Actions.C, axelrod.Actions.D
 class TestTransformers(unittest.TestCase):
 
     def test_all_strategies(self):
-        # Attempt to transform each strategy to ensure that implemenation
+        # Attempt to transform each strategy to ensure that implementation
         # choices (like use of super) do not cause issues
         for s in axelrod.ordinary_strategies:
             opponent = axelrod.Cooperator()

--- a/axelrod/tests/unit/test_strategy_transformers.py
+++ b/axelrod/tests/unit/test_strategy_transformers.py
@@ -212,6 +212,53 @@ class TestTransformers(unittest.TestCase):
             p1.play(p2)
         self.assertEqual(p1.history, [D, D, C, D, D, C])
 
+    def test_mutate(self):
+        """Tests the MutateTransformer."""
+        probability = 1
+        MD = MutateTransformer(probability, axelrod.Cooperator)(axelrod.Defector)
+
+        p1 = MD()
+        p2 = axelrod.Cooperator()
+        for _ in range(5):
+            p1.play(p2)
+        self.assertEqual(p1.history, [C, C, C, C, C])
+
+        probability = 0
+        MD = MutateTransformer(probability, axelrod.Cooperator)(axelrod.Defector)
+
+        p1 = MD()
+        p2 = axelrod.Cooperator()
+        for _ in range(5):
+            p1.play(p2)
+        self.assertEqual(p1.history, [D, D, D, D, D])
+
+        # Decorating with list and distribution
+
+        # Decorate a cooperator putting all weight on other strategies that are
+        # 'nice'
+        probability = [.3, .2, 0]
+        strategies = [axelrod.TitForTat, axelrod.Grudger, axelrod.Defector]
+        MD = MutateTransformer(probability, strategies)(axelrod.Cooperator)
+
+        p1 = MD()
+        # Against a cooperator we see that we only cooperate
+        p2 = axelrod.Cooperator()
+        for _ in range(5):
+            p1.play(p2)
+        self.assertEqual(p1.history, [C, C, C, C, C])
+
+        # Decorate a cooperator putting all weight on Defector
+        probability = [0, 0, 1]
+        strategies = [axelrod.TitForTat, axelrod.Grudger, axelrod.Defector]
+        MD = MutateTransformer(probability, strategies)(axelrod.Cooperator)
+
+        p1 = MD()
+        # Against a cooperator we see that we only cooperate
+        p2 = axelrod.Cooperator()
+        for _ in range(5):
+            p1.play(p2)
+        self.assertEqual(p1.history, [D, D, D, D, D])
+
     def test_deadlock(self):
         """Test the DeadlockBreakingTransformer."""
         # We can induce a deadlock by alterting TFT to defect first

--- a/axelrod/tests/unit/test_strategy_transformers.py
+++ b/axelrod/tests/unit/test_strategy_transformers.py
@@ -213,9 +213,9 @@ class TestTransformers(unittest.TestCase):
         self.assertEqual(p1.history, [D, D, C, D, D, C])
 
     def test_mutate(self):
-        """Tests the MutateTransformer."""
+        """Tests the MixedTransformer."""
         probability = 1
-        MD = MutateTransformer(probability, axelrod.Cooperator)(axelrod.Defector)
+        MD = MixedTransformer(probability, axelrod.Cooperator)(axelrod.Defector)
 
         p1 = MD()
         p2 = axelrod.Cooperator()
@@ -224,7 +224,7 @@ class TestTransformers(unittest.TestCase):
         self.assertEqual(p1.history, [C, C, C, C, C])
 
         probability = 0
-        MD = MutateTransformer(probability, axelrod.Cooperator)(axelrod.Defector)
+        MD = MixedTransformer(probability, axelrod.Cooperator)(axelrod.Defector)
 
         p1 = MD()
         p2 = axelrod.Cooperator()
@@ -238,7 +238,7 @@ class TestTransformers(unittest.TestCase):
         # 'nice'
         probability = [.3, .2, 0]
         strategies = [axelrod.TitForTat, axelrod.Grudger, axelrod.Defector]
-        MD = MutateTransformer(probability, strategies)(axelrod.Cooperator)
+        MD = MixedTransformer(probability, strategies)(axelrod.Cooperator)
 
         p1 = MD()
         # Against a cooperator we see that we only cooperate
@@ -250,7 +250,7 @@ class TestTransformers(unittest.TestCase):
         # Decorate a cooperator putting all weight on Defector
         probability = [0, 0, 1]
         strategies = [axelrod.TitForTat, axelrod.Grudger, axelrod.Defector]
-        MD = MutateTransformer(probability, strategies)(axelrod.Cooperator)
+        MD = MixedTransformer(probability, strategies)(axelrod.Cooperator)
 
         p1 = MD()
         # Against a cooperator we see that we only cooperate

--- a/axelrod/tests/unit/test_strategy_transformers.py
+++ b/axelrod/tests/unit/test_strategy_transformers.py
@@ -212,7 +212,7 @@ class TestTransformers(unittest.TestCase):
             p1.play(p2)
         self.assertEqual(p1.history, [D, D, C, D, D, C])
 
-    def test_mutate(self):
+    def test_mixed(self):
         """Tests the MixedTransformer."""
         probability = 1
         MD = MixedTransformer(probability, axelrod.Cooperator)(axelrod.Defector)
@@ -248,7 +248,7 @@ class TestTransformers(unittest.TestCase):
         self.assertEqual(p1.history, [C, C, C, C, C])
 
         # Decorate a cooperator putting all weight on Defector
-        probability = [0, 0, 1]
+        probability = (0, 0, 1)  # Note can also pass tuple
         strategies = [axelrod.TitForTat, axelrod.Grudger, axelrod.Defector]
         MD = MixedTransformer(probability, strategies)(axelrod.Cooperator)
 

--- a/docs/tutorials/advanced/strategy_transformers.rst
+++ b/docs/tutorials/advanced/strategy_transformers.rst
@@ -132,22 +132,22 @@ after two consequtive rounds of `(D, C)`::
     >>> from axelrod.strategy_transformers import TrackHistoryTransformer
     >>> player = TrackHistoryTransformer(axelrod.Random)()
 
-* :code:`MutateTransformer`: Randomly plays a mutation to another strategy (or
+* :code:`MixedTransformer`: Randomly plays a mutation to another strategy (or
   set of strategies. Here is the syntax to do this with a set of strategies::
 
     >>> import axelrod
-    >>> from axelrod.strategy_transformers import MutateTransformer
+    >>> from axelrod.strategy_transformers import MixedTransformer
     >>> strategies = [axelrod.Grudger, axelrod.TitForTat]
     >>> probability = [.2, .3]  # .5 chance of mutated to one of above
-    >>> player =  MutateTransformer(probability, strategies)(axelrod.Cooperator)
+    >>> player =  MixedTransformer(probability, strategies)(axelrod.Cooperator)
 
   Here is the syntax when passing a single strategy::
 
     >>> import axelrod
-    >>> from axelrod.strategy_transformers import MutateTransformer
+    >>> from axelrod.strategy_transformers import MixedTransformer
     >>> strategy = axelrod.Grudger
     >>> probability = .2
-    >>> player =  MutateTransformer(probability, strategy)(axelrod.Cooperator)
+    >>> player =  MixedTransformer(probability, strategy)(axelrod.Cooperator)
 
 
 Composing Transformers

--- a/docs/tutorials/advanced/strategy_transformers.rst
+++ b/docs/tutorials/advanced/strategy_transformers.rst
@@ -132,6 +132,23 @@ after two consequtive rounds of `(D, C)`::
     >>> from axelrod.strategy_transformers import TrackHistoryTransformer
     >>> player = TrackHistoryTransformer(axelrod.Random)()
 
+* :code:`MutateTransformer`: Randomly plays a mutation to another strategy (or
+  set of strategies. Here is the syntax to do this with a set of strategies::
+
+    >>> import axelrod
+    >>> from axelrod.strategy_transformers import MutateTransformer
+    >>> strategies = [axelrod.Grudger, axelrod.TitForTat]
+    >>> probability = [.2, .3]  # .5 chance of mutated to one of above
+    >>> player =  MutateTransformer(probability, strategies)(axelrod.Cooperator)
+
+  Here is the syntax when passing a single strategy::
+
+    >>> import axelrod
+    >>> from axelrod.strategy_transformers import MutateTransformer
+    >>> strategy = axelrod.Grudger
+    >>> probability = .2
+    >>> player =  MutateTransformer(probability, strategy)(axelrod.Cooperator)
+
 
 Composing Transformers
 ----------------------

--- a/docs/tutorials/further_topics/classification_of_strategies.rst
+++ b/docs/tutorials/further_topics/classification_of_strategies.rst
@@ -24,7 +24,7 @@ This allows us to, for example, quickly identify all the stochastic
 strategies::
 
     >>> len([s for s in axl.strategies if s().classifier['stochastic']])
-    36
+    37
 
 Or indeed find out how many strategy only use 1 turn worth of memory to
 make a decision::
@@ -37,13 +37,13 @@ tournament. For example, here is the number of strategies that  make use of the
 length of each match of the tournament::
 
     >>> len([s() for s in axl.strategies if 'length' in s().classifier['makes_use_of']])
-    8
+    9
 
 Here are how many of the strategies that make use of the particular game being
 played (whether or not it's the default Prisoner's dilemma)::
 
     >>> len([s() for s in axl.strategies if 'game' in s().classifier['makes_use_of']])
-    20
+    21
 
 Similarly, strategies that :code:`manipulate_source`, :code:`manipulate_state`
 and/or :code:`inspect_source` return :code:`False` for the :code:`obey_axelrod`


### PR DESCRIPTION
This adds the ability to make random mutations on a player (transform) **or** create a metaplayer that randomly switches between a team of players.
