### PR TITLE
Change depth for docs.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,3 @@
-.. image:: https://badge.waffle.io/Axelrod-Python/Axelrod.svg?label=ready&title=Ready
-    :target: https://waffle.io/Axelrod-Python/Axelrod
-
 .. image:: https://coveralls.io/repos/Axelrod-Python/Axelrod/badge.svg
     :target: https://coveralls.io/r/Axelrod-Python/Axelrod
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ Welcome to the documentation for the Axelrod Python library
 ===========================================================
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
 
    tutorials/index.rst
    reference/index.rst


### PR DESCRIPTION
I thought the landing page for the documentation isn't actually that helpful. You are met by the 3 levels of tutorials but no information about what is in them.

Here is a screenshot of what this change looks like:

![screenshot 2015-12-08 18 20 33](https://cloud.githubusercontent.com/assets/2131546/11664256/95d99444-9dd8-11e5-9a7f-c24ffd725694.png)


What does everyone think?