### PR TITLE
Investigating 520: reducing memory consumption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Axelrod.egg-info
 basic_strategies.csv
 cache.txt
 test.csv
+basic_tournament.csv

--- a/axelrod/__init__.py
+++ b/axelrod/__init__.py
@@ -14,6 +14,6 @@ from .tournament import Tournament, ProbEndTournament
 from .tournament_manager import TournamentManager, ProbEndTournamentManager
 from .tournament_manager_factory import (TournamentManagerFactory,
                                          ProbEndTournamentManagerFactory)
-from .result_set import ResultSet
+from .result_set import ResultSet, ResultSetFromFile
 from .ecosystem import Ecosystem
 from .utils import run_tournaments, run_prob_end_tournaments, setup_logging

--- a/axelrod/interaction_utils.py
+++ b/axelrod/interaction_utils.py
@@ -80,3 +80,20 @@ def get_normalised_cooperation(interactions):
     normalised_cooperation = tuple([c / float(nturns) for c in cooperation])
 
     return normalised_cooperation
+
+
+def sparkline(actions, c_symbol=u'█', d_symbol=u' '):
+    return u''.join([
+        c_symbol if play == 'C' else d_symbol for play in actions])
+
+
+def get_sparklines(interactions, c_symbol=u'█', d_symbol=u' '):
+    """Returns the sparklines for a set of interactions"""
+    if len(interactions) == 0:
+        return None
+
+    histories = list(zip(*interactions))
+    return (
+        sparkline(histories[0], c_symbol, d_symbol) +
+        u'\n' +
+        sparkline(histories[1], c_symbol, d_symbol))

--- a/axelrod/interaction_utils.py
+++ b/axelrod/interaction_utils.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Functions to calculate results from interactions. Interactions are lists of the
 form:

--- a/axelrod/interaction_utils.py
+++ b/axelrod/interaction_utils.py
@@ -98,3 +98,19 @@ def get_sparklines(interactions, c_symbol=u'█', d_symbol=u' '):
         sparkline(histories[0], c_symbol, d_symbol) +
         u'\n' +
         sparkline(histories[1], c_symbol, d_symbol))
+
+
+def string_to_interactions(string):
+    """
+    Converts a compact string representation of an interaction to an
+    interaction:
+
+    'CDCDDD' -> [('C', 'D'), ('C', 'D'), ('D', 'D')]
+    """
+    interactions = []
+    interactions_list = list(string)
+    while interactions_list:
+        p1action = interactions_list.pop(0)
+        p2action = interactions_list.pop(0)
+        interactions.append((p1action, p2action))
+    return interactions

--- a/axelrod/interaction_utils.py
+++ b/axelrod/interaction_utils.py
@@ -1,0 +1,82 @@
+"""
+Functions to calculate results from interactions. Interactions are lists of the
+form:
+
+    [('C', 'D'), ('D', 'C'),...]
+
+This is used by both the Match class and the ResultSet class which analyse
+interactions.
+"""
+from .game import Game
+from axelrod import Actions
+
+C, D = Actions.C, Actions.D
+
+def get_scores(interactions, game=None):
+    """Returns the scores of a given set of interactions."""
+    if not game:
+        game = Game()
+    return [game.score(plays) for plays in interactions]
+
+
+def get_final_score(interactions, game=None):
+    """Returns the final score of a given set of interactions."""
+    scores = get_scores(interactions, game)
+    if len(scores) == 0:
+        return None
+
+    final_score = tuple(sum([score[playeri] for score in scores])
+                        for playeri in [0, 1])
+    return final_score
+
+
+def get_final_score_per_turn(interactions, game=None):
+    """Returns the mean score per round for a set of interactions"""
+    scores = get_scores(interactions, game)
+    nturns = len(interactions)
+
+    if len(scores) == 0:
+        return None
+
+    final_score_per_turn = tuple(
+        sum([score[playeri] for score in scores]) / (float(nturns))
+        for playeri in [0, 1])
+    return final_score_per_turn
+
+
+def get_winner_index(interactions, game=None):
+    """Returns the index of the winner of the Match"""
+    scores = get_final_score(interactions, game)
+
+    if scores is not None:
+        if scores[0] == scores[1]:
+            return False  # No winner
+        return sorted([0, 1],
+                      key=lambda i: scores[i])[-1]
+    return None
+
+
+def get_cooperations(interactions):
+    """Returns the count of cooperations by each player for a set of
+    interactions"""
+
+    if len(interactions) == 0:
+        return None
+
+    cooperation = tuple(sum([play[playeri] == C for play in interactions])
+                        for playeri in [0, 1])
+    return cooperation
+
+
+def get_normalised_cooperation(interactions):
+    """Returns the count of cooperations by each player per turn for a set of
+    interactions"""
+    if len(interactions) == 0:
+        return None
+
+    nturns = len(interactions)
+    cooperation = get_cooperations(interactions)
+
+    normalised_cooperation = tuple([c / float(nturns) for c in cooperation])
+
+    return normalised_cooperation

--- a/axelrod/match.py
+++ b/axelrod/match.py
@@ -1,13 +1,9 @@
 # -*- coding: utf-8 -*-
 from axelrod import Actions
-from .interaction_utils import *
+
+import axelrod.interaction_utils as iu
 
 C, D = Actions.C, Actions.D
-
-
-def sparkline(actions, c_symbol=u'█', d_symbol=u' '):
-    return u''.join([
-        c_symbol if play == 'C' else d_symbol for play in actions])
 
 
 class Match(object):
@@ -100,22 +96,22 @@ class Match(object):
 
     def scores(self, game=None):
         """Returns the scores of the previous Match plays."""
-        scores = get_scores(self.result, game)
+        scores = iu.get_scores(self.result, game)
         return scores
 
     def final_score(self, game=None):
         """Returns the final score for a Match"""
-        final_score = get_final_score(self.result, game)
+        final_score = iu.get_final_score(self.result, game)
         return final_score
 
     def final_score_per_turn(self, game=None):
         """Returns the mean score per round for a Match"""
-        final_score_per_turn = get_final_score_per_turn(self.result, game)
+        final_score_per_turn = iu.get_final_score_per_turn(self.result, game)
         return final_score_per_turn
 
     def winner(self, game=None):
         """Returns the winner of the Match"""
-        winner_index = get_winner_index(self.result, game)
+        winner_index = iu.get_winner_index(self.result, game)
         if winner_index is False:  # No winner
             return False
         if winner_index is None:  # No plays
@@ -124,17 +120,14 @@ class Match(object):
 
     def cooperation(self):
         """Returns the count of cooperations by each player"""
-        return get_cooperations(self.result)
+        return iu.get_cooperations(self.result)
 
     def normalised_cooperation(self):
         """Returns the count of cooperations by each player per turn"""
-        return get_normalised_cooperation(self.result)
+        return iu.get_normalised_cooperation(self.result)
 
     def sparklines(self, c_symbol=u'█', d_symbol=u' '):
-        return (
-            sparkline(self.players[0].history, c_symbol, d_symbol) +
-            u'\n' +
-            sparkline(self.players[1].history, c_symbol, d_symbol))
+        return iu.get_sparklines(self.result, c_symbol, d_symbol)
 
     def __len__(self):
         return self._turns

--- a/axelrod/match.py
+++ b/axelrod/match.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from .game import Game
 from axelrod import Actions
+from .interaction_utils import *
 
 C, D = Actions.C, Actions.D
 
@@ -100,66 +100,35 @@ class Match(object):
 
     def scores(self, game=None):
         """Returns the scores of the previous Match plays."""
