### PR TITLE
Testing

### DIFF
--- a/axelrod/tests/unit/test_axelrod_first.py
+++ b/axelrod/tests/unit/test_axelrod_first.py
@@ -310,5 +310,4 @@ class TestUnnamedStrategy(TestPlayer):
     }
 
     def test_strategy(self):
-        random.seed(10)
-        self.responses_test([], [], [C, C, D, C, C, D])
+        self.responses_test([], [], [C, C, D, C, C, D], random_seed=10)

--- a/axelrod/tests/unit/test_memoryone.py
+++ b/axelrod/tests/unit/test_memoryone.py
@@ -196,9 +196,9 @@ class TestZDExtort2(TestPlayer):
 
     def test_effect_of_strategy(self):
         self.responses_test([C], [C], [D, D, C, C], random_seed=2)
-        self.responses_test([C], [D], [D, D, D, C])
-        self.responses_test([D], [C], [D, D, D, C])
-        self.responses_test([D], [D], [D, D, D, D])
+        self.responses_test([C], [D], [D, D, C, C], random_seed=2)
+        self.responses_test([D], [C], [D, D, C, C], random_seed=2)
+        self.responses_test([D], [D], [D, D, C, C], random_seed=2)
 
 
 class TestZDExtort2v2(TestPlayer):
@@ -290,9 +290,9 @@ class TestZDGTFT2(TestPlayer):
 
     def test_effect_of_strategy(self):
         self.responses_test([C], [C], [C, C, C, C], random_seed=2)
-        self.responses_test([C], [D], [D])
-        self.responses_test([D], [C], [C, C, C, C])
-        self.responses_test([D], [D], [D])
+        self.responses_test([C], [D], [D], random_seed=2)
+        self.responses_test([D], [C], [C, C, C, C], random_seed=2)
+        self.responses_test([D], [D], [D], random_seed=2)
 
 
 class TestZDSet2(TestPlayer):

--- a/axelrod/tests/unit/test_oncebitten.py
+++ b/axelrod/tests/unit/test_oncebitten.py
@@ -105,8 +105,8 @@ class TestForgetfulFoolMeOnce(TestPlayer):
         self.responses_test([C], [D], [C])
         self.responses_test([C, C], [D, D], [D])
         # Sometime eventually forget count:
-        self.responses_test([C, C], [D, D], [D] * 13 + [C],
-                            attrs={"D_count": 0})
+        self.responses_test([C, C], [D, D], [D] * 18 + [C],
+                            attrs={"D_count": 0}, random_seed=2)
 
     def test_reset(self):
         """Check that count gets reset properly"""

--- a/axelrod/tests/unit/test_player.py
+++ b/axelrod/tests/unit/test_player.py
@@ -68,7 +68,6 @@ class TestPlayerClass(unittest.TestCase):
     def test_strategy(self):
         self.assertRaises(NotImplementedError, self.player().strategy, self.player())
 
-
 def test_responses(test_class, P1, P2, history_1, history_2, responses,
                    random_seed=None, attrs=None):
     """
@@ -220,6 +219,23 @@ class TestPlayer(unittest.TestCase):
         test_responses(
             self, P1, P2, history_1, history_2, responses,
             random_seed=random_seed, attrs=attrs)
+
+        # Test that we get the same sequence after a reset
+        P1.reset()
+        P2 = TestOpponent()
+        P2.tournament_attributes['length'] = tournament_length
+        test_responses(
+            self, P1, P2, history_1, history_2, responses,
+            random_seed=random_seed, attrs=attrs)
+
+        # Test that we get the same sequence after a clone
+        P1 = P1.clone()
+        P2 = TestOpponent()
+        P2.tournament_attributes['length'] = tournament_length
+        test_responses(
+            self, P1, P2, history_1, history_2, responses,
+            random_seed=random_seed, attrs=attrs)
+
 
     def classifier_test(self):
         """Test that the keys in the expected_classifier dictionary give the


### PR DESCRIPTION
Since we have a nice test suite for most strategies, I thought it would be a good idea to re-run the tests on players that had been reset or cloned automatically. I did this by updating `responses_test` to check both cloning and resetting. This required updating a few other tests that relied on random number generation.