### PR TITLE
Strategy transformer fix

### DIFF
--- a/axelrod/strategies/backstabber.py
+++ b/axelrod/strategies/backstabber.py
@@ -4,7 +4,7 @@ from axelrod.strategy_transformers import FinalTransformer
 C, D = Actions.C, Actions.D
 
 
-@FinalTransformer([D, D]) # End with two defections
+@FinalTransformer((D, D)) # End with two defections
 class BackStabber(Player):
     """
     Forgives the first 3 defections but on the fourth

--- a/axelrod/strategy_transformers.py
+++ b/axelrod/strategy_transformers.py
@@ -187,6 +187,12 @@ def final_sequence(player, opponent, action, seq):
         return action
 
     index = length - len(player.history)
+    # If for some reason we've overrun the expected game length, just pass
+    # the intended action through
+    if len(player.history) >= length:
+        return action
+    # Check if we're near the end and need to start passing the actions
+    # from seq for the final few rounds.
     if index <= len(seq):
         return seq[-index]
     return action

--- a/axelrod/tests/unit/test_backstabber.py
+++ b/axelrod/tests/unit/test_backstabber.py
@@ -35,7 +35,8 @@ class TestBackStabber(TestPlayer):
         # Defects on rounds 199, and 200 no matter what
         self.responses_test([C] * 197 , [C] * 197, [C, D, D],
                             tournament_length=200)
-        self.responses_test([C] * 198 , [C] * 198, [D, D],
+        # Test that exceeds tournament length
+        self.responses_test([C] * 198 , [C] * 198, [D, D, C],
                             tournament_length=200)
         # But only if the tournament is known
         self.responses_test([C] * 198 , [C] * 198, [C, C, C],

--- a/axelrod/tests/unit/test_backstabber.py
+++ b/axelrod/tests/unit/test_backstabber.py
@@ -35,7 +35,7 @@ class TestBackStabber(TestPlayer):
         # Defects on rounds 199, and 200 no matter what
         self.responses_test([C] * 197 , [C] * 197, [C, D, D],
                             tournament_length=200)
-        self.responses_test([C] * 198 , [C] * 198, [D, D, D],
+        self.responses_test([C] * 198 , [C] * 198, [D, D],
                             tournament_length=200)
         # But only if the tournament is known
         self.responses_test([C] * 198 , [C] * 198, [C, C, C],


### PR DESCRIPTION
This fixes the issue with mindreader and the final transformer from #465. The problem was that mindreader was reading beyond the end of the game length which causes an index error in FinalTransformer. The transformer now simply passes through the action if the tournament length is exceeded.