### PR TITLE
Fixes #516 Workers only send results back (a dictionary)

### DIFF
--- a/axelrod/tests/integration/test_tournament.py
+++ b/axelrod/tests/integration/test_tournament.py
@@ -32,7 +32,6 @@ class TestTournament(unittest.TestCase):
         tournament = axelrod.Tournament(name='test', players=strategies, game=self.game, turns=20, repetitions=2)
         results = tournament.play()
         self.assertIsInstance(results, axelrod.ResultSet)
-        #self.assertEqual(len(output_of_tournament['payoff']), len(strategies))
 
     def test_serial_play(self):
         tournament = axelrod.Tournament(

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -152,6 +152,20 @@ class TestTournament(unittest.TestCase):
         results = tournament.play()
         self.assertIsInstance(results, axelrod.ResultSet)
 
+        # The following relates to #516
+        players = [axelrod.Cooperator(), axelrod.Defector(),
+                   axelrod.BackStabber(), axelrod.PSOGambler(),
+                   axelrod.ThueMorse()]
+        tournament = axelrod.Tournament(
+            name=self.test_name,
+            players=players,
+            game=self.game,
+            turns=20,
+            repetitions=self.test_repetitions,
+            processes=2)
+        scores = tournament.play().scores
+        self.assertEqual(len(scores), len(players))
+
     def test_build_cache_required(self):
         # Noisy, no prebuilt cache, empty deterministic cache
         tournament = axelrod.Tournament(
@@ -331,7 +345,7 @@ class TestTournament(unittest.TestCase):
             turns=200,
             repetitions=self.test_repetitions)
         for r in range(self.test_repetitions):
-            done_queue.put([])
+            done_queue.put({})
         for w in range(workers):
             done_queue.put('STOP')
         tournament._process_done_queue(workers, done_queue, matches)
@@ -357,7 +371,7 @@ class TestTournament(unittest.TestCase):
             self.assertEqual(len(new_matches), 15)
             for index_pair, match in new_matches.items():
                 self.assertIsInstance(index_pair, tuple)
-                self.assertIsInstance(match, axelrod.Match)
+                self.assertIsInstance(match, list)
         queue_stop = done_queue.get()
         self.assertEqual(queue_stop, 'STOP')
 

--- a/axelrod/tournament.py
+++ b/axelrod/tournament.py
@@ -233,11 +233,6 @@ class Tournament(object):
             if results == 'STOP':
                 stops += 1
             else:
-
-                # Because of the Multiprocessing issue described in `def
-                # _worker` we have to rebuild the matches so that they can be
-                # handled in a consistent way by the results class.  Rebuild
-                # the matches with the data:
                 new_matches = self.tournament_type.build_matches(
                     cache_mutable=False, noise=self.noise)
                 for index_pair, result in results.items():
@@ -262,9 +257,6 @@ class Tournament(object):
                 cache_mutable=False, noise=self.noise)
             self._play_matches(new_matches)
 
-            # Multiprocessing cannot pass back the `new_matches`
-            # so we cannot do: `done_queue.put(new_matches)`
-            # Instead we send back the results.
             results = {index_pair: match.result for
                        index_pair, match in new_matches.items()}
             done_queue.put(results)

--- a/axelrod/tournament.py
+++ b/axelrod/tournament.py
@@ -233,10 +233,11 @@ class Tournament(object):
             if results == 'STOP':
                 stops += 1
             else:
-                # Because of the Multiprocessing issue described in `def _worker`
-                # we have to rebuild the matches so that they can be handled in
-                # a consistent way by the results class.
-                # Rebuild the matches with the data:
+
+                # Because of the Multiprocessing issue described in `def
+                # _worker` we have to rebuild the matches so that they can be
+                # handled in a consistent way by the results class.  Rebuild
+                # the matches with the data:
                 new_matches = self.tournament_type.build_matches(
                     cache_mutable=False, noise=self.noise)
                 for index_pair, result in results.items():

--- a/axelrod/tournament.py
+++ b/axelrod/tournament.py
@@ -228,10 +228,20 @@ class Tournament(object):
         """
         stops = 0
         while stops < workers:
-            new_matches = done_queue.get()
-            if new_matches == 'STOP':
+            results = done_queue.get()
+
+            if results == 'STOP':
                 stops += 1
             else:
+                # Because of the Multiprocessing issue described in `def _worker`
+                # we have to rebuild the matches so that they can be handled in
+                # a consistent way by the results class.
+                # Rebuild the matches with the data:
+                new_matches = self.tournament_type.build_matches(
+                    cache_mutable=False, noise=self.noise)
+                for index_pair, result in results.items():
+                    new_matches[index_pair].result = result
+
                 matches.append(new_matches)
         return True
 
@@ -250,7 +260,13 @@ class Tournament(object):
             new_matches = self.tournament_type.build_matches(
                 cache_mutable=False, noise=self.noise)
             self._play_matches(new_matches)
-            done_queue.put(new_matches)
+
+            # Multiprocessing cannot pass back the `new_matches`
+            # so we cannot do: `done_queue.put(new_matches)`
+            # Instead we send back the results.
+            results = {index_pair: match.result for
+                       index_pair, match in new_matches.items()}
+            done_queue.put(results)
         done_queue.put('STOP')
         return True
 


### PR DESCRIPTION
This can be handled by the Multiprocessing module.

Here is a screenshot showing this working (with 8 repetitions so it definitely used the cores):

https://www.dropbox.com/s/1gzozp3vsj9mcuy/Screenshot%202016-04-03%2021.08.32.png?dl=0

I've left comments in the relevant places but these could be removed and
put in an issue to investigate the use of alternatives to the standard
multiprocessing module.