### PR TITLE
431 - Minor fix of README following change to tournament repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,17 +85,9 @@ Results
 =======
 
 A tournament with the full set of strategies from the library can be found at
-https://github.com/Axelrod-Python/tournament. Here is the latest graphical
-version of the results:
+https://github.com/Axelrod-Python/tournament. These results can be easily viewed
+at http://axelrod-tournament.readthedocs.org.
 
-.. image:: http://axelrod-python.github.io/tournament/assets/strategies_boxplot.svg
-   :width: 100%
-
-.. image:: http://axelrod-python.github.io/tournament/assets/strategies_winplot.svg
-   :width: 100%
-
-See the `tournament repository <https://github.com/Axelrod-Python/tournament>`_
-for many additional plots.
 
 Contributing
 ============

--- a/docs/tutorials/getting_started/command_line.rst
+++ b/docs/tutorials/getting_started/command_line.rst
@@ -7,12 +7,12 @@ of the strategies from the library. You can view them at `Axelrod-Python/tournam
 
 To view the help for the :code:`run_axelrod` file run::
 
-    $ run_axelrod.py -h
+    $ run_axelrod -h
 
 Note that if you have not installed the package you can still use this script
 directly from the repository::
 
-    $ python run_axelrod -h
+    $ run_axelrod -h
 
 There is a variety of options that include:
 
@@ -33,13 +33,5 @@ take quite a while!)::
 
     $ run_axelrod --xc -p 0
 
-Here are some of the plots that are output when running with the latest total number of strategies:
-
-The results from the tournament itself (ordered by median score):
-
-.. raw:: html
-
-   <img src="http://axelrod-python.github.io/tournament/assets/strategies_boxplot.svg" style="width: 50%; align: center">
-
-This is just a brief overview of what the tool can do, take a look at the help
-to see all the options.
+You can see results from various tournaments here:
+http://axelrod-tournament.readthedocs.org/en/latest/


### PR DESCRIPTION
After creating http://axelrod-tournament.readthedocs.org/en/latest/ I've made some minor tweaks to docs. This also addresses #456.