### PR TITLE
Add prob end tournament type to run_axelrod

### DIFF
--- a/axelrod/__init__.py
+++ b/axelrod/__init__.py
@@ -11,7 +11,7 @@ from .match import Match
 from .strategies import *
 from .tournament_type import *
 from .tournament import Tournament, ProbEndTournament
-from .tournament_manager import TournamentManager
+from .tournament_manager import TournamentManager, ProbEndTournamentManager
 from .tournament_manager_factory import TournamentManagerFactory
 from .result_set import ResultSet
 from .ecosystem import Ecosystem

--- a/axelrod/__init__.py
+++ b/axelrod/__init__.py
@@ -16,4 +16,4 @@ from .tournament_manager_factory import (TournamentManagerFactory,
                                          ProbEndTournamentManagerFactory)
 from .result_set import ResultSet
 from .ecosystem import Ecosystem
-from .utils import run_tournaments, setup_logging
+from .utils import run_tournaments, run_prob_end_tournaments, setup_logging

--- a/axelrod/__init__.py
+++ b/axelrod/__init__.py
@@ -12,7 +12,8 @@ from .strategies import *
 from .tournament_type import *
 from .tournament import Tournament, ProbEndTournament
 from .tournament_manager import TournamentManager, ProbEndTournamentManager
-from .tournament_manager_factory import TournamentManagerFactory
+from .tournament_manager_factory import (TournamentManagerFactory,
+                                         ProbEndTournamentManagerFactory)
 from .result_set import ResultSet
 from .ecosystem import Ecosystem
 from .utils import run_tournaments, setup_logging

--- a/axelrod/plot.py
+++ b/axelrod/plot.py
@@ -214,30 +214,30 @@ class Plot(object):
         ax.set_xticklabels(names, rotation=90)
         ax.set_yticklabels(names)
         plt.tick_params(axis='both', which='both', labelsize=16)
+        if title:
+            plt.xlabel(title)
         # Make the colorbar match up with the plot
         divider = make_axes_locatable(plt.gca())
         cax = divider.append_axes("right", "5%", pad="3%")
         plt.colorbar(mat, cax=cax)
-        if title:
-            plt.title(title)
         return figure
 
-    def pdplot(self):
+    def pdplot(self, title=None):
         """Payoff difference heatmap to visualize the distributions of how
         players attain their payoffs."""
         matrix, names = self._pdplot_dataset
-        return self._payoff_heatmap(matrix, names)
+        return self._payoff_heatmap(matrix, names, title)
 
-    def payoff(self):
+    def payoff(self, title=None):
         """Payoff heatmap to visualize the distributions of how
         players attain their payoffs."""
         data = self._payoff_dataset
         names = self.result_set.ranked_names
-        return self._payoff_heatmap(data, names)
+        return self._payoff_heatmap(data, names, title)
 
     # Ecological Plot
 
-    def stackplot(self, eco):
+    def stackplot(self, eco, title=None):
 
         if not self.matplotlib_installed:
             return None
@@ -260,7 +260,8 @@ class Plot(object):
         plt.ylim([0.0, 1.0])
         plt.ylabel('Relative population size')
         plt.xlabel('Turn')
-        plt.title("Strategy population dynamics based on average payoffs")
+        if title is not None:
+            plt.title(title)
 
         trans = transforms.blended_transform_factory(ax.transAxes, ax.transData)
         ticks = []

--- a/axelrod/tests/integration/test_tournament.py
+++ b/axelrod/tests/integration/test_tournament.py
@@ -97,3 +97,29 @@ class TestTournamentManager(unittest.TestCase):
                     exclude_cheating=True,
                     exclude_ordinary=True,
                     noise=0)
+
+
+class TestProbEndTournamentManager(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.game = axelrod.Game()
+        cls.players = [s() for s in axelrod.demo_strategies]
+
+    def test_tournament_manager(self):
+        strategies = [s() for s in axelrod.demo_strategies]
+        tm = axelrod.ProbEndTournamentManager("./", False, save_cache=False)
+        tm.add_tournament("test-prob-end", strategies, repetitions=2, prob_end=.1,
+                          noise=0.05)
+        tm.run_tournaments()
+
+        strategies = [s() for s in axelrod.basic_strategies]
+        tm = axelrod.ProbEndTournamentManager("./", False, load_cache=False,
+                                       save_cache=True)
+        tm.add_tournament("test-prob-end", strategies, repetitions=2, prob_end=.1, noise=0.)
+        tm.run_tournaments()
+
+        tm = axelrod.ProbEndTournamentManager("./", False, load_cache=True,
+                                       save_cache=True)
+        tm.add_tournament("test-prob-end", strategies, repetitions=2, prob_end=.1, noise=0.)
+        tm.run_tournaments()

--- a/axelrod/tests/integration/test_tournament.py
+++ b/axelrod/tests/integration/test_tournament.py
@@ -1,7 +1,7 @@
 import unittest
 import axelrod
 
-from axelrod.utils import setup_logging, run_tournaments
+from axelrod.utils import setup_logging, run_tournaments, run_prob_end_tournaments
 
 class TestTournament(unittest.TestCase):
 
@@ -115,11 +115,28 @@ class TestProbEndTournamentManager(unittest.TestCase):
 
         strategies = [s() for s in axelrod.basic_strategies]
         tm = axelrod.ProbEndTournamentManager("./", False, load_cache=False,
-                                       save_cache=True)
-        tm.add_tournament("test-prob-end", strategies, repetitions=2, prob_end=.1, noise=0.)
+                                              save_cache=True)
+        tm.add_tournament("test-prob-end", strategies, repetitions=2,
+                          prob_end=.1, noise=0.)
         tm.run_tournaments()
 
         tm = axelrod.ProbEndTournamentManager("./", False, load_cache=True,
-                                       save_cache=True)
-        tm.add_tournament("test-prob-end", strategies, repetitions=2, prob_end=.1, noise=0.)
+                                              save_cache=True)
+        tm.add_tournament("test-prob-end", strategies, repetitions=2,
+                          prob_end=.1, noise=0.)
         tm.run_tournaments()
