### PR TITLE
All plots: simple label in tnrmnt manager. Addresses #510

### DIFF
--- a/axelrod/plot.py
+++ b/axelrod/plot.py
@@ -214,30 +214,30 @@ class Plot(object):
         ax.set_xticklabels(names, rotation=90)
         ax.set_yticklabels(names)
         plt.tick_params(axis='both', which='both', labelsize=16)
+        if title:
+            plt.xlabel(title)
         # Make the colorbar match up with the plot
         divider = make_axes_locatable(plt.gca())
         cax = divider.append_axes("right", "5%", pad="3%")
         plt.colorbar(mat, cax=cax)
-        if title:
-            plt.title(title)
         return figure
 
-    def pdplot(self):
+    def pdplot(self, title=None):
         """Payoff difference heatmap to visualize the distributions of how
         players attain their payoffs."""
         matrix, names = self._pdplot_dataset
-        return self._payoff_heatmap(matrix, names)
+        return self._payoff_heatmap(matrix, names, title)
 
-    def payoff(self):
+    def payoff(self, title=None):
         """Payoff heatmap to visualize the distributions of how
         players attain their payoffs."""
         data = self._payoff_dataset
         names = self.result_set.ranked_names
-        return self._payoff_heatmap(data, names)
+        return self._payoff_heatmap(data, names, title)
 
     # Ecological Plot
 
-    def stackplot(self, eco):
+    def stackplot(self, eco, title=None):
 
         if not self.matplotlib_installed:
             return None
@@ -260,7 +260,8 @@ class Plot(object):
         plt.ylim([0.0, 1.0])
         plt.ylabel('Relative population size')
         plt.xlabel('Turn')
-        plt.title("Strategy population dynamics based on average payoffs")
+        if title is not None:
+            plt.title(title)
 
         trans = transforms.blended_transform_factory(ax.transAxes, ax.transData)
         ticks = []

--- a/axelrod/tests/unit/test_tournament_manager.py
+++ b/axelrod/tests/unit/test_tournament_manager.py
@@ -70,6 +70,7 @@ class TestTournamentManager(unittest.TestCase):
         mgr = axelrod.TournamentManager(
             output_directory=self.test_output_directory,
             with_ecological=self.test_with_ecological, load_cache=False)
-        expected_label = "Turns: {}, Repetitions: {}".format(tournament.turns,
-                tournament.repetitions)
+        expected_label = "Turns: {}, Repetitions: {}, Strategies: {}.".format(tournament.turns,
+                tournament.repetitions, len(tournament.players))
+
         self.assertEqual(mgr._tournament_label(tournament), expected_label)

--- a/axelrod/tests/unit/test_tournament_manager.py
+++ b/axelrod/tests/unit/test_tournament_manager.py
@@ -63,3 +63,13 @@ class TestTournamentManager(unittest.TestCase):
         mgr._cache_valid_for_turns = 500
         self.assertFalse(mgr._valid_cache(200))
         self.assertTrue(mgr._valid_cache(500))
+
+    def test_tournament_label(self):
+        tournament = axelrod.Tournament(self.test_players, turns=20,
+                                        repetitions=2)
+        mgr = axelrod.TournamentManager(
+            output_directory=self.test_output_directory,
+            with_ecological=self.test_with_ecological, load_cache=False)
+        expected_label = "Turns: {}, Repetitions: {}".format(tournament.turns,
+                tournament.repetitions)
+        self.assertEqual(mgr._tournament_label(tournament), expected_label)

--- a/axelrod/tournament_manager.py
+++ b/axelrod/tournament_manager.py
@@ -11,6 +11,10 @@ from .utils import *
 
 class TournamentManager(object):
 
+    plot_types = {'boxplot': "Payoffs. ", 'payoff': "Payoffs. ",
+                  'winplot': "Wins. ", 'sdvplot': "Std Payoffs. ",
+                  'pdplot': "Payoff differences. ", 'lengthplot': "Lengths. "}
+
     def __init__(self, output_directory, with_ecological,
                  pass_cache=True, load_cache=True, save_cache=False,
                  cache_file='./cache.txt', image_format="svg"):
@@ -128,16 +132,23 @@ class TournamentManager(object):
             self._logger.error('The matplotlib library is not installed. '
                             'No plots will be produced')
             return
-        for plot_type in ('boxplot', 'payoff', 'winplot', 'sdvplot', 'pdplot'):
-            figure = getattr(plot, plot_type)()
+        label = self._tournament_label(tournament)
+        for plot_type, name in self.plot_types.items():
+            title = name + label
+            figure = getattr(plot, plot_type)(title=title)
             file_name = self._output_file_path(
                 tournament.name + '_' + plot_type, image_format)
             self._save_plot(figure, file_name)
         if ecosystem is not None:
-            figure = plot.stackplot(ecosystem)
+            figure = plot.stackplot(ecosystem, title=title)
             file_name = self._output_file_path(
                     tournament.name + '_reproduce', image_format)
             self._save_plot(figure, file_name)
+
+    def _tournament_label(self, tournament):
+        """A label for the tournament for the corresponding title plots"""
+        return "Turns: {}, Repetitions: {}".format(tournament.turns,
+                tournament.repetitions)
 
     def _output_file_path(self, file_name, file_extension):
         return os.path.join(

--- a/axelrod/tournament_manager.py
+++ b/axelrod/tournament_manager.py
@@ -140,6 +140,7 @@ class TournamentManager(object):
                 tournament.name + '_' + plot_type, image_format)
             self._save_plot(figure, file_name)
         if ecosystem is not None:
+            title = "Eco. " + label
             figure = plot.stackplot(ecosystem, title=title)
             file_name = self._output_file_path(
                     tournament.name + '_reproduce', image_format)

--- a/axelrod/tournament_manager.py
+++ b/axelrod/tournament_manager.py
@@ -148,8 +148,9 @@ class TournamentManager(object):
 
     def _tournament_label(self, tournament):
         """A label for the tournament for the corresponding title plots"""
-        return "Turns: {}, Repetitions: {}".format(tournament.turns,
-                tournament.repetitions)
+        return "Turns: {}, Repetitions: {}, Strategies: {}.".format(tournament.turns,
+                                                       tournament.repetitions,
+                                                       len(tournament.players))
 
     def _output_file_path(self, file_name, file_extension):
         return os.path.join(


### PR DESCRIPTION
I use the xlabel for the heatplot as otherwise it overlapped. This was actually missing for some plots previously. As you can see I've gone for keeping things simple. About to work on #509 in which I'll make a slight tweak to have the prob end instead of the match length.

Here are some examples:

![basic_strategies_boxplot](https://cloud.githubusercontent.com/assets/2131546/14225291/a266546c-f8b5-11e5-8fba-71a7ac753252.png)
![basic_strategies_payoff](https://cloud.githubusercontent.com/assets/2131546/14225292/a2668c0c-f8b5-11e5-8a13-8ea1622ad68f.png)
![basic_strategies_lengthplot svg](https://cloud.githubusercontent.com/assets/2131546/14225293/a266a200-f8b5-11e5-862a-36623d7dcc86.png)
![screenshot 2016-04-02 09 30 59](https://cloud.githubusercontent.com/assets/2131546/14225294/ad75aa9c-f8b5-11e5-835f-8e3b6071c686.png)