-        if not game:
-            game = Game()
-        scores = [game.score(plays) for plays in self.result]
+        scores = get_scores(self.result, game)
         return scores
 
     def final_score(self, game=None):
         """Returns the final score for a Match"""
-        scores = self.scores(game)
-
-        if len(scores) == 0:
-            return None
-
-        final_score = tuple(sum([score[playeri] for score in scores])
-                            for playeri in [0, 1])
+        final_score = get_final_score(self.result, game)
         return final_score
 
     def final_score_per_turn(self, game=None):
         """Returns the mean score per round for a Match"""
-        scores = self.scores(game)
-
-        if len(scores) == 0:
-            return None
-
-        final_score_per_turn = tuple(
-            sum([score[playeri] for score in scores]) / (float(self._turns))
-            for playeri in [0, 1])
+        final_score_per_turn = get_final_score_per_turn(self.result, game)
         return final_score_per_turn
 
     def winner(self, game=None):
         """Returns the winner of the Match"""
-        scores = self.final_score(game)
-
-        if scores is not None:
-            if scores[0] == scores[1]:
-                return False  # No winner
-            return sorted(self.players,
-                          key=lambda x: scores[self.players.index(x)])[-1]
-        return None
+        winner_index = get_winner_index(self.result, game)
+        if winner_index is False:  # No winner
+            return False
+        if winner_index is None:  # No plays
+            return None
+        return self.players[winner_index]
 
     def cooperation(self):
         """Returns the count of cooperations by each player"""
-
-        if len(self.result) == 0:
-            return None
-
-        cooperation = tuple(sum([play[playeri] == C for play in self.result])
-                            for playeri in [0, 1])
-        return cooperation
+        return get_cooperations(self.result)
 
     def normalised_cooperation(self):
         """Returns the count of cooperations by each player per turn"""