+
+    def test_utils(self):
+        setup_logging(logging_destination="none")
+        run_prob_end_tournaments(cache_file='./cache.txt',
+                                 output_directory='./',
+                                 repetitions=2,
+                                 prob_end=.1,
+                                 processes=None,
+                                 no_ecological=False,
+                                 rebuild_cache=False,
+                                 exclude_combined=True,
+                                 exclude_basic=False,
+                                 exclude_cheating=True,
+                                 exclude_ordinary=True,
+                                 noise=0)

--- a/axelrod/tests/integration/test_tournament.py
+++ b/axelrod/tests/integration/test_tournament.py
@@ -109,7 +109,7 @@ class TestProbEndTournamentManager(unittest.TestCase):
     def test_tournament_manager(self):
         strategies = [s() for s in axelrod.demo_strategies]
         tm = axelrod.ProbEndTournamentManager("./", False, save_cache=False)
-        tm.add_tournament("test-prob-end", strategies, repetitions=2, prob_end=.1,
+        tm.add_tournament("test-prob-end", strategies, repetitions=2, prob_end=.5,
                           noise=0.05)
         tm.run_tournaments()
 
@@ -117,13 +117,13 @@ class TestProbEndTournamentManager(unittest.TestCase):
         tm = axelrod.ProbEndTournamentManager("./", False, load_cache=False,
                                               save_cache=True)
         tm.add_tournament("test-prob-end", strategies, repetitions=2,
-                          prob_end=.1, noise=0.)
+                          prob_end=.5, noise=0.)
         tm.run_tournaments()
 
         tm = axelrod.ProbEndTournamentManager("./", False, load_cache=True,
                                               save_cache=True)
         tm.add_tournament("test-prob-end", strategies, repetitions=2,
-                          prob_end=.1, noise=0.)
+                          prob_end=.5, noise=0.)
         tm.run_tournaments()
 
     def test_utils(self):
