### PR TITLE
Addressing #482: some tests for utils.py

### DIFF
--- a/axelrod/tests/unit/test_utils.py
+++ b/axelrod/tests/unit/test_utils.py
@@ -42,14 +42,3 @@ class TestSetupLogging(unittest.TestCase):
             axelrod.utils.setup_logging(logging_destination='console',
                                         verbosity=level)
             compare(logger.level, levels[level])
-
-        # Removing this as it doesn't seem to work on travis.
-        #compare([
-            #C('logging.StreamHandler',
-              #stream=sys.stderr,
-              #formatter=C('logging.Formatter',
-                          #_fmt='%(message)s',
-                          #strict=False),
-              #level=logging.NOTSET,
-              #strict=False)
-            #], logger.handlers)

--- a/axelrod/tests/unit/test_utils.py
+++ b/axelrod/tests/unit/test_utils.py
@@ -7,8 +7,7 @@ from hypothesis import given
 from hypothesis.strategies import floats, text
 
 import logging
-from testfixtures import Comparison as C, compare
-import sys
+from testfixtures import compare
 
 class TestTimedMessage(unittest.TestCase):
 

--- a/axelrod/tests/unit/test_utils.py
+++ b/axelrod/tests/unit/test_utils.py
@@ -1,0 +1,55 @@
+"""Tests for the utils functions and classes."""
+
+import axelrod
+import unittest
+
+from hypothesis import given
+from hypothesis.strategies import floats, text
+
+import logging
+from testfixtures import Comparison as C, compare
+import sys
+
+class TestTimedMessage(unittest.TestCase):
+
+    @given(start_time=floats(min_value=0, allow_nan=False,
+                             allow_infinity=False),
+           message=text())
+    def test_time_message(self, start_time, message):
+        timed_message = axelrod.utils.timed_message(message, start_time)
+        self.assertEqual(timed_message[:len(message)], message)
+
+    def test_time_message_example(self):
+        message = "Full tournament"
+        start_time = 0
+        timed_message = axelrod.utils.timed_message(message, start_time)
+        self.assertEqual(timed_message[:len(message)], message)
+        self.assertGreaterEqual(float(timed_message[len(message)+4:-1]), 0)
+
+
+
+class TestSetupLogging(unittest.TestCase):
+
+    def test_basic_configuration_console(self):
+        logger = logging.getLogger("axelrod")
+        levels = {"CRITICAL": 50,
+                  "ERROR": 40,
+                  "WARNING": 30,
+                  "INFO": 20,
+                  "DEBUG": 10,
+                  "NOTSET": 0}
+        for level in levels:
+            axelrod.utils.setup_logging(logging_destination='console',
+                                        verbosity=level)
+            compare(logger.level, levels[level])
+
+        # Removing this as it doesn't seem to work on travis.
+        #compare([
+            #C('logging.StreamHandler',
+              #stream=sys.stderr,
+              #formatter=C('logging.Formatter',
+                          #_fmt='%(message)s',
+                          #strict=False),
+              #level=logging.NOTSET,
+              #strict=False)
+            #], logger.handlers)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy>=1.9.2
 matplotlib>=1.4.2
 cloudpickle==0.1.1
 hypothesis>=3.0
+testfixtures==4.9.1


### PR DESCRIPTION
- Tests for timed_message (simple)
- Tests for logger
        - Adding testfixtures https://pythonhosted.org/testfixtures/logging.html It looks like this is necessary but it *does* add to the requirements.txt. Is it worth it?

Furthermore I'm not completely satisfied by the tests for the logger but
it *is* at least a test.

Note that this doesn't add a test for `run_tournament`, that's very much tested in a lot of other places and everytime we run the results but I suppose that a test would be nice. I might get to that at some point.