-        cooperation = self.cooperation()
-
-        if len(self.result) == 0:
-            return None
-
-        normalised_cooperation = tuple(
-            [c / float(self._turns) for c in cooperation])
-
-        return normalised_cooperation
+        return get_normalised_cooperation(self.result)
 
     def sparklines(self, c_symbol=u'█', d_symbol=u' '):
         return (

--- a/axelrod/result_set.py
+++ b/axelrod/result_set.py
@@ -729,10 +729,4 @@ class ResultSetFromFile(ResultSet):
 
         'CDCDDD' -> [('C', 'D'), ('C', 'D'), ('D', 'D')]
         """
-        interactions = []
-        interactions_list = list(string)
-        while interactions_list:
-            p1action = interactions_list.pop(0)
-            p2action = interactions_list.pop(0)
-            interactions.append((p1action, p2action))
-        return interactions
+        return iu.string_to_interactions(string)

--- a/axelrod/result_set.py
+++ b/axelrod/result_set.py
@@ -1,7 +1,7 @@
 import csv
 from . import eigen
 
-from .interaction_utils import *
+import axelrod.interaction_utils as iu
 
 from numpy import mean, median, std
 
@@ -130,7 +130,7 @@ class ResultSet(object):
         for rep, inter_dict in enumerate(self.interactions):
             for index_pair, interactions in inter_dict.items():
                 if index_pair[0] != index_pair[1]: # Ignoring self interactions
-                    final_scores = get_final_score(interactions)
+                    final_scores = iu.get_final_score(interactions)
                     for player in range(2):
                         player_index = index_pair[player]
                         player_score = final_scores[player]
@@ -176,7 +176,7 @@ class ResultSet(object):
                     for player in range(2):
                         player_index = index_pair[player]
 
-                        winner_index = get_winner_index(interactions)
+                        winner_index = iu.get_winner_index(interactions)
                         if winner_index is not False and player == winner_index:
                             wins[player_index][rep] += 1
 
@@ -210,7 +210,7 @@ class ResultSet(object):
         for rep, inter_dict in enumerate(self.interactions):
             for index_pair, interactions in inter_dict.items():
                 if index_pair[0] != index_pair[1]:  # Ignore self interactions
-                    scores_per_turn = get_final_score_per_turn(interactions)
+                    scores_per_turn = iu.get_final_score_per_turn(interactions)
                     for player in range(2):
                         player_index = index_pair[player]
                         score_per_turn = scores_per_turn[player]
@@ -270,10 +270,10 @@ class ResultSet(object):
 
                     if (i, j) in rep:
                         interactions = rep[(i, j)]
-                        utilities.append(get_final_score_per_turn(interactions)[0])
+                        utilities.append(iu.get_final_score_per_turn(interactions)[0])
                     if (j, i) in rep:
                         interactions = rep[(j, i)]
-                        utilities.append(get_final_score_per_turn(interactions)[1])
+                        utilities.append(iu.get_final_score_per_turn(interactions)[1])
 
                     payoffs[i][j] = utilities
         return payoffs
@@ -376,11 +376,11 @@ class ResultSet(object):
             for j in plist:
                 for r, rep in enumerate(self.interactions):
                     if (i, j) in rep:
-                        scores = get_final_score_per_turn(rep[(i, j)])
+                        scores = iu.get_final_score_per_turn(rep[(i, j)])
                         diff = (scores[0] - scores[1])
                         score_diffs[i][j][r] = diff
                     if (j, i) in rep:
-                        scores = get_final_score_per_turn(rep[(j, i)])
+                        scores = iu.get_final_score_per_turn(rep[(j, i)])
                         diff = (scores[1] - scores[0])
                         score_diffs[i][j][r] = diff
         return score_diffs
@@ -410,10 +410,10 @@ class ResultSet(object):
                 diffs = []
                 for rep in self.interactions:
                     if (i, j) in rep:
-                        scores = get_final_score_per_turn(rep[(i, j)])
+                        scores = iu.get_final_score_per_turn(rep[(i, j)])
                         diffs.append(scores[0] - scores[1])
                     if (j, i) in rep:
-                        scores = get_final_score_per_turn(rep[(j, i)])
+                        scores = iu.get_final_score_per_turn(rep[(j, i)])
                         diffs.append(scores[1] - scores[0])
                 if diffs:
                     payoff_diffs_means[i][j] = mean(diffs)
@@ -449,10 +449,10 @@ class ResultSet(object):
 
                         if (i, j) in rep:
                             interactions = rep[(i, j)]
-                            coop_count = get_cooperations(interactions)[0]
+                            coop_count = iu.get_cooperations(interactions)[0]
                         if (j, i) in rep:
                             interactions = rep[(j, i)]
-                            coop_count = get_cooperations(interactions)[1]
+                            coop_count = iu.get_cooperations(interactions)[1]
 
                         cooperations[i][j] += coop_count
         return cooperations
@@ -485,11 +485,11 @@ class ResultSet(object):
 
                     if (i, j) in rep:
                         interactions = rep[(i, j)]
-                        coop_counts.append(get_normalised_cooperation(interactions)[0])
+                        coop_counts.append(iu.get_normalised_cooperation(interactions)[0])
 
                     if (j, i) in rep:
                         interactions = rep[(j, i)]
-                        coop_counts.append(get_normalised_cooperation(interactions)[1])
+                        coop_counts.append(iu.get_normalised_cooperation(interactions)[1])
 
                     if ((i, j) not in rep) and ((j, i) not in rep):
                         coop_counts.append(0)
@@ -563,13 +563,13 @@ class ResultSet(object):
 
                         if (i, j) in rep:
                             interaction = rep[(i, j)]
-                            coops = get_cooperations(interaction)
+                            coops = iu.get_cooperations(interaction)
                             if coops[0] >= coops[1]:
                                 good_partner_matrix[i][j] += 1
 
                         if (j, i) in rep:
                             interaction = rep[(j, i)]
-                            coops = get_cooperations(interaction)
+                            coops = iu.get_cooperations(interaction)
                             if coops[0] <= coops[1]:
                                 good_partner_matrix[i][j] += 1
 

--- a/axelrod/tests/unit/test_interaction_utils.py
+++ b/axelrod/tests/unit/test_interaction_utils.py
@@ -79,3 +79,8 @@ class TestMatch(unittest.TestCase):
     def test_get_sparklines(self):
         for inter, spark in zip(self.interactions, self.sparklines):
             self.assertEqual(spark, iu.get_sparklines(inter))
+
+    def test_string_to_interactions(self):
+        string = 'CDCDDD'
+        interactions = [('C', 'D'), ('C', 'D'), ('D', 'D')]
+        self.assertEqual(iu.string_to_interactions(string), interactions)

--- a/axelrod/tests/unit/test_interaction_utils.py
+++ b/axelrod/tests/unit/test_interaction_utils.py
@@ -1,0 +1,80 @@
+import unittest
+import axelrod.interaction_utils as iu
+from axelrod import Actions
+
+C, D = Actions.C, Actions.D
+
+
+class TestMatch(unittest.TestCase):
+    interactions = [
+            [(C, D), (D, C)],
+            [(D, C), (D, C)],
+            [(C, C), (C, D)],
+            [],
+            ]
+
+
+    scores = [
+            [(0, 5), (5, 0)],
+            [(5, 0), (5, 0)],
+            [(3, 3), (0, 5)],
+            [],
+            ]
+
+
+    final_scores = [
+            (5, 5),
+            (10, 0),
+            (3, 8),
+            None,
+            ]
+
+
+    final_score_per_turn = [
+            (2.5, 2.5),
+            (5, 0),
+            (1.5, 4),
+            None,
+            ]
+
+    winners = [False, 0, 1, None]
+    cooperations = [(1, 1), (0, 2), (2, 1), None]
+    normalised_cooperations = [(.5, .5), (0, 1), (1, .5), None]
+
+    sparklines = [
+            u'█ \n █',
+            u'  \n██',
+            u'██\n█ ',
+            None
+            ]
+
+
+    def test_get_scores(self):
+        for inter, score in zip(self.interactions, self.scores):
+            self.assertEqual(score, iu.get_scores(inter))
+
+    def test_get_final_score(self):
+        for inter, final_score in zip(self.interactions, self.final_scores):
+            self.assertEqual(final_score, iu.get_final_score(inter))
+
+    def test_get_final_score_per_turn(self):
+        for inter, final_score_per_round in zip(self.interactions,
+                                                self.final_score_per_turn):
+            self.assertEqual(final_score_per_round,
+                             iu.get_final_score_per_turn(inter))
+
+    def test_get_winner_index(self):
+        for inter, winner in zip(self.interactions, self.winners):
+            self.assertEqual(winner, iu.get_winner_index(inter))
+
+    def test_get_cooperations(self):
+        for inter, coop in zip(self.interactions, self.cooperations):
+            self.assertEqual(coop, iu.get_cooperations(inter))
+
+    def test_get_normalised_cooperations(self):
+        for inter, coop in zip(self.interactions, self.normalised_cooperations):
+            self.assertEqual(coop, iu.get_normalised_cooperation(inter))
+
+    def test_get_sparklines(self):
+        for inter, spark in zip(self.interactions, self.sparklines):
+            self.assertEqual(spark, iu.get_sparklines(inter))

--- a/axelrod/tests/unit/test_interaction_utils.py
+++ b/axelrod/tests/unit/test_interaction_utils.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import unittest
 import axelrod.interaction_utils as iu
 from axelrod import Actions

--- a/axelrod/tests/unit/test_plot.py
+++ b/axelrod/tests/unit/test_plot.py
@@ -2,6 +2,7 @@ import unittest
 import axelrod
 
 from numpy import mean
+import tempfile
 
 matplotlib_installed = True
 try:
@@ -62,6 +63,22 @@ class TestPlot(unittest.TestCase):
     def test_init(self):
         plot = axelrod.Plot(self.test_result_set)
         self.assertEqual(plot.result_set, self.test_result_set)
+        self.assertEqual(matplotlib_installed, plot.matplotlib_installed)
+
+    def test_init_from_resulsetfromfile(self):
+        tournament = axelrod.Tournament(
+            players=[axelrod.Cooperator(),
+                     axelrod.TitForTat(),
+                     axelrod.Defector()],
+            turns=2,
+            repetitions=2)
+        tmp_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
+        tournament.play(filename=tmp_file.name)
+        tmp_file.close()
+        rs = axelrod.ResultSetFromFile(tmp_file.name)
+
+        plot = axelrod.Plot(rs)
+        self.assertEqual(plot.result_set, rs)
         self.assertEqual(matplotlib_installed, plot.matplotlib_installed)
 
     def test_boxplot_dataset(self):

--- a/axelrod/tests/unit/test_plot.py
+++ b/axelrod/tests/unit/test_plot.py
@@ -31,7 +31,12 @@ class TestPlot(unittest.TestCase):
             for match in rep.values():
                 match.play()
 
-        cls.test_result_set = axelrod.ResultSet(cls.players, cls.matches)
+        cls.interactions = []
+        for rep in cls.matches:
+            cls.interactions.append({index_pair: match.result for
+                                     index_pair, match in rep.items()})
+
+        cls.test_result_set = axelrod.ResultSet(cls.players, cls.interactions)
         cls.expected_boxplot_dataset = [
                [(17.0 / 5 + 9.0 / 5) / 2 for _ in range(3)],
                [(13.0 / 5 + 4.0 / 5) / 2 for _ in range(3)],

--- a/axelrod/tests/unit/test_resultset.py
+++ b/axelrod/tests/unit/test_resultset.py
@@ -28,6 +28,11 @@ class TestResultSet(unittest.TestCase):
             for match in rep.values():
                 match.play()
 
+        cls.interactions = []
+        for rep in cls.matches:
+            cls.interactions.append({index_pair: match.result for
+                                     index_pair, match in rep.items()})
+
         cls.expected_players_to_match_dicts = [{0: [rep[(0, 1)], rep[(0, 2)]],
                                                 1: [rep[(0, 1)], rep[(1, 2)]],
                                                 2: [rep[(1, 2)], rep[(0, 2)]]}
@@ -156,28 +161,28 @@ class TestResultSet(unittest.TestCase):
             'Defector,Tit For Tat,Alternator\n2.6,1.7,1.5\n2.6,1.7,1.5\n2.6,1.7,1.5\n')
 
     def test_init(self):
-        rs = axelrod.ResultSet(self.players, self.matches)
+        rs = axelrod.ResultSet(self.players, self.interactions)
         self.assertEqual(rs.players, self.players)
         self.assertEqual(rs.nplayers, len(self.players))
-        self.assertEqual(rs.matches, self.matches)
-        self.assertEqual(rs.nrepetitions, len(self.matches))
+        self.assertEqual(rs.interactions, self.interactions)
+        self.assertEqual(rs.nrepetitions, len(self.interactions))
 
         # Test structure of matches
         # This is really a test of the test
-        for rep in rs.matches:
+        for rep in rs.interactions:
             self.assertIsInstance(rep, dict)
-            for index_pair, match in rep.items():
+            for index_pair, inter in rep.items():
                 self.assertIsInstance(index_pair, tuple)
-                self.assertIsInstance(match, axelrod.Match)
-                self.assertEqual(len(match), self.turns)
+                self.assertIsInstance(inter, list)
+                self.assertEqual(len(inter), self.turns)
 
     def test_null_results_matrix(self):
-        rs = axelrod.ResultSet(self.players, self.matches)
+        rs = axelrod.ResultSet(self.players, self.interactions)
         self.assertEqual(
             rs._null_results_matrix, self.expected_null_results_matrix)
 
     def test_match_lengths(self):
-        rs = axelrod.ResultSet(self.players, self.matches)
+        rs = axelrod.ResultSet(self.players, self.interactions)
         self.assertIsInstance(rs.match_lengths, list)
         self.assertEqual(len(rs.match_lengths), rs.nrepetitions)
         self.assertEqual(rs.match_lengths, self.expected_match_lengths)
@@ -197,49 +202,49 @@ class TestResultSet(unittest.TestCase):
                         #self.assertEqual(length, self.turns)
 
     def test_scores(self):
-        rs = axelrod.ResultSet(self.players, self.matches)
+        rs = axelrod.ResultSet(self.players, self.interactions)
         self.assertIsInstance(rs.scores, list)
         self.assertEqual(len(rs.scores), rs.nplayers)
         self.assertEqual(rs.scores, self.expected_scores)
 
     def test_ranking(self):
-        rs = axelrod.ResultSet(self.players, self.matches)
+        rs = axelrod.ResultSet(self.players, self.interactions)
         self.assertIsInstance(rs.ranking, list)
         self.assertEqual(len(rs.ranking), rs.nplayers)
         self.assertEqual(rs.ranking, self.expected_ranking)
 
     def test_ranked_names(self):
-        rs = axelrod.ResultSet(self.players, self.matches)
+        rs = axelrod.ResultSet(self.players, self.interactions)
         self.assertIsInstance(rs.ranked_names, list)
         self.assertEqual(len(rs.ranked_names), rs.nplayers)
         self.assertEqual(rs.ranked_names, self.expected_ranked_names)
 
     def test_wins(self):
-        rs = axelrod.ResultSet(self.players, self.matches)
+        rs = axelrod.ResultSet(self.players, self.interactions)
         self.assertIsInstance(rs.wins, list)
         self.assertEqual(len(rs.wins), rs.nplayers)
         self.assertEqual(rs.wins, self.expected_wins)
 
     def test_normalised_scores(self):
-        rs = axelrod.ResultSet(self.players, self.matches)
+        rs = axelrod.ResultSet(self.players, self.interactions)
         self.assertIsInstance(rs.normalised_scores, list)
         self.assertEqual(len(rs.normalised_scores), rs.nplayers)
         self.assertEqual(rs.normalised_scores, self.expected_normalised_scores)
 
     def test_payoffs(self):
-        rs = axelrod.ResultSet(self.players, self.matches)
+        rs = axelrod.ResultSet(self.players, self.interactions)
         self.assertIsInstance(rs.payoffs, list)
         self.assertEqual(len(rs.payoffs), rs.nplayers)
         self.assertEqual(rs.payoffs, self.expected_payoffs)
 
     def test_payoff_matrix(self):
-        rs = axelrod.ResultSet(self.players, self.matches)
+        rs = axelrod.ResultSet(self.players, self.interactions)
         self.assertIsInstance(rs.payoff_matrix, list)
         self.assertEqual(len(rs.payoff_matrix), rs.nplayers)
         self.assertEqual(rs.payoff_matrix, self.expected_payoff_matrix)
 
     def test_score_diffs(self):
-        rs = axelrod.ResultSet(self.players, self.matches)
+        rs = axelrod.ResultSet(self.players, self.interactions)
         self.assertIsInstance(rs.score_diffs, list)
         self.assertEqual(len(rs.score_diffs), rs.nplayers)
         for i, row in enumerate(rs.score_diffs):
@@ -249,7 +254,7 @@ class TestResultSet(unittest.TestCase):
                                      self.expected_score_diffs[i][j][k])
 
     def test_payoff_diffs_means(self):
-        rs = axelrod.ResultSet(self.players, self.matches)
+        rs = axelrod.ResultSet(self.players, self.interactions)
         self.assertIsInstance(rs.payoff_diffs_means, list)
         self.assertEqual(len(rs.payoff_diffs_means), rs.nplayers)
         for i, row in enumerate(rs.payoff_diffs_means):
@@ -258,66 +263,66 @@ class TestResultSet(unittest.TestCase):
                                  self.expected_payoff_diffs_means[i][j])
 
     def test_payoff_stddevs(self):
-        rs = axelrod.ResultSet(self.players, self.matches)
+        rs = axelrod.ResultSet(self.players, self.interactions)
         self.assertIsInstance(rs.payoff_stddevs, list)
         self.assertEqual(len(rs.payoff_stddevs), rs.nplayers)
         self.assertEqual(rs.payoff_stddevs, self.expected_payoff_stddevs)
 
     def test_cooperation(self):
-        rs = axelrod.ResultSet(self.players, self.matches)
+        rs = axelrod.ResultSet(self.players, self.interactions)
         self.assertIsInstance(rs.cooperation, list)
         self.assertEqual(len(rs.cooperation), rs.nplayers)
         self.assertEqual(rs.cooperation, self.expected_cooperation)
 
     def test_normalised_cooperation(self):
-        rs = axelrod.ResultSet(self.players, self.matches)
+        rs = axelrod.ResultSet(self.players, self.interactions)
         self.assertIsInstance(rs.normalised_cooperation, list)
         self.assertEqual(len(rs.normalised_cooperation), rs.nplayers)
         self.assertEqual(rs.normalised_cooperation,
                          self.expected_normalised_cooperation)
 
     def test_vengeful_cooperation(self):
-        rs = axelrod.ResultSet(self.players, self.matches)
+        rs = axelrod.ResultSet(self.players, self.interactions)
         self.assertIsInstance(rs.vengeful_cooperation, list)
         self.assertEqual(len(rs.vengeful_cooperation), rs.nplayers)
         self.assertEqual(rs.vengeful_cooperation,
                          self.expected_vengeful_cooperation)
 
     def test_cooperating_rating(self):
-        rs = axelrod.ResultSet(self.players, self.matches)
+        rs = axelrod.ResultSet(self.players, self.interactions)
         self.assertIsInstance(rs.cooperating_rating, list)
         self.assertEqual(len(rs.cooperating_rating), rs.nplayers)
         self.assertEqual(rs.cooperating_rating,
                          self.expected_cooperating_rating)
 
     def test_good_partner_matrix(self):
-        rs = axelrod.ResultSet(self.players, self.matches)
+        rs = axelrod.ResultSet(self.players, self.interactions)
         self.assertIsInstance(rs.good_partner_matrix, list)
         self.assertEqual(len(rs.good_partner_matrix), rs.nplayers)
         self.assertEqual(rs.good_partner_matrix,
                          self.expected_good_partner_matrix)
 
     def test_good_partner_rating(self):
-        rs = axelrod.ResultSet(self.players, self.matches)
+        rs = axelrod.ResultSet(self.players, self.interactions)
         self.assertIsInstance(rs.good_partner_rating, list)
         self.assertEqual(len(rs.good_partner_rating), rs.nplayers)
         self.assertEqual(rs.good_partner_rating,
                          self.expected_good_partner_rating)
 
     def test_eigenjesus_rating(self):
-        rs = axelrod.ResultSet(self.players, self.matches)
+        rs = axelrod.ResultSet(self.players, self.interactions)
         self.assertIsInstance(rs.eigenjesus_rating, list)
         self.assertEqual(len(rs.eigenjesus_rating), rs.nplayers)
         for j, rate in enumerate(rs.eigenjesus_rating):
             self.assertAlmostEqual(rate, self.expected_eigenjesus_rating[j])
 
     def test_eigenmoses_rating(self):
-        rs = axelrod.ResultSet(self.players, self.matches)
+        rs = axelrod.ResultSet(self.players, self.interactions)
         self.assertIsInstance(rs.eigenmoses_rating, list)
         self.assertEqual(len(rs.eigenmoses_rating), rs.nplayers)
         for j, rate in enumerate(rs.eigenmoses_rating):
             self.assertAlmostEqual(rate, self.expected_eigenmoses_rating[j])
 
     def test_csv(self):
-        rs = axelrod.ResultSet(self.players, self.matches)
+        rs = axelrod.ResultSet(self.players, self.interactions)
         self.assertEqual(rs.csv(), self.expected_csv)

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -394,30 +394,38 @@ class TestTournament(unittest.TestCase):
             players=self.players,
             game=self.game,
             repetitions=self.test_repetitions)
-        matches = {
-            (0, 0): axelrod.Match((axelrod.Cooperator(), axelrod.Cooperator()), turns=turns),
-            (0, 1): axelrod.Match((axelrod.Cooperator(), axelrod.TitForTat()), turns=turns),
-            (0, 2): axelrod.Match((axelrod.Cooperator(), axelrod.Defector()), turns=turns),
-            (0, 3): axelrod.Match((axelrod.Cooperator(), axelrod.Grudger()), turns=turns),
-            (0, 4): axelrod.Match((axelrod.Cooperator(), axelrod.GoByMajority()), turns=turns),
-            (1, 1): axelrod.Match((axelrod.TitForTat(), axelrod.TitForTat()), turns=turns),
-            (1, 2): axelrod.Match((axelrod.TitForTat(), axelrod.Defector()), turns=turns),
-            (1, 3): axelrod.Match((axelrod.TitForTat(), axelrod.Grudger()), turns=turns),
-            (1, 4): axelrod.Match((axelrod.TitForTat(), axelrod.GoByMajority()), turns=turns),
-            (2, 2): axelrod.Match((axelrod.Defector(), axelrod.Defector()), turns=turns),
-            (2, 3): axelrod.Match((axelrod.Defector(), axelrod.Grudger()), turns=turns),
-            (2, 4): axelrod.Match((axelrod.Defector(), axelrod.GoByMajority()), turns=turns),
-            (3, 3): axelrod.Match((axelrod.Grudger(), axelrod.Grudger()), turns=turns),
-            (3, 4): axelrod.Match((axelrod.Grudger(), axelrod.GoByMajority()), turns=turns),
-            (4, 4): axelrod.Match((axelrod.GoByMajority(), axelrod.GoByMajority()), turns=turns),
-        }
-        tournament._play_matches(matches)
-        for m in matches.values():
-            self.assertEqual(len(m), turns)
-            # Check that the name of the winner is in the list of names of
-            # players in the tournament (the way the matches are created these
-            # are not the same players).
-            self.assertIn(str(m.winner()), [str(p) for p in tournament.players] + ['False'])
+
+        matches = [
+            ((0, 0), axelrod.Match((axelrod.Cooperator(), axelrod.Cooperator()), turns=turns)),
+            ((0, 1), axelrod.Match((axelrod.Cooperator(), axelrod.TitForTat()), turns=turns)),
+            ((0, 2), axelrod.Match((axelrod.Cooperator(), axelrod.Defector()), turns=turns)),
+            ((0, 3), axelrod.Match((axelrod.Cooperator(), axelrod.Grudger()), turns=turns)),
+            ((0, 4), axelrod.Match((axelrod.Cooperator(), axelrod.GoByMajority()), turns=turns)),
+            ((1, 1), axelrod.Match((axelrod.TitForTat(), axelrod.TitForTat()), turns=turns)),
+            ((1, 2), axelrod.Match((axelrod.TitForTat(), axelrod.Defector()), turns=turns)),
+            ((1, 3), axelrod.Match((axelrod.TitForTat(), axelrod.Grudger()), turns=turns)),
+            ((1, 4), axelrod.Match((axelrod.TitForTat(), axelrod.GoByMajority()), turns=turns)),
+            ((2, 2), axelrod.Match((axelrod.Defector(), axelrod.Defector()), turns=turns)),
+            ((2, 3), axelrod.Match((axelrod.Defector(), axelrod.Grudger()), turns=turns)),
+            ((2, 4), axelrod.Match((axelrod.Defector(), axelrod.GoByMajority()), turns=turns)),
+            ((3, 3), axelrod.Match((axelrod.Grudger(), axelrod.Grudger()), turns=turns)),
+            ((3, 4), axelrod.Match((axelrod.Grudger(), axelrod.GoByMajority()), turns=turns)),
+            ((4, 4), axelrod.Match((axelrod.GoByMajority(), axelrod.GoByMajority()), turns=turns)),
+        ]
+        matches_generator = (element for element in matches)
+
+        self.assertEqual((len(list(matches_generator))), len(matches))
+
+        interactions = tournament._play_matches(matches_generator)
+        for index_pair, inter in interactions.items():
+            self.assertEqual(len(inter), turns)
+            self.assertEqual(len(index_pair), 2)
+            for plays in inter:
+                self.assertIsInstance(plays, tuple)
+                self.assertEqual(len(plays), 2)
+
+        # Check that matches no longer exist?
+        self.assertEqual((len(list(matches_generator))), 0)
 
 
 class TestProbEndTournament(unittest.TestCase):

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -6,6 +6,9 @@ import multiprocessing
 import unittest
 import random
 
+import tempfile
+import csv
+
 from hypothesis import given, example, settings
 from hypothesis.strategies import integers, lists, sampled_from, random_module, floats
 
@@ -426,6 +429,105 @@ class TestTournament(unittest.TestCase):
 
         # Check that matches no longer exist?
         self.assertEqual((len(list(matches_generator))), 0)
+
+    def test_play_and_write_to_csv(self):
+        tournament = axelrod.Tournament(
+            name=self.test_name,
+            players=self.players,
+            game=self.game,
+            turns=2,
+            repetitions=2)
+        tmp_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
+        tournament.play(filename=tmp_file.name)
+        with open(tmp_file.name, 'r') as f:
+            written_data = [[int(r[0]), int(r[1])] + r[2:] for r in csv.reader(f)]
+            expected_data = [[0, 1, 'Cooperator', 'Tit For Tat', 'CCCC', 'CCCC'],
+                             [1, 2, 'Tit For Tat', 'Defector', 'CDDD', 'CDDD'],
+                             [0, 0, 'Cooperator', 'Cooperator', 'CCCC', 'CCCC'],
+                             [3, 3, 'Grudger', 'Grudger', 'CCCC', 'CCCC'],
+                             [2, 2, 'Defector', 'Defector', 'DDDD', 'DDDD'],
+                             [4, 4, 'Soft Go By Majority', 'Soft Go By Majority',
+                              'CCCC', 'CCCC'],
+                             [1, 4, 'Tit For Tat', 'Soft Go By Majority',
+                              'CCCC', 'CCCC'],
+                             [1, 1, 'Tit For Tat', 'Tit For Tat', 'CCCC', 'CCCC'],
+                             [1, 3, 'Tit For Tat', 'Grudger', 'CCCC', 'CCCC'],
+                             [2, 3, 'Defector', 'Grudger', 'DCDD', 'DCDD'],
+                             [0, 4, 'Cooperator', 'Soft Go By Majority',
+                              'CCCC', 'CCCC'],
+                             [2, 4, 'Defector', 'Soft Go By Majority',
+                              'DCDD', 'DCDD'],
+                             [0, 3, 'Cooperator', 'Grudger', 'CCCC', 'CCCC'],
+                             [3, 4, 'Grudger', 'Soft Go By Majority',
+                              'CCCC', 'CCCC'],
+                             [0, 2, 'Cooperator', 'Defector', 'CDCD', 'CDCD']]
+            self.assertEqual(written_data, expected_data)
+
+    def test_write_to_csv(self):
+        tournament = axelrod.Tournament(
+            name=self.test_name,
+            players=self.players,
+            game=self.game,
+            turns=2,
+            repetitions=2)
+        tournament.play()
+        tmp_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
+        tournament._write_to_csv(tmp_file.name)
+        with open(tmp_file.name, 'r') as f:
+            written_data = [[int(r[0]), int(r[1])] + r[2:] for r in csv.reader(f)]
+            expected_data = [[0, 1, 'Cooperator', 'Tit For Tat', 'CCCC', 'CCCC'],
+                             [1, 2, 'Tit For Tat', 'Defector', 'CDDD', 'CDDD'],
+                             [0, 0, 'Cooperator', 'Cooperator', 'CCCC', 'CCCC'],
+                             [3, 3, 'Grudger', 'Grudger', 'CCCC', 'CCCC'],
+                             [2, 2, 'Defector', 'Defector', 'DDDD', 'DDDD'],
+                             [4, 4, 'Soft Go By Majority', 'Soft Go By Majority',
+                              'CCCC', 'CCCC'],
+                             [1, 4, 'Tit For Tat', 'Soft Go By Majority',
+                              'CCCC', 'CCCC'],
+                             [1, 1, 'Tit For Tat', 'Tit For Tat', 'CCCC', 'CCCC'],
+                             [1, 3, 'Tit For Tat', 'Grudger', 'CCCC', 'CCCC'],
+                             [2, 3, 'Defector', 'Grudger', 'DCDD', 'DCDD'],
+                             [0, 4, 'Cooperator', 'Soft Go By Majority',
+                              'CCCC', 'CCCC'],
+                             [2, 4, 'Defector', 'Soft Go By Majority',
+                              'DCDD', 'DCDD'],
+                             [0, 3, 'Cooperator', 'Grudger', 'CCCC', 'CCCC'],
+                             [3, 4, 'Grudger', 'Soft Go By Majority',
+                              'CCCC', 'CCCC'],
+                             [0, 2, 'Cooperator', 'Defector', 'CDCD', 'CDCD']]
+            self.assertEqual(written_data, expected_data)
+
+    def test_data_for_csv(self):
+        tournament = axelrod.Tournament(
+            name=self.test_name,
+            players=self.players,
+            game=self.game,
+            turns=2,
+            repetitions=2)
+        tournament.play()
+        expected_data = [[0, 1, 'Cooperator', 'Tit For Tat', 'CCCC', 'CCCC'],
+                         [1, 2, 'Tit For Tat', 'Defector', 'CDDD', 'CDDD'],
+                         [0, 0, 'Cooperator', 'Cooperator', 'CCCC', 'CCCC'],
+                         [3, 3, 'Grudger', 'Grudger', 'CCCC', 'CCCC'],
+                         [2, 2, 'Defector', 'Defector', 'DDDD', 'DDDD'],
+                         [4, 4, 'Soft Go By Majority', 'Soft Go By Majority',
+                          'CCCC', 'CCCC'],
+                         [1, 4, 'Tit For Tat', 'Soft Go By Majority',
+                          'CCCC', 'CCCC'],
+                         [1, 1, 'Tit For Tat', 'Tit For Tat', 'CCCC', 'CCCC'],
+                         [1, 3, 'Tit For Tat', 'Grudger', 'CCCC', 'CCCC'],
+                         [2, 3, 'Defector', 'Grudger', 'DCDD', 'DCDD'],
+                         [0, 4, 'Cooperator', 'Soft Go By Majority',
+                          'CCCC', 'CCCC'],
+                         [2, 4, 'Defector', 'Soft Go By Majority',
+                          'DCDD', 'DCDD'],
+                         [0, 3, 'Cooperator', 'Grudger', 'CCCC', 'CCCC'],
+                         [3, 4, 'Grudger', 'Soft Go By Majority',
+                          'CCCC', 'CCCC'],
+                         [0, 2, 'Cooperator', 'Defector', 'CDCD', 'CDCD']]
+        generator_data = tournament._data_for_csv()
+        for row, expected_row in zip(generator_data, expected_data):
+            self.assertEqual(row, expected_row)
 
 
 class TestProbEndTournament(unittest.TestCase):

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -240,30 +240,30 @@ class TestTournament(unittest.TestCase):
             tournament._parallel_repetitions, self.test_repetitions - 1)
 
     def test_run_single_repetition(self):
-        matches = []
+        interactions = []
         tournament = axelrod.Tournament(
             name=self.test_name,
             players=self.players,
             game=self.game,
             turns=200,
             repetitions=self.test_repetitions)
-        tournament._run_single_repetition(matches)
-        self.assertEqual(len(tournament.matches), 1)
-        self.assertEqual(len(tournament.matches[0]), 15)
+        tournament._run_single_repetition(interactions)
+        self.assertEqual(len(tournament.interactions), 1)
+        self.assertEqual(len(tournament.interactions[0]), 15)
 
     def test_run_serial_repetitions(self):
-        matches = []
+        interactions = []
         tournament = axelrod.Tournament(
             name=self.test_name,
             players=self.players,
             game=self.game,
             turns=200,
             repetitions=self.test_repetitions)
-        tournament._run_serial_repetitions(matches)
-        self.assertEqual(len(tournament.matches), self.test_repetitions)
+        tournament._run_serial_repetitions(interactions)
+        self.assertEqual(len(tournament.interactions), self.test_repetitions)
 
     def test_run_parallel_repetitions(self):
-        matches = []
+        interactions = []
         tournament = axelrod.Tournament(
             name=self.test_name,
             players=self.players,
@@ -271,9 +271,9 @@ class TestTournament(unittest.TestCase):
             turns=200,
             repetitions=self.test_repetitions,
             processes=2)
-        tournament._run_parallel_repetitions(matches)
-        self.assertEqual(len(matches), self.test_repetitions)
-        for r in matches:
+        tournament._run_parallel_repetitions(interactions)
+        self.assertEqual(len(interactions), self.test_repetitions)
+        for r in interactions:
             self.assertEqual(len(r.values()), 15)
 
     def test_n_workers(self):
@@ -518,4 +518,4 @@ class TestProbEndTournament(unittest.TestCase):
         self.assertIsInstance(results, axelrod.ResultSet)
         self.assertEqual(results.nplayers, len(players))
         self.assertEqual(results.players, players)
-        self.assertEqual(len(results.matches), repetitions)
+        self.assertEqual(len(results.interactions), repetitions)

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -461,7 +461,7 @@ class TestTournament(unittest.TestCase):
                              [3, 4, 'Grudger', 'Soft Go By Majority',
                               'CCCC', 'CCCC'],
                              [0, 2, 'Cooperator', 'Defector', 'CDCD', 'CDCD']]
-            self.assertEqual(written_data, expected_data)
+            self.assertEqual(sorted(written_data), sorted(expected_data))
 
     def test_write_to_csv(self):
         tournament = axelrod.Tournament(
@@ -495,7 +495,7 @@ class TestTournament(unittest.TestCase):
                              [3, 4, 'Grudger', 'Soft Go By Majority',
                               'CCCC', 'CCCC'],
                              [0, 2, 'Cooperator', 'Defector', 'CDCD', 'CDCD']]
-            self.assertEqual(written_data, expected_data)
+            self.assertEqual(sorted(written_data), sorted(expected_data))
 
     def test_data_for_csv(self):
         tournament = axelrod.Tournament(
@@ -526,7 +526,7 @@ class TestTournament(unittest.TestCase):
                           'CCCC', 'CCCC'],
                          [0, 2, 'Cooperator', 'Defector', 'CDCD', 'CDCD']]
         generator_data = tournament._data_for_csv()
-        for row, expected_row in zip(generator_data, expected_data):
+        for row, expected_row in zip(sorted(generator_data), sorted(expected_data)):
             self.assertEqual(row, expected_row)
 
 

--- a/axelrod/tests/unit/test_tournament_type.py
+++ b/axelrod/tests/unit/test_tournament_type.py
@@ -50,7 +50,7 @@ class TestRoundRobin(unittest.TestCase):
         rr = axelrod.RoundRobin(self.players, test_turns, {})
         matches = rr.build_matches()
         match_definitions = [
-            (match) for match in matches]
+            (index_pair) for index_pair, match in matches]
         expected_match_definitions = [
             (0, 0),
             (0, 1),
@@ -82,7 +82,7 @@ class TestProbEndRoundRobin(unittest.TestCase):
         rr = axelrod.ProbEndRoundRobin(self.players, prob_end, {})
         matches = rr.build_matches()
         match_definitions = [
-            (match) for match in matches]
+            (index_pair) for index_pair, match in matches]
         expected_match_definitions = [
             (0, 0),
             (0, 1),
@@ -113,7 +113,7 @@ class TestProbEndRoundRobin(unittest.TestCase):
         """
         rr = axelrod.ProbEndRoundRobin(self.players, prob_end, {})
         matches = rr.build_matches()
-        match_lengths = [len(m) for m in matches.values()]
+        match_lengths = [len(match) for index_pair, match in matches]
         self.assertNotEqual(min(match_lengths), max(match_lengths))
 
     @given(prob_end=floats(min_value=0, max_value=1), rm=random_module())

--- a/axelrod/tournament_type.py
+++ b/axelrod/tournament_type.py
@@ -54,7 +54,8 @@ class RoundRobin(TournamentType):
 
     def build_matches(self, cache_mutable=True, noise=0):
         """
-        Create a dictionary of match objects for a round robin tournament.
+        A generator that returns player index pairs and match objects for a
+        round robin tournament.
 
         Parameters
         ----------
@@ -63,19 +64,17 @@ class RoundRobin(TournamentType):
         noise : float
             The probability that a player's intended action should be flipped
 
-        Returns
+        Yields
         -------
-        dictionary
-            Mapping a tuple of player index numbers to an axelrod Match object
+        tuple
+            player pair index, match object
         """
-        matches = {}
         for player1_index in range(len(self.players)):
             for player2_index in range(player1_index, len(self.players)):
                 pair = (
                     self.players[player1_index], self.opponents[player2_index])
                 match = self.build_single_match(pair, cache_mutable, noise)
-                matches[(player1_index, player2_index)] = match
-        return matches
+                yield (player1_index, player2_index), match
 
     def build_single_match(self, pair, cache_mutable=True, noise=0):
         """Create a single match for a given pair"""

--- a/docs/tutorials/further_topics/creating_matches.rst
+++ b/docs/tutorials/further_topics/creating_matches.rst
@@ -77,3 +77,16 @@ A `Match` class can also score the individual turns of a match. Just call
     [('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C')]
     >>> match.scores()
     [(3, 3), (0, 5), (3, 3), (0, 5), (3, 3), (0, 5), (3, 3), (0, 5), (3, 3), (0, 5), (3, 3), (0, 5), (3, 3), (0, 5), (3, 3), (0, 5), (3, 3), (0, 5), (3, 3), (0, 5), (3, 3), (0, 5), (3, 3), (0, 5), (3, 3)]
+
+There are various further methods::
+
+    >>> match.final_score()
+    (39, 99)
+    >>> match.final_score_per_turn()
+    (1.56, 3.96)
+    >>> match.winner()
+    Alternator
+    >>> match.cooperation()  # The count of cooperations
+    (25, 13)
+    >>> match.normalised_cooperation()  # The count of cooperations per turn
+    (1.0, 0.52)

--- a/docs/tutorials/further_topics/index.rst
+++ b/docs/tutorials/further_topics/index.rst
@@ -13,3 +13,4 @@ Contents:
    creating_matches.rst
    morality_metrics.rst
    probabilistict_end_tournaments.rst
+   reading_and_writing_interactions.rst

--- a/docs/tutorials/further_topics/reading_and_writing_interactions.rst
+++ b/docs/tutorials/further_topics/reading_and_writing_interactions.rst
@@ -1,0 +1,88 @@
+Reading and writing interactions to file
+========================================
+
+When dealing with large tournaments it might be desirable to separate the
+analysis from the actual running of the tournaments. This can be done by passing
+a :code:`filename` argument to the :code:`play` method of a tournament::
+
+    >>> import axelrod as axl
+    >>> players = [s() for s in axl.basic_strategies]
+    >>> tournament = axl.Tournament(players, turns=4, repetitions=2)
+    >>> tournament.play(filename="basic_tournament.csv")
+
+This will create a file `basic_tournament.csv` with data that looks something
+like::
+
+    1,2,Anti Tit For Tat,Bully,CDCDCDCD,CDCDCDCD
+    4,7,Defector,Win-Stay Lose-Shift,DCDDDCDD,DCDDDCDD
+    0,0,Alternator,Alternator,CCDDCCDD,CCDDCCDD
+    6,6,Tit For Tat,Tit For Tat,CCCCCCCC,CCCCCCCC
+    4,5,Defector,Suspicious Tit For Tat,DDDDDDDD,DDDDDDDD
+    2,2,Bully,Bully,DDCCDDCC,DDCCDDCC
+    2,7,Bully,Win-Stay Lose-Shift,DCDDCCDC,DCDDCCDC
+    0,7,Alternator,Win-Stay Lose-Shift,CCDCCDDD,CCDCCDDD
+    4,6,Defector,Tit For Tat,DCDDDDDD,DCDDDDDD
+    5,6,Suspicious Tit For Tat,Tit For Tat,DCCDDCCD,DCCDDCCD
+    2,6,Bully,Tit For Tat,DCDDCDCC,DCDDCDCC
+    0,5,Alternator,Suspicious Tit For Tat,CDDCCDDC,CDDCCDDC
+    1,4,Anti Tit For Tat,Defector,CDCDCDCD,CDCDCDCD
+    3,7,Cooperator,Win-Stay Lose-Shift,CCCCCCCC,CCCCCCCC
+    0,4,Alternator,Defector,CDDDCDDD,CDDDCDDD
+    2,5,Bully,Suspicious Tit For Tat,DDCDCCDC,DDCDCCDC
+    5,7,Suspicious Tit For Tat,Win-Stay Lose-Shift,DCCDDDDC,DCCDDDDC
+    0,3,Alternator,Cooperator,CCDCCCDC,CCDCCCDC
+    3,5,Cooperator,Suspicious Tit For Tat,CDCCCCCC,CDCCCCCC
+    0,1,Alternator,Anti Tit For Tat,CCDDCCDD,CCDDCCDD
+    7,7,Win-Stay Lose-Shift,Win-Stay Lose-Shift,CCCCCCCC,CCCCCCCC
+    0,2,Alternator,Bully,CDDDCCDD,CDDDCCDD
+    3,3,Cooperator,Cooperator,CCCCCCCC,CCCCCCCC
+    6,7,Tit For Tat,Win-Stay Lose-Shift,CCCCCCCC,CCCCCCCC
+    0,6,Alternator,Tit For Tat,CCDCCDDC,CCDCCDDC
+    5,5,Suspicious Tit For Tat,Suspicious Tit For Tat,DDDDDDDD,DDDDDDDD
+    4,4,Defector,Defector,DDDDDDDD,DDDDDDDD
+    1,6,Anti Tit For Tat,Tit For Tat,CCDCDDCD,CCDCDDCD
+    1,1,Anti Tit For Tat,Anti Tit For Tat,CCDDCCDD,CCDDCCDD
+    1,5,Anti Tit For Tat,Suspicious Tit For Tat,CDCCDCDD,CDCCDCDD
+    3,6,Cooperator,Tit For Tat,CCCCCCCC,CCCCCCCC
+    1,7,Anti Tit For Tat,Win-Stay Lose-Shift,CCDCDDCC,CCDCDDCC
+    1,3,Anti Tit For Tat,Cooperator,CCDCDCDC,CCDCDCDC
+    2,3,Bully,Cooperator,DCDCDCDC,DCDCDCDC
+    3,4,Cooperator,Defector,CDCDCDCD,CDCDCDCD
+    2,4,Bully,Defector,DDCDCDCD,DDCDCDCD
+
+The columns of this file are of the form:
+
+1. Index of first player
+2. Index of second player
+3. Name of first player
+4. Name of second player
+5. All further columns are interactions written in a compressed format.
+
+Alternator versus TitForTat has the following interactions: :code:`CCDCCDDC`:
+
+- First turn: :code:`C` versus :code:`C` (the first two letters)
+- Second turn: :code:`D` versus :code:`C` (the second pair of letters)
+- Third turn: :code:`C` versus :code:`D` (the third pair of letters)
+- Fourth turn: :code:`D` versus :code:`C` (the fourth pair of letters)
+
+This can be transformed in to the usual interactions using the
+:code:`interactions_util.string_to_interactions` function:
+
+    >>> string = 'CCDCCDDC'
+    >>> axl.interaction_utils.string_to_interactions(string)
+    [('C', 'C'), ('D', 'C'), ('C', 'D'), ('D', 'C')]
+
+This should allow for easy manipulation of data outside of the capabilities
+within the library, but it is also possible to generate a standard result set
+from the datafile::
+
+    >>> results = axl.ResultSetFromFile(filename="basic_tournament.csv")
+    >>> results.ranked_names  # doctest: +SKIP
+    ['Defector',
+     'Bully',
+     'Suspicious Tit For Tat',
+     'Alternator',
+     'Tit For Tat',
+     'Anti Tit For Tat',
+     'Win-Stay Lose-Shift',
+     'Cooperator']

--- a/docs/tutorials/getting_started/interactions.rst
+++ b/docs/tutorials/getting_started/interactions.rst
@@ -14,15 +14,16 @@ To access the detailed interaction results we create a tournament as usual
     >>> tournament = axl.Tournament(strategies, turns=3, repetitions=1)
     >>> results = tournament.play()
 
-The tournament object has a 'matches' attribute which is a list of axelrod.Match
-objects. (Actually, it's a list of lists: one list for each repetition which, in
-turn, has a list of Match objects). Each match object holds the pair of
-axelrod.Player objects for that match and the history of their interactions::
+The tournament object has an 'interactions' attribute which contains all the
+interactions between the players.
+(Actually, it's a list of lists: one list for each repetition which, in
+turn, has a list of Match objects). These can be used to view the history of the
+interactions::
 
-    >>> for match in tournament.matches[0]:
-    ...     player1 = match.player1.name
-    ...     player2 = match.player2.name
-    ...     print('%s vs %s: %s' % (player1, player2, match.result)) # doctest: +SKIP
+    >>> for index_pair, interaction in tournament.interactions[0].items():
+    ...     player1 = tournament.players[index_pair[0]]
+    ...     player2 = tournament.players[index_pair[1]]
+    ...     print('%s vs %s: %s' % (player1, player2, interaction)) # doctest: +SKIP
     Cooperator vs Defector: [('C', 'D'), ('C', 'D'), ('C', 'D')]
     Defector vs Tit For Tat: [('D', 'C'), ('D', 'D'), ('D', 'D')]
     Cooperator vs Cooperator: [('C', 'C'), ('C', 'C'), ('C', 'C')]
@@ -34,5 +35,35 @@ axelrod.Player objects for that match and the history of their interactions::
     Cooperator vs Tit For Tat: [('C', 'C'), ('C', 'C'), ('C', 'C')]
     Defector vs Defector: [('D', 'D'), ('D', 'D'), ('D', 'D')]
 
-There is further detail on axelrod.Match objects and the information you can
-retrieve from them in :ref:`creating_matches`.
+We can use these interactions to reconstruct :code:`axelrod.Match` objects which have
+a variety of available methods for analysis (more information can be found in
+:ref:`creating_matches`)::
+
+    >>> matches = []
+    >>> for index_pair, interaction in tournament.interactions[0].items():
+    ...     player1 = tournament.players[index_pair[0]]
+    ...     player2 = tournament.players[index_pair[1]]
+    ...     match = axl.Match([player1, player2], turns=3)
+    ...     match.result = interaction
+    ...     matches.append(match)
+    >>> len(matches)
+    10
+
+As an example let us view all winners of each match (:code:`False` indicates a
+tie):
+
+    >>> for match in matches:
+    ...     print("{} v {}, winner: {}".format(match.players[0],
+    ... 									   match.players[1],
+    ...									       match.winner()))  #doctest: +SKIP
+	Cooperator v Defector, winner: Defector
+    Defector v Tit For Tat, winner: Defector
+    Cooperator v Cooperator, winner: False
+    Tit For Tat v Grudger, winner: False
+    Grudger v Grudger, winner: False
+    Tit For Tat v Tit For Tat, winner: False
+    Defector v Grudger, winner: Defector
+    Cooperator v Grudger, winner: False
+    Cooperator v Tit For Tat, winner: False
+    Defector v Defector, winner: False
+


### PR DESCRIPTION
**No rush with this one: #520 needs investigating.**

This does two things in an attempt to address #520 (although it helped it did not address it on my machine).

1. No longer pass the match class to the `ResultSet`: pass interactions instead (I'm not yet sure how I feel about this, although recreating match instances to deal with the multiprocessing bug, ie the bandaid is silly):

    Whereas before we were passing a dictionary mapping index pairs to matches (which held the interactions as well as methods to analyse those interactions). Now I'm just passing the interactions (this is still in line with the refactor the ResultsSet as all analyse is done with no assumptions of the structure and with just the one base data type). This is what the interactions looks like:

    ```
    {(0,2}:[('C', 'D'), ('D', 'C')...], ...
    ```

    They used to look like:

    ```
    {(0,2), <Match>,...
    ```

    This results in the methods that the Match class use to use now also being made available to the Results class by introducing a `interactions_utils` module (which is lacking tests right now: will get to that).

2. The `tournament_type.build_matches` function is now a generator. I read that that helped with memory, seems like a good idea (doesn't hurt if we're not keeping the matches anyway).

I've also included something to the docs to show how to quickly get the matches back from the interactions (so you can get the sparklines etc...).