@@ -131,7 +131,7 @@ class TestProbEndTournamentManager(unittest.TestCase):
         run_prob_end_tournaments(cache_file='./cache.txt',
                                  output_directory='./',
                                  repetitions=2,
-                                 prob_end=.1,
+                                 prob_end=.5,
                                  processes=None,
                                  no_ecological=False,
                                  rebuild_cache=False,

--- a/axelrod/tests/unit/test_tournament_manager.py
+++ b/axelrod/tests/unit/test_tournament_manager.py
@@ -108,6 +108,7 @@ class TestProbEndTournamentManager(unittest.TestCase):
         mgr = self.mgr_class(
             output_directory=self.test_output_directory,
             with_ecological=self.test_with_ecological, load_cache=False)
-        expected_label = "Prob end: {}, Repetitions: {}".format(tournament.prob_end,
-                tournament.repetitions)
+        expected_label = "Prob end: {}, Repetitions: {}, Strategies: {}.".format(tournament.prob_end,
+                    tournament.repetitions,
+                    len(tournament.players))
         self.assertEqual(mgr._tournament_label(tournament), expected_label)

--- a/axelrod/tests/unit/test_tournament_manager.py
+++ b/axelrod/tests/unit/test_tournament_manager.py
@@ -70,6 +70,7 @@ class TestTournamentManager(unittest.TestCase):
         mgr = axelrod.TournamentManager(
             output_directory=self.test_output_directory,
             with_ecological=self.test_with_ecological, load_cache=False)
-        expected_label = "Turns: {}, Repetitions: {}".format(tournament.turns,
-                tournament.repetitions)
+        expected_label = "Turns: {}, Repetitions: {}, Strategies: {}.".format(tournament.turns,
+                tournament.repetitions, len(tournament.players))
+
         self.assertEqual(mgr._tournament_label(tournament), expected_label)

--- a/axelrod/tests/unit/test_tournament_manager.py
+++ b/axelrod/tests/unit/test_tournament_manager.py
@@ -15,9 +15,10 @@ class TestTournamentManager(unittest.TestCase):
         cls.test_players = [axelrod.Defector(), axelrod.Cooperator()]
 
         cls.expected_output_file_path = './assets/test_file_name.png'
+        cls.mgr_class = axelrod.TournamentManager
 
     def test_init(self):
-        mgr = axelrod.TournamentManager(
+        mgr = self.mgr_class(
             self.test_output_directory,
             self.test_with_ecological)
         self.assertEqual(mgr._output_directory, self.test_output_directory)
@@ -26,7 +27,7 @@ class TestTournamentManager(unittest.TestCase):
         self.assertTrue(mgr._pass_cache)
 
     def test_one_player_per_strategy(self):
-        mgr = axelrod.TournamentManager(
+        mgr = self.mgr_class(
             self.test_output_directory,
             self.test_with_ecological)
         players = mgr.one_player_per_strategy(self.test_strategies)
@@ -34,7 +35,7 @@ class TestTournamentManager(unittest.TestCase):
         self.assertIsInstance(players[1], axelrod.Cooperator)
 
     def test_output_file_path(self):
-        mgr = axelrod.TournamentManager(
+        mgr = self.mgr_class(
             self.test_output_directory,
             self.test_with_ecological)
         output_file_path = mgr._output_file_path(
@@ -42,7 +43,7 @@ class TestTournamentManager(unittest.TestCase):
         self.assertEqual(output_file_path, self.expected_output_file_path)
 
     def test_add_tournament(self):
-        mgr = axelrod.TournamentManager(
+        mgr = self.mgr_class(
             self.test_output_directory,
             self.test_with_ecological)
         mgr.add_tournament(
@@ -52,7 +53,7 @@ class TestTournamentManager(unittest.TestCase):
         self.assertEqual(mgr._tournaments[0].name, self.test_tournament_name)
 
     def test_valid_cache(self):
-        mgr = axelrod.TournamentManager(
+        mgr = self.mgr_class(
             output_directory=self.test_output_directory,
             with_ecological=self.test_with_ecological, load_cache=False)
         mgr.add_tournament(
@@ -67,10 +68,46 @@ class TestTournamentManager(unittest.TestCase):
     def test_tournament_label(self):
         tournament = axelrod.Tournament(self.test_players, turns=20,
                                         repetitions=2)
-        mgr = axelrod.TournamentManager(
+        mgr = self.mgr_class(
             output_directory=self.test_output_directory,
             with_ecological=self.test_with_ecological, load_cache=False)
         expected_label = "Turns: {}, Repetitions: {}, Strategies: {}.".format(tournament.turns,
                 tournament.repetitions, len(tournament.players))
 
+        self.assertEqual(mgr._tournament_label(tournament), expected_label)
+
+
+class TestProbEndTournamentManager(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.test_output_directory = './assets/'
+        cls.test_with_ecological = True
+        cls.test_tournament_name = 'test_prob_tournament'
+        cls.test_file_name = 'test_prob_end_file_name'
+        cls.test_file_extenstion = 'png'
+        cls.test_strategies = [axelrod.Defector, axelrod.Cooperator]
+        cls.test_players = [axelrod.Defector(), axelrod.Cooperator()]
+
+        cls.expected_output_file_path = './assets/test__prob_end_file_name.png'
+        cls.mgr_class = axelrod.ProbEndTournamentManager
+
+    def test_add_tournament(self):
+        mgr = self.mgr_class(
+            self.test_output_directory,
+            self.test_with_ecological)
+        mgr.add_tournament(
+            players=self.test_players, name=self.test_tournament_name)
+        self.assertEqual(len(mgr._tournaments), 1)
+        self.assertIsInstance(mgr._tournaments[0], axelrod.ProbEndTournament)
+        self.assertEqual(mgr._tournaments[0].name, self.test_tournament_name)
+
+    def test_tournament_label(self):
+        tournament = axelrod.ProbEndTournament(self.test_players, prob_end=.5,
+                                               repetitions=2)
+        mgr = self.mgr_class(
+            output_directory=self.test_output_directory,
+            with_ecological=self.test_with_ecological, load_cache=False)
+        expected_label = "Prob end: {}, Repetitions: {}".format(tournament.prob_end,
+                tournament.repetitions)
         self.assertEqual(mgr._tournament_label(tournament), expected_label)

--- a/axelrod/tests/unit/test_tournament_manager.py
+++ b/axelrod/tests/unit/test_tournament_manager.py
@@ -63,3 +63,13 @@ class TestTournamentManager(unittest.TestCase):
         mgr._cache_valid_for_turns = 500
         self.assertFalse(mgr._valid_cache(200))
         self.assertTrue(mgr._valid_cache(500))
+
+    def test_tournament_label(self):
+        tournament = axelrod.Tournament(self.test_players, turns=20,
+                                        repetitions=2)
+        mgr = axelrod.TournamentManager(
+            output_directory=self.test_output_directory,
+            with_ecological=self.test_with_ecological, load_cache=False)
+        expected_label = "Turns: {}, Repetitions: {}".format(tournament.turns,
+                tournament.repetitions)
+        self.assertEqual(mgr._tournament_label(tournament), expected_label)

--- a/axelrod/tests/unit/test_tournament_manager_factory.py
+++ b/axelrod/tests/unit/test_tournament_manager_factory.py
@@ -21,10 +21,10 @@ class TestTournamentManagerFactory(unittest.TestCase):
         }
 
         cls.expected_basic_strategies = axelrod.basic_strategies
-        cls.expected_strategies = (
+        cls.expected_ordinary_strategies = (
             axelrod.ordinary_strategies)
         cls.expected_cheating_strategies = axelrod.cheating_strategies
-        cls.expected_all_strategies = (
+        cls.expected_strategies = (
             axelrod.ordinary_strategies +
             axelrod.cheating_strategies)
 
@@ -37,14 +37,14 @@ class TestTournamentManagerFactory(unittest.TestCase):
         actual_strategies = self.tmf._tournaments_dict()['strategies']
         actual_cheating_strategies = (
             self.tmf._tournaments_dict()['cheating_strategies'])
-        actual_all_strategies = self.tmf._tournaments_dict()['all_strategies']
+        actual_all_strategies = self.tmf._tournaments_dict()['strategies']
 
         self.assertEqual(
             actual_basic_strategies, self.expected_basic_strategies)
         self.assertEqual(actual_strategies, self.expected_strategies)
         self.assertEqual(
             actual_cheating_strategies, self.expected_cheating_strategies)
-        self.assertEqual(actual_all_strategies, self.expected_all_strategies)
+        self.assertEqual(actual_all_strategies, self.expected_strategies)
 
         # Tests to ensure that the exclusions list works as intended
         with_exclusions = self.tmf._tournaments_dict(self.test_exclusions)
@@ -61,7 +61,7 @@ class TestTournamentManagerFactory(unittest.TestCase):
         self.tmf._add_tournaments(mgr, self.test_exclusions, self.test_kwargs)
         self.assertEqual(len(mgr._tournaments), 2)
         self.assertIsInstance(mgr._tournaments[0], axelrod.Tournament)
-        self.assertEqual(mgr._tournaments[0].name, 'strategies')
+        self.assertEqual(mgr._tournaments[0].name, 'ordinary_strategies')
 
     def test_create_tournament_manager(self):
         mgr = self.tmf.create_tournament_manager(
@@ -98,10 +98,10 @@ class TestProbEndTournamentManagerFactory(unittest.TestCase):
         }
 
         cls.expected_basic_strategies = axelrod.basic_strategies
-        cls.expected_strategies = (
+        cls.expected_ordinary_strategies = (
             axelrod.ordinary_strategies)
         cls.expected_cheating_strategies = axelrod.cheating_strategies
-        cls.expected_all_strategies = (
+        cls.expected_strategies = (
             axelrod.ordinary_strategies +
             axelrod.cheating_strategies)
 
@@ -110,25 +110,25 @@ class TestProbEndTournamentManagerFactory(unittest.TestCase):
         # Tests to ensure that the tournaments dictionary contains the correct
         # keys and values
         actual_basic_strategies = (
-            self.tmf._tournaments_dict()['basic_strategies'])
-        actual_strategies = self.tmf._tournaments_dict()['strategies']
+            self.tmf._tournaments_dict()['basic_strategies_prob_end'])
+        actual_ordinary_strategies = self.tmf._tournaments_dict()['ordinary_strategies_prob_end']
         actual_cheating_strategies = (
-            self.tmf._tournaments_dict()['cheating_strategies'])
-        actual_all_strategies = self.tmf._tournaments_dict()['all_strategies']
+            self.tmf._tournaments_dict()['cheating_strategies_prob_end'])
+        actual_all_strategies = self.tmf._tournaments_dict()['strategies_prob_end']
 
         self.assertEqual(
             actual_basic_strategies, self.expected_basic_strategies)
-        self.assertEqual(actual_strategies, self.expected_strategies)
+        self.assertEqual(actual_ordinary_strategies, self.expected_ordinary_strategies)
         self.assertEqual(
             actual_cheating_strategies, self.expected_cheating_strategies)
-        self.assertEqual(actual_all_strategies, self.expected_all_strategies)
+        self.assertEqual(actual_all_strategies, self.expected_strategies)
 
         # Tests to ensure that the exclusions list works as intended
         with_exclusions = self.tmf._tournaments_dict(self.test_exclusions)
         self.assertFalse('basic_strategies' in with_exclusions)
         self.assertFalse('cheating_strategies' in with_exclusions)
         self.assertEqual(
-            with_exclusions['strategies'], self.expected_strategies)
+            with_exclusions['strategies_prob_end'], self.expected_strategies)
 
     def test_add_tournaments(self):
         mgr = axelrod.ProbEndTournamentManager(
@@ -138,7 +138,7 @@ class TestProbEndTournamentManagerFactory(unittest.TestCase):
         self.tmf._add_tournaments(mgr, self.test_exclusions, self.test_kwargs)
         self.assertEqual(len(mgr._tournaments), 2)
         self.assertIsInstance(mgr._tournaments[0], axelrod.Tournament)
-        self.assertEqual(mgr._tournaments[0].name, 'strategies')
+        self.assertEqual(mgr._tournaments[0].name, 'ordinary_strategies_prob_end')
 
     def test_create_tournament_manager(self):
         mgr = self.tmf.create_tournament_manager(

--- a/axelrod/tests/unit/test_tournament_manager_factory.py
+++ b/axelrod/tests/unit/test_tournament_manager_factory.py
@@ -77,3 +77,80 @@ class TestTournamentManagerFactory(unittest.TestCase):
         self.assertEqual(len(mgr._tournaments), 2)
         self.assertTrue(mgr._with_ecological)
         self.assertTrue(mgr._pass_cache)
+
+
+class TestProbEndTournamentManagerFactory(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmf = axelrod.ProbEndTournamentManagerFactory
+
+        cls.test_output_directory = './assets/'
+        cls.test_with_ecological = True
+        cls.test_rebuild_cache = False
+        cls.test_cache_file = './cache.txt'
+        cls.test_exclusions = ['basic_strategies', 'cheating_strategies']
+        cls.test_kwargs = {
+            'processes': 2,
+            'prob_end': .1,
+            'repetitions': 200,
+            'noise': 0
+        }
+
+        cls.expected_basic_strategies = axelrod.basic_strategies
+        cls.expected_strategies = (
+            axelrod.ordinary_strategies)
+        cls.expected_cheating_strategies = axelrod.cheating_strategies
+        cls.expected_all_strategies = (
+            axelrod.ordinary_strategies +
+            axelrod.cheating_strategies)
+
+    def test_tournaments_dict(self):
+
+        # Tests to ensure that the tournaments dictionary contains the correct
+        # keys and values
+        actual_basic_strategies = (
+            self.tmf._tournaments_dict()['basic_strategies'])
+        actual_strategies = self.tmf._tournaments_dict()['strategies']
+        actual_cheating_strategies = (
+            self.tmf._tournaments_dict()['cheating_strategies'])
+        actual_all_strategies = self.tmf._tournaments_dict()['all_strategies']
+
+        self.assertEqual(
+            actual_basic_strategies, self.expected_basic_strategies)
+        self.assertEqual(actual_strategies, self.expected_strategies)
+        self.assertEqual(
+            actual_cheating_strategies, self.expected_cheating_strategies)
+        self.assertEqual(actual_all_strategies, self.expected_all_strategies)
+
+        # Tests to ensure that the exclusions list works as intended
+        with_exclusions = self.tmf._tournaments_dict(self.test_exclusions)
+        self.assertFalse('basic_strategies' in with_exclusions)
+        self.assertFalse('cheating_strategies' in with_exclusions)
+        self.assertEqual(
+            with_exclusions['strategies'], self.expected_strategies)
+
+    def test_add_tournaments(self):
+        mgr = axelrod.ProbEndTournamentManager(
+            self.test_output_directory,
+            self.test_with_ecological)
+
+        self.tmf._add_tournaments(mgr, self.test_exclusions, self.test_kwargs)
+        self.assertEqual(len(mgr._tournaments), 2)
+        self.assertIsInstance(mgr._tournaments[0], axelrod.Tournament)
+        self.assertEqual(mgr._tournaments[0].name, 'strategies')
+
+    def test_create_tournament_manager(self):
+        mgr = self.tmf.create_tournament_manager(
+            output_directory=self.test_output_directory,
+            no_ecological=False,
+            rebuild_cache=self.test_rebuild_cache,
+            cache_file=self.test_cache_file,
+            exclusions=self.test_exclusions,
+            **self.test_kwargs)
+
+        self.assertIsInstance(mgr, axelrod.TournamentManager)
+        self.assertEqual(mgr._output_directory, self.test_output_directory)
+        self.assertEqual(len(mgr._tournaments), 2)
+        self.assertTrue(mgr._with_ecological)
+        self.assertTrue(mgr._pass_cache)

--- a/axelrod/tests/unit/test_utils.py
+++ b/axelrod/tests/unit/test_utils.py
@@ -51,8 +51,8 @@ class TestBuildExclusionsDict(unittest.TestCase):
         for (eb, eo, ec, eco) in itertools.product(bools, repeat=4):
             expected_dict = {
                 'basic_strategies': eb,
-                'strategies': eo,
+                'ordinary_strategies': eo,
                 'cheating_strategies': ec,
-                'all_strategies': eco}
+                'strategies': eco}
             self.assertEqual(axelrod.utils.build_exclusions_dict(eb, eo, ec, eco),
                              expected_dict)

--- a/axelrod/tests/unit/test_utils.py
+++ b/axelrod/tests/unit/test_utils.py
@@ -48,7 +48,7 @@ class TestBuildExclusionsDict(unittest.TestCase):
         """This is really a regression test to make sure the names of the
         tournaments stay consistent"""
         bools = [True, False]
-        for (eb, eo, ec, eco) in itertools.product(*[bools for _ in range(4)]):
+        for (eb, eo, ec, eco) in itertools.product(bools, repeat=4):
             expected_dict = {
                 'basic_strategies': eb,
                 'strategies': eo,

--- a/axelrod/tests/unit/test_utils.py
+++ b/axelrod/tests/unit/test_utils.py
@@ -2,6 +2,7 @@
 
 import axelrod
 import unittest
+import itertools
 
 from hypothesis import given
 from hypothesis.strategies import floats, text
@@ -26,7 +27,6 @@ class TestTimedMessage(unittest.TestCase):
         self.assertGreaterEqual(float(timed_message[len(message)+4:-1]), 0)
 
 
-
 class TestSetupLogging(unittest.TestCase):
 
     def test_basic_configuration_console(self):
@@ -41,3 +41,18 @@ class TestSetupLogging(unittest.TestCase):
             axelrod.utils.setup_logging(logging_destination='console',
                                         verbosity=level)
             compare(logger.level, levels[level])
+
+
+class TestBuildExclusionsDict(unittest.TestCase):
+    def test_build_exclusions_dict(self):
+        """This is really a regression test to make sure the names of the
+        tournaments stay consistent"""
+        bools = [True, False]
+        for (eb, eo, ec, eco) in itertools.product(*[bools for _ in range(4)]):
+            expected_dict = {
+                'basic_strategies': eb,
+                'strategies': eo,
+                'cheating_strategies': ec,
+                'all_strategies': eco}
+            self.assertEqual(axelrod.utils.build_exclusions_dict(eb, eo, ec, eco),
+                             expected_dict)

--- a/axelrod/tournament_manager.py
+++ b/axelrod/tournament_manager.py
@@ -16,6 +16,13 @@ class TournamentManager(object):
                   'winplot': "Wins. ", 'sdvplot': "Std Payoffs. ",
                   'pdplot': "Payoff differences. ", 'lengthplot': "Lengths. "}
 
+    ecoturns = {
+            'basic_strategies': 1000,
+            'cheating_strategies': 10,
+            'strategies': 1000,
+            'all_strategies': 10,
+        }
+
     def __init__(self, output_directory, with_ecological,
                  pass_cache=True, load_cache=True, save_cache=False,
                  cache_file='./cache.txt', image_format="svg"):
@@ -104,13 +111,7 @@ class TournamentManager(object):
         self._logger.debug(
             'Starting ecological variant of %s' % tournament.name)
         t0 = time.time()
-        ecoturns = {
-            'basic_strategies': 1000,
-            'cheating_strategies': 10,
-            'strategies': 1000,
-            'all_strategies': 10,
-        }
-        ecosystem.reproduce(ecoturns.get(tournament.name))
+        ecosystem.reproduce(self.ecoturns.get(tournament.name))
         self._logger.debug(
             timed_message('Finished ecological variant of %s' % tournament.name, t0))
 
@@ -189,6 +190,14 @@ class TournamentManager(object):
 
 class ProbEndTournamentManager(TournamentManager):
     """A class to manage and create probabilistic ending tournaments."""
+
+    ecoturns = {
+            'basic_strategies_prob_end': 1000,
+            'cheating_strategies_prob_end': 10,
+            'strategies_prob_end': 1000,
+            'all_strategies_prob_end': 10,
+        }
+
     def add_tournament(self, name, players, game=None, prob_end=.01,
                        repetitions=10, processes=None, noise=0,
                        with_morality=True):

--- a/axelrod/tournament_manager.py
+++ b/axelrod/tournament_manager.py
@@ -11,6 +11,10 @@ from .utils import *
 
 class TournamentManager(object):
 
+    plot_types = {'boxplot': "Payoffs. ", 'payoff': "Payoffs. ",
+                  'winplot': "Wins. ", 'sdvplot': "Std Payoffs. ",
+                  'pdplot': "Payoff differences. ", 'lengthplot': "Lengths. "}
+
     def __init__(self, output_directory, with_ecological,
                  pass_cache=True, load_cache=True, save_cache=False,
                  cache_file='./cache.txt', image_format="svg"):
@@ -128,16 +132,23 @@ class TournamentManager(object):
             self._logger.error('The matplotlib library is not installed. '
                             'No plots will be produced')
             return
-        for plot_type in ('boxplot', 'payoff', 'winplot', 'sdvplot', 'pdplot'):
-            figure = getattr(plot, plot_type)()
+        label = self._tournament_label(tournament)
+        for plot_type, name in self.plot_types.items():
+            title = name + label
+            figure = getattr(plot, plot_type)(title=title)
             file_name = self._output_file_path(
                 tournament.name + '_' + plot_type, image_format)
             self._save_plot(figure, file_name)
         if ecosystem is not None:
-            figure = plot.stackplot(ecosystem)
+            figure = plot.stackplot(ecosystem, title=title)
             file_name = self._output_file_path(
                     tournament.name + '_reproduce', image_format)
             self._save_plot(figure, file_name)
+
+    def _tournament_label(self, tournament):
+        """A label for the tournament for the corresponding title plots"""
+        return "Turns: {}, Repetitions: {}".format(tournament.turns,
+                tournament.repetitions)
 
     def _output_file_path(self, file_name, file_extension):
         return os.path.join(

--- a/axelrod/tournament_manager.py
+++ b/axelrod/tournament_manager.py
@@ -213,8 +213,9 @@ class ProbEndTournamentManager(TournamentManager):
 
     def _tournament_label(self, tournament):
         """A label for the tournament for the corresponding title plots"""
-        return "Prob end: {}, Repetitions: {}".format(tournament.prob_end,
-                                                      tournament.repetitions)
+        return "Prob end: {}, Repetitions: {}, Strategies: {}.".format(tournament.prob_end,
+                                                       tournament.repetitions,
+                                                       len(tournament.players))
 
 
 class DeterministicCache(object):

--- a/axelrod/tournament_manager.py
+++ b/axelrod/tournament_manager.py
@@ -19,8 +19,8 @@ class TournamentManager(object):
     ecoturns = {
             'basic_strategies': 1000,
             'cheating_strategies': 10,
-            'strategies': 1000,
-            'all_strategies': 10,
+            'ordinary_strategies': 1000,
+            'strategies': 10,
         }
 
     def __init__(self, output_directory, with_ecological,
@@ -194,8 +194,8 @@ class ProbEndTournamentManager(TournamentManager):
     ecoturns = {
             'basic_strategies_prob_end': 1000,
             'cheating_strategies_prob_end': 10,
-            'strategies_prob_end': 1000,
-            'all_strategies_prob_end': 10,
+            'ordinary_strategies_prob_end': 1000,
+            'strategies_prob_end': 10,
         }
 
     def add_tournament(self, name, players, game=None, prob_end=.01,

--- a/axelrod/tournament_manager.py
+++ b/axelrod/tournament_manager.py
@@ -140,6 +140,7 @@ class TournamentManager(object):
                 tournament.name + '_' + plot_type, image_format)
             self._save_plot(figure, file_name)
         if ecosystem is not None:
+            title = "Eco. " + label
             figure = plot.stackplot(ecosystem, title=title)
             file_name = self._output_file_path(
                     tournament.name + '_reproduce', image_format)

--- a/axelrod/tournament_manager.py
+++ b/axelrod/tournament_manager.py
@@ -10,6 +10,7 @@ from .utils import *
 
 
 class TournamentManager(object):
+    """A class to manage and create tournaments."""
 
     plot_types = {'boxplot': "Payoffs. ", 'payoff': "Payoffs. ",
                   'winplot': "Wins. ", 'sdvplot': "Std Payoffs. ",
@@ -61,8 +62,8 @@ class TournamentManager(object):
 
     def _run_single_tournament(self, tournament):
         self._logger.info(
-            'Starting %s tournament with %d round robins of %d turns per pair.'
-            % (tournament.name, tournament.repetitions, tournament.turns))
+                'Starting %s tournament: ' + self._tournament_label(tournament)
+            )
 
         t0 = time.time()
 
@@ -184,6 +185,27 @@ class TournamentManager(object):
         except IOError:
             self._logger.debug('Cache file not found. Starting with empty cache')
             return False
+
+
+class ProbEndTournamentManager(TournamentManager):
+    """A class to manage and create probabilistic ending tournaments."""
+    def add_tournament(self, name, players, game=None, prob_end=.01,
+                       repetitions=10, processes=None, noise=0,
+                       with_morality=True):
+        tournament = ProbEndTournament(
+            name=name,
+            players=players,
+            prob_end=prob_end,
+            repetitions=repetitions,
+            processes=processes,
+            noise=noise,
+            with_morality=with_morality)
+        self._tournaments.append(tournament)
+
+    def _tournament_label(self, tournament):
+        """A label for the tournament for the corresponding title plots"""
+        return "Prob end: {}, Repetitions: {}".format(tournament.prob_end,
+                                                      tournament.repetitions)
 
 
 class DeterministicCache(object):

--- a/axelrod/tournament_manager.py
+++ b/axelrod/tournament_manager.py
@@ -148,8 +148,9 @@ class TournamentManager(object):
 
     def _tournament_label(self, tournament):
         """A label for the tournament for the corresponding title plots"""
-        return "Turns: {}, Repetitions: {}".format(tournament.turns,
-                tournament.repetitions)
+        return "Turns: {}, Repetitions: {}, Strategies: {}.".format(tournament.turns,
+                                                       tournament.repetitions,
+                                                       len(tournament.players))
 
     def _output_file_path(self, file_name, file_extension):
         return os.path.join(

--- a/axelrod/tournament_manager.py
+++ b/axelrod/tournament_manager.py
@@ -62,7 +62,7 @@ class TournamentManager(object):
 
     def _run_single_tournament(self, tournament):
         self._logger.info(
-                'Starting %s tournament: ' + self._tournament_label(tournament)
+                'Starting {} tournament: '.format(tournament.name) + self._tournament_label(tournament)
             )
 
         t0 = time.time()

--- a/axelrod/tournament_manager_factory.py
+++ b/axelrod/tournament_manager_factory.py
@@ -66,3 +66,38 @@ class TournamentManagerFactory(object):
             (key, value) for
             key, value in tournaments.items() if key not in exclusions
         ])
+
+
+class ProbEndTournamentManagerFactory(TournamentManagerFactory):
+
+    @classmethod
+    def create_tournament_manager(
+            cls,
+            output_directory,
+            no_ecological,
+            rebuild_cache,
+            cache_file,
+            exclusions,
+            processes,
+            prob_end,
+            repetitions,
+            noise,
+            image_format="svg"):
+
+        kwargs = {
+            'processes': processes,
+            'prob_end': prob_end,
+            'repetitions': repetitions,
+            'noise': noise,
+        }
+
+        manager = axelrod.ProbEndTournamentManager(
+            output_directory=output_directory,
+            with_ecological=not no_ecological,
+            save_cache=rebuild_cache,
+            cache_file=cache_file,
+            image_format=image_format)
+
+        cls._add_tournaments(manager, exclusions, kwargs)
+
+        return manager

--- a/axelrod/tournament_manager_factory.py
+++ b/axelrod/tournament_manager_factory.py
@@ -8,6 +8,17 @@ from .tournament_manager import *
 
 class TournamentManagerFactory(object):
 
+
+    tournaments = OrderedDict([
+        ('basic_strategies', axelrod.basic_strategies),
+        ('ordinary_strategies',
+            axelrod.ordinary_strategies),
+        ('cheating_strategies', axelrod.cheating_strategies),
+        ('strategies',
+            axelrod.ordinary_strategies +
+            axelrod.cheating_strategies)
+    ])
+
     @classmethod
     def create_tournament_manager(
             cls,
@@ -47,24 +58,14 @@ class TournamentManagerFactory(object):
             manager.add_tournament(
                 name=name, players=players, **kwargs)
 
-    @staticmethod
-    def _tournaments_dict(exclusions=None):
+    @classmethod
+    def _tournaments_dict(cls, exclusions=None):
         if exclusions is None:
             exclusions = []
 
-        tournaments = OrderedDict([
-            ('basic_strategies', axelrod.basic_strategies),
-            ('strategies',
-                axelrod.ordinary_strategies),
-            ('cheating_strategies', axelrod.cheating_strategies),
-            ('all_strategies',
-                axelrod.ordinary_strategies +
-                axelrod.cheating_strategies)
-        ])
-
         return OrderedDict([
             (key, value) for
-            key, value in tournaments.items() if key not in exclusions
+            key, value in cls.tournaments.items() if key not in exclusions
         ])
 
 
@@ -102,23 +103,12 @@ class ProbEndTournamentManagerFactory(TournamentManagerFactory):
 
         return manager
 
-    @staticmethod
-    def _tournaments_dict(exclusions=None):
+    @classmethod
+    def _tournaments_dict(cls, exclusions=None):
         if exclusions is None:
             exclusions = []
 
-        tournaments = OrderedDict([
-            ('basic_strategies', axelrod.basic_strategies),
-            ('strategies',
-                axelrod.ordinary_strategies),
-            ('cheating_strategies', axelrod.cheating_strategies),
-            ('all_strategies',
-                axelrod.ordinary_strategies +
-                axelrod.cheating_strategies)
-        ])
-
         return OrderedDict([
             (key+'_prob_end', value) for
-            key, value in tournaments.items() if key not in exclusions
+            key, value in cls.tournaments.items() if key not in exclusions
         ])
-

--- a/axelrod/tournament_manager_factory.py
+++ b/axelrod/tournament_manager_factory.py
@@ -101,3 +101,24 @@ class ProbEndTournamentManagerFactory(TournamentManagerFactory):
         cls._add_tournaments(manager, exclusions, kwargs)
 
         return manager
+
+    @staticmethod
+    def _tournaments_dict(exclusions=None):
+        if exclusions is None:
+            exclusions = []
+
+        tournaments = OrderedDict([
+            ('basic_strategies', axelrod.basic_strategies),
+            ('strategies',
+                axelrod.ordinary_strategies),
+            ('cheating_strategies', axelrod.cheating_strategies),
+            ('all_strategies',
+                axelrod.ordinary_strategies +
+                axelrod.cheating_strategies)
+        ])
+
+        return OrderedDict([
+            (key+'_prob_end', value) for
+            key, value in tournaments.items() if key not in exclusions
+        ])
+

--- a/axelrod/utils.py
+++ b/axelrod/utils.py
@@ -43,9 +43,9 @@ def build_exclusions_dict(exclude_basic, exclude_ordinary,
     to booleans."""
     return {
         'basic_strategies': exclude_basic,
-        'strategies': exclude_ordinary,
+        'ordinary_strategies': exclude_ordinary,
         'cheating_strategies': exclude_cheating,
-        'all_strategies': exclude_combined}
+        'strategies': exclude_combined}
 
 
 def run_tournaments(cache_file='./cache.txt',

--- a/axelrod/utils.py
+++ b/axelrod/utils.py
@@ -37,6 +37,17 @@ def setup_logging(logging_destination='console', verbosity='INFO'):
     logger.addHandler(logHandler)
 
 
+def build_exclusions_dict(exclude_basic, exclude_ordinary,
+                          exclude_cheating, exclude_combined):
+    """A utility function to return a dictionary mapping tournament string names
+    to booleans."""
+    return {
+        'basic_strategies': exclude_basic,
+        'strategies': exclude_ordinary,
+        'cheating_strategies': exclude_cheating,
+        'all_strategies': exclude_combined}
+
+
 def run_tournaments(cache_file='./cache.txt',
                     output_directory='./',
                     repetitions=10,
@@ -51,11 +62,8 @@ def run_tournaments(cache_file='./cache.txt',
                     noise=0,
                     image_format="svg"):
 
-    exclusions_dict = {
-        'basic_strategies': exclude_basic,
-        'strategies': exclude_ordinary,
-        'cheating_strategies': exclude_cheating,
-        'all_strategies': exclude_combined}
+    exclusions_dict = build_exclusions_dict(exclude_basic, exclude_ordinary,
+                                            exclude_cheating, exclude_combined)
 
     exclusions = [key for key, value in exclusions_dict.items() if value]
 
@@ -88,11 +96,8 @@ def run_prob_end_tournaments(cache_file='./cache.txt',
                     noise=0,
                     image_format="svg"):
 
-    exclusions_dict = {
-        'basic_strategies': exclude_basic,
-        'strategies': exclude_ordinary,
-        'cheating_strategies': exclude_cheating,
-        'all_strategies': exclude_combined}
+    exclusions_dict = build_exclusions_dict(exclude_basic, exclude_ordinary,
+                                            exclude_cheating, exclude_combined)
 
     exclusions = [key for key, value in exclusions_dict.items() if value]
 

--- a/axelrod/utils.py
+++ b/axelrod/utils.py
@@ -3,7 +3,8 @@ from __future__ import absolute_import
 import time
 import logging
 
-from .tournament_manager_factory import TournamentManagerFactory
+from .tournament_manager_factory import (TournamentManagerFactory,
+                                         ProbEndTournamentManagerFactory)
 
 
 def timed_message(message, start_time):
@@ -66,6 +67,43 @@ def run_tournaments(cache_file='./cache.txt',
         exclusions=exclusions,
         processes=processes,
         turns=turns,
+        repetitions=repetitions,
+        noise=noise,
+        image_format=image_format)
+
+    manager.run_tournaments()
+
+
+def run_prob_end_tournaments(cache_file='./cache.txt',
+                    output_directory='./',
+                    repetitions=10,
+                    prob_end=.01,  # By default have mean of 100 rounds
+                    processes=None,
+                    no_ecological=False,
+                    rebuild_cache=False,
+                    exclude_combined=False,
+                    exclude_basic=False,
+                    exclude_cheating=False,
+                    exclude_ordinary=False,
+                    noise=0,
+                    image_format="svg"):
+
+    exclusions_dict = {
+        'basic_strategies': exclude_basic,
+        'strategies': exclude_ordinary,
+        'cheating_strategies': exclude_cheating,
+        'all_strategies': exclude_combined}
+
+    exclusions = [key for key, value in exclusions_dict.items() if value]
+
+    manager = ProbEndTournamentManagerFactory.create_tournament_manager(
+        output_directory=output_directory,
+        no_ecological=no_ecological,
+        rebuild_cache=rebuild_cache,
+        cache_file=cache_file,
+        exclusions=exclusions,
+        processes=processes,
+        prob_end=prob_end,
         repetitions=repetitions,
         noise=noise,
         image_format=image_format)

--- a/docs/tutorials/getting_started/command_line.rst
+++ b/docs/tutorials/getting_started/command_line.rst
@@ -19,7 +19,8 @@ There is a variety of options that include:
 - Excluding certain strategy sets.
 - Not running the ecological variant.
 - Running the rounds of the tournament in parallel.
-- Include background noise
+- Include background noise.
+- Running probabilistic ending tournament.
 
 Particular parameters can also be changed:
 

--- a/run_axelrod
+++ b/run_axelrod
@@ -7,7 +7,7 @@ The code for strategies is present in `axelrod/strategies`.
 
 from __future__ import division
 import argparse
-from axelrod import run_tournaments, setup_logging
+from axelrod import run_tournaments, run_prob_end_tournaments, setup_logging
 
 if __name__ == "__main__":
 
@@ -33,6 +33,13 @@ if __name__ == "__main__":
         type=int,
         default=200,
         help='turns per pair')
+
+    parser.add_argument(
+        '-pe',
+        '--prob_end',
+        type=float,
+        default=None,
+        help='probability of a match ending (if provided overrides turns)')
 
     parser.add_argument(
         '-r', '--repetitions',
@@ -119,4 +126,10 @@ if __name__ == "__main__":
         kwargs = vars(args)
         del kwargs["logging_destination"]
         del kwargs["verbosity"]
-        run_tournaments(**kwargs)
+
+        if kwargs['prob_end'] is None:
+            del kwargs["prob_end"]
+            run_tournaments(**kwargs)
+        else:
+            del kwargs["turns"]
+            run_prob_end_tournaments(**kwargs)

--- a/test
+++ b/test
@@ -1,14 +1,50 @@
 #!/usr/bin/env bash
 python -m unittest discover axelrod/tests/
+python doctests.py
+
+# Deleting outputs:
+
 rm basic_strategies_boxplot.svg
+rm basic_strategies_lengthplot.svg
 rm basic_strategies_payoff.svg
 rm basic_strategies_pdplot.svg
+rm basic_strategies_prob_end.csv
+rm basic_strategies_prob_end_boxplot.svg
+rm basic_strategies_prob_end_lengthplot.svg
+rm basic_strategies_prob_end_payoff.svg
+rm basic_strategies_prob_end_pdplot.svg
+rm basic_strategies_prob_end_reproduce.svg
+rm basic_strategies_prob_end_sdvplot.svg
+rm basic_strategies_prob_end_winplot.svg
 rm basic_strategies_reproduce.svg
 rm basic_strategies_sdvplot.svg
 rm basic_strategies_winplot.svg
+rm ordinary_strategies.csv
+rm ordinary_strategies_boxplot.svg
+rm ordinary_strategies_lengthplot.svg
+rm ordinary_strategies_payoff.svg
+rm ordinary_strategies_pdplot.svg
+rm ordinary_strategies_prob_end.csv
+rm ordinary_strategies_prob_end_boxplot.svg
+rm ordinary_strategies_prob_end_lengthplot.svg
+rm ordinary_strategies_prob_end_payoff.svg
+rm ordinary_strategies_prob_end_pdplot.svg
+rm ordinary_strategies_prob_end_reproduce.svg
+rm ordinary_strategies_prob_end_sdvplot.svg
+rm ordinary_strategies_prob_end_winplot.svg
+rm ordinary_strategies_reproduce.svg
+rm ordinary_strategies_sdvplot.svg
+rm ordinary_strategies_winplot.svg
+rm test-prob-end.csv
+rm test-prob-end_boxplot.svg
+rm test-prob-end_lengthplot.svg
+rm test-prob-end_payoff.svg
+rm test-prob-end_pdplot.svg
+rm test-prob-end_sdvplot.svg
+rm test-prob-end_winplot.svg
 rm test_boxplot.svg
+rm test_lengthplot.svg
 rm test_payoff.svg
 rm test_pdplot.svg
 rm test_sdvplot.svg
 rm test_winplot.svg
-python doctests.py


### PR DESCRIPTION
This adds to #513 and also addresses the naming of the tournaments output by the manager as discussed here: https://github.com/Axelrod-Python/tournament/issues/27