### PR TITLE
Added Gambler strategy

### DIFF
--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -15,6 +15,7 @@ from .darwin import Darwin
 from .defector import Defector, TrickyDefector
 from .forgiver import Forgiver, ForgivingTitForTat
 from .geller import Geller, GellerCooperator, GellerDefector
+from .gambler import Gambler, PSOGambler
 from .gobymajority import (GoByMajority,
     GoByMajority10, GoByMajority20, GoByMajority40,
     GoByMajority5,
@@ -88,6 +89,7 @@ strategies = [
     ForgetfulGrudger,
     Forgiver,
     ForgivingTitForTat,
+    PSOGambler,
     GTFT,
     Geller,
     GellerCooperator,

--- a/axelrod/strategies/gambler.py
+++ b/axelrod/strategies/gambler.py
@@ -57,7 +57,7 @@ class Gambler(Player):
         # If there isn't enough history to lookup an action, cooperate.
         if len(self.history) < max(self.plays, self.opponent_start_plays):
             return C
-        # GK: Defect Last 2 turns
+        # GK: Defect Last 2 turns, Idea came from the Backstabber class
         if len(opponent.history) > (self.tournament_attributes['length'] - 3):
             return D
         # Count backward m turns to get my own recent history.

--- a/axelrod/strategies/gambler.py
+++ b/axelrod/strategies/gambler.py
@@ -1,3 +1,9 @@
+from axelrod import Actions, Player, init_args, random_choice
+from itertools import product
+
+C, D = Actions.C, Actions.D
+
+
 class Gambler(Player):
 
     name = 'Gambler'

--- a/axelrod/strategies/gambler.py
+++ b/axelrod/strategies/gambler.py
@@ -10,7 +10,7 @@ class Gambler(Player):
     classifier = {
         'memory_depth': float('inf'),
         'stochastic': True,
-        'makes_use_of': set(),
+        'makes_use_of': set(['length']),
         'inspects_source': False,
         'manipulates_source': False,
         'manipulates_state': False

--- a/axelrod/strategies/gambler.py
+++ b/axelrod/strategies/gambler.py
@@ -1,0 +1,100 @@
+class Gambler(Player):
+
+    name = 'Gambler'
+    classifier = {
+        'memory_depth': float('inf'),
+        'stochastic': True,
+        'makes_use_of': set(),
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+
+    @init_args
+    def __init__(self, lookup_table=None):
+        """
+        If no lookup table is provided to the constructor, then use the TFT one.
+        """
+        Player.__init__(self)
+
+        if not lookup_table:
+            lookup_table = {
+            ('', 'C', 'D') : 0,
+            ('', 'D', 'D') : 0,
+            ('', 'C', 'C') : 1,
+            ('', 'D', 'C') : 1,
+        }
+
+        self.lookup_table = lookup_table
+        # Rather than pass the number of previous turns (m) to consider in as a
+        # separate variable, figure it out. The number of turns is the length
+        # of the second element of any given key in the dict.
+        self.plays = len(list(self.lookup_table.keys())[0][1])
+        # The number of opponent starting actions is the length of the first
+        # element of any given key in the dict.
+        self.opponent_start_plays = len(list(self.lookup_table.keys())[0][0])
+        # If the table dictates to ignore the opening actions of the opponent
+        # then the memory classification is adjusted
+        if self.opponent_start_plays == 0:
+            self.classifier['memory_depth'] = self.plays
+
+        # Ensure that table is well-formed
+        for k, v in lookup_table.items():
+            if (len(k[1]) != self.plays) or (len(k[0]) != self.opponent_start_plays):
+                raise ValueError("All table elements must have the same size")
+
+
+    def strategy(self, opponent):
+        # If there isn't enough history to lookup an action, cooperate.
+        if len(self.history) < max(self.plays, self.opponent_start_plays):
+            return C
+        # GK: Defect Last 2 turns
+        if len(opponent.history) > (self.tournament_attributes['length'] - 3):
+            return D
+        # Count backward m turns to get my own recent history.
+        history_start = -1 * self.plays
+        my_history = ''.join(self.history[history_start:])
+        # Do the same for the opponent.
+        opponent_history = ''.join(opponent.history[history_start:])
+        # Get the opponents first n actions.
+        opponent_start = ''.join(opponent.history[:self.opponent_start_plays])
+        # Put these three strings together in a tuple.
+        key = (opponent_start, my_history, opponent_history)
+        # Look up the action number associated with that tuple in the lookup table.
+        action = float(self.lookup_table[key])
+        # Depending on the action number return a choice
+        return random_choice(action)
+
+
+
+class PSOGambler(Gambler):
+    """
+    A LookerUp strategy that uses a lookup table with probability numbers generated using 
+    a Particle Swarm Optimisation (PSO) algorithm.
+    """
+
+    name = "PSO Gambler"
+
+    def __init__(self,pattern):
+        plays = 2
+        opponent_start_plays = 2
+
+        # Generate the list of possible tuples, i.e. all possible combinations
+        # of m actions for me, m actions for opponent, and n starting actions
+        # for opponent.
+        self_histories = [''.join(x) for x in product('CD', repeat=plays)]
+        other_histories = [''.join(x) for x in product('CD', repeat=plays)]
+        opponent_starts = [''.join(x) for x in
+                           product('CD', repeat=opponent_start_plays)]
+        lookup_table_keys = list(product(opponent_starts, self_histories,
+                                         other_histories))
+
+        # Pattern of values determed previously with a pso algorithm.
+        pattern_pso = [1.0 ,0.0,1.0,1.0 ,0.0 ,1.0,1.0,1.0,0.0 ,1.0 ,0.0,0.0,0.0,0.0,0.0,1.0 ,
+                       0.93,0.0,1.0,0.67,0.42,0.0,0.0,0.0,0.0 ,1.0 ,0.0,1.0,0.0,0.0,0.0,0.48,
+                       0.0 ,0.0,0.0,0.0 ,1.0 ,1.0,1.0,0.0,0.19,1.0 ,1.0,0.0,0.0,0.0,0.0,0.0 ,
+                       1.0 ,0.0,1.0,0.0 ,0.0 ,0.0,1.0,0.0,1.0 ,0.36,0.0,0.0,0.0,0.0,0.0,0.0 ]
+
+        # Zip together the keys and the action pattern to get the lookup table.
+        lookup_table = dict(zip(lookup_table_keys, pattern))
+        Gambler.__init__(self, lookup_table=lookup_table)

--- a/axelrod/strategies/gambler.py
+++ b/axelrod/strategies/gambler.py
@@ -8,9 +8,11 @@ class Gambler(Player):
     """
     A LookerUp class player which will select randomly an action in some cases.
     It will always defect the last 2 turns.
-    Most comments and structure come from the LookerUp class.
-    New comments start with GK
     """
+    
+    # Most comments and structure come from the LookerUp class.
+    # New comments start with GK
+    
     name = 'Gambler'
     classifier = {
         'memory_depth': float('inf'),

--- a/axelrod/strategies/gambler.py
+++ b/axelrod/strategies/gambler.py
@@ -6,6 +6,8 @@ C, D = Actions.C, Actions.D
 
 class Gambler(Player):
     """
+    A LookerUp class player which will select randomly an action in some cases.
+    It will always defect the last 2 turns.
     Most comments and structure come from the LookerUp class.
     New comments start with GK
     """
@@ -84,7 +86,7 @@ class PSOGambler(Gambler):
 
     name = "PSO Gambler"
 
-    def __init__(self,pattern):
+    def __init__(self):
         plays = 2
         opponent_start_plays = 2
 

--- a/axelrod/strategies/gambler.py
+++ b/axelrod/strategies/gambler.py
@@ -5,7 +5,10 @@ C, D = Actions.C, Actions.D
 
 
 class Gambler(Player):
-
+    """
+    Most comments and structure come from the LookerUp class.
+    New comments start with GK
+    """
     name = 'Gambler'
     classifier = {
         'memory_depth': float('inf'),
@@ -68,7 +71,7 @@ class Gambler(Player):
         key = (opponent_start, my_history, opponent_history)
         # Look up the action number associated with that tuple in the lookup table.
         action = float(self.lookup_table[key])
-        # Depending on the action number return a choice
+        # GK: Depending on the action number return a choice
         return random_choice(action)
 
 
@@ -95,12 +98,12 @@ class PSOGambler(Gambler):
         lookup_table_keys = list(product(opponent_starts, self_histories,
                                          other_histories))
 
-        # Pattern of values determed previously with a pso algorithm.
+        # GK: Pattern of values determined previously with a pso algorithm.
         pattern_pso = [1.0 ,0.0,1.0,1.0 ,0.0 ,1.0,1.0,1.0,0.0 ,1.0 ,0.0,0.0,0.0,0.0,0.0,1.0 ,
                        0.93,0.0,1.0,0.67,0.42,0.0,0.0,0.0,0.0 ,1.0 ,0.0,1.0,0.0,0.0,0.0,0.48,
                        0.0 ,0.0,0.0,0.0 ,1.0 ,1.0,1.0,0.0,0.19,1.0 ,1.0,0.0,0.0,0.0,0.0,0.0 ,
                        1.0 ,0.0,1.0,0.0 ,0.0 ,0.0,1.0,0.0,1.0 ,0.36,0.0,0.0,0.0,0.0,0.0,0.0 ]
 
         # Zip together the keys and the action pattern to get the lookup table.
-        lookup_table = dict(zip(lookup_table_keys, pattern))
+        lookup_table = dict(zip(lookup_table_keys, pattern_pso))
         Gambler.__init__(self, lookup_table=lookup_table)

--- a/axelrod/tests/unit/test_gambler.py
+++ b/axelrod/tests/unit/test_gambler.py
@@ -1,0 +1,129 @@
+"""Test for the Gambler strategy."""
+
+import axelrod
+import random
+from .test_player import TestPlayer, TestHeadsUp
+from axelrod import random_choice, Actions
+
+C, D = axelrod.Actions.C, axelrod.Actions.D
+
+
+class TestGambler(TestPlayer):
+
+    name = "Gambler"
+    player = axelrod.Gambler
+
+    expected_classifier = {
+        'memory_depth': 1, # Default TFT table
+        'stochastic': True,
+        'makes_use_of': set(['length']),
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+
+    def test_init(self):
+        # Test empty table
+        player = self.player(dict())
+        opponent = axelrod.Cooperator()
+        self.assertEqual(player.strategy(opponent), C)
+        # Test default table
+        player = self.player()
+        expected_lookup_table = {
+            ('', 'C', 'D') : 0,
+            ('', 'D', 'D') : 0,
+            ('', 'C', 'C') : 1,
+            ('', 'D', 'C') : 1,
+        }
+        self.assertEqual(player.lookup_table, expected_lookup_table)
+        # Test malformed tables
+        table = {(C, C): 1, ('DD', 'DD'): 1}
+        with self.assertRaises(ValueError):
+            player = self.player(table)
+
+
+    def test_strategy(self):
+        self.responses_test([C] * 4, [C, C, C, C], [C])
+        self.responses_test([C] * 5, [C, C, C, C, D], [D])
+
+    def test_defector_table(self):
+        """
+        Testing a lookup table that always defects if there is enough history.
+        In order for the testing framework to be able to construct new player
+        objects for the test, self.player needs to be callable with no
+        arguments, thus we use a lambda expression which will call the
+        constructor with the lookup table we want.
+        """
+        defector_table = {
+            ('', C, D) : 0,
+            ('', D, D) : 0,
+            ('', C, C) : 0,
+            ('', D, C) : 0,
+        }
+        self.player = lambda : axelrod.Gambler(defector_table)
+        self.responses_test([C, C], [C, C], [D])
+        self.responses_test([C, D], [D, C], [D])
+        self.responses_test([D, D], [D, D], [D])
+
+
+
+class TestPSOGambler(TestPlayer):
+
+    name = "PSO Gambler"
+    player = axelrod.PSOGambler
+
+    expected_classifier = {
+        'memory_depth': float('inf'),
+        'stochastic': True,
+        'makes_use_of': set(['length']),
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+
+    def test_init(self):
+        # Check for a few known keys
+        known_pairs = { ('CD', 'DD', 'DD'): 0.48, ('CD', 'CC', 'DD'): 0.67}
+        player = self.player()
+        for k, v in known_pairs.items():
+            self.assertEqual(player.lookup_table[k], v)
+
+    def test_strategy(self):
+        """Starts by cooperating."""
+        self.first_play_test(C)
+        # Defects on the last two rounds no matter what
+        self.responses_test([C] * 197 , [C] * 197, [C, D, D],
+                            tournament_length=200)
+
+    def test_return_values(self):
+        self.assertEqual(random_choice(1), C)
+        self.assertEqual(random_choice(0), D)
+        random.seed(1)
+        self.assertEqual(random_choice(), C)
+        random.seed(2)
+        self.assertEqual(random_choice(), D)
+
+# Some heads up tests for PSOGambler
+class PSOGamblervsDefector(TestHeadsUp):
+    def test_vs(self):
+        self.versus_test(axelrod.PSOGambler(), axelrod.Defector(),
+                         [C, C, D, D], [D, D, D, D])
+
+
+class PSOGamblervsCooperator(TestHeadsUp):
+    def test_vs(self):
+        self.versus_test(axelrod.PSOGambler(), axelrod.Cooperator(),
+                         [C, C, D, D], [C, C, C, C])
+
+
+class PSOGamblervsTFT(TestHeadsUp):
+    def test_vs(self):
+        outcomes = zip()
+        self.versus_test(axelrod.PSOGambler(), axelrod.TitForTat(),
+                         [C, C, D, D] , [C, C, C, D])
+
+
+class PSOGamblervsAlternator(TestHeadsUp):
+    def test_vs(self):
+        self.versus_test(axelrod.PSOGambler(), axelrod.Alternator(),
+                         [C, C, D, D, D, D], [C, D, C, D, C, D])

--- a/axelrod/tests/unit/test_gambler.py
+++ b/axelrod/tests/unit/test_gambler.py
@@ -1,4 +1,7 @@
-"""Test for the Gambler strategy."""
+"""
+Test for the Gambler strategy.
+Most tests come form the LookerUp test suite
+"""
 
 import axelrod
 import random
@@ -91,10 +94,11 @@ class TestPSOGambler(TestPlayer):
     def test_strategy(self):
         """Starts by cooperating."""
         self.first_play_test(C)
-        # Defects on the last two rounds no matter what
+        # Defects on the last two rounds no matter what, from Backstabber test suite
         self.responses_test([C] * 197 , [C] * 197, [C, D, D],
                             tournament_length=200)
 
+    # Test from Random test suite
     def test_return_values(self):
         self.assertEqual(random_choice(1), C)
         self.assertEqual(random_choice(0), D)

--- a/docs/reference/all_strategies.rst
+++ b/docs/reference/all_strategies.rst
@@ -43,6 +43,9 @@ Here are the docstrings of all the strategies in the library.
 .. automodule:: axelrod.strategies.forgiver
    :members:
    :undoc-members:
+.. automodule:: axelrod.strategies.gambler
+   :members:
+   :undoc-members:
 .. automodule:: axelrod.strategies.geller
    :members:
    :undoc-members:

--- a/docs/tutorials/further_topics/classification_of_strategies.rst
+++ b/docs/tutorials/further_topics/classification_of_strategies.rst
@@ -24,7 +24,7 @@ This allows us to, for example, quickly identify all the stochastic
 strategies::
 
     >>> len([s for s in axl.strategies if s().classifier['stochastic']])
-    38
+    39
 
 Or indeed find out how many strategy only use 1 turn worth of memory to
 make a decision::
@@ -37,7 +37,7 @@ tournament. For example, here is the number of strategies that  make use of the
 length of each match of the tournament::
 
     >>> len([s() for s in axl.strategies if 'length' in s().classifier['makes_use_of']])
-    9
+    10
 
 Here are how many of the strategies that make use of the particular game being
 played (whether or not it's the default Prisoner's dilemma)::


### PR DESCRIPTION
Hello axelrod people,

I have added a new strategy called PSO Gambler.
Instead of using a binary outcome for the lookup table from LookerUp class, I have run a Particle Swarm Optimisation to calculate the probability for C or D based on the lookup_table. This resulted in 6 cases where the action is randomised. 
Furthermore, It will always defect the last 2 turns (similar to the Backstabber class).

I have also added some tests, based on the lookerup, backstabber and random test suites.

Let me know if there are any problems.

I had great fun using the library.

Cheers,
Georgios
