### PR TITLE
Fix DoubleCrosser and test to match description

### DIFF
--- a/axelrod/strategies/backstabber.py
+++ b/axelrod/strategies/backstabber.py
@@ -29,7 +29,7 @@ class BackStabber(Player):
             return D
         return C
 
-
+@FinalTransformer((D, D)) # End with two defections
 class DoubleCrosser(Player):
     """
     Forgives the first 3 defections but on the fourth
@@ -53,8 +53,6 @@ class DoubleCrosser(Player):
 
         if not opponent.history:
             return C
-        if len(opponent.history) > (self.tournament_attributes['length'] - 3):
-            return D
         if len(opponent.history) < 180:
             if len(opponent.history) > cutoff:
                 if D not in opponent.history[:cutoff + 1]:

--- a/axelrod/tests/unit/test_backstabber.py
+++ b/axelrod/tests/unit/test_backstabber.py
@@ -80,6 +80,5 @@ class TestDoubleCrosser(TestPlayer):
                             tournament_length=200)
 
         # Defects on rounds 199, and 200 no matter what
-        self.responses_test([C] * 198 , [C] * 198, [D, D, D],
+        self.responses_test([C] * 197 , [C] * 197, [C, D, D],
                             tournament_length=200)
-

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -29,6 +29,7 @@ test_turns = 100
 
 test_prob_end = .5
 
+
 class TestTournament(unittest.TestCase):
 
     @classmethod
@@ -158,7 +159,7 @@ class TestTournament(unittest.TestCase):
         # The following relates to #516
         players = [axelrod.Cooperator(), axelrod.Defector(),
                    axelrod.BackStabber(), axelrod.PSOGambler(),
-                   axelrod.ThueMorse()]
+                   axelrod.ThueMorse(), axelrod.DoubleCrosser()]
         tournament = axelrod.Tournament(
             name=self.test_name,
             players=players,

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -116,7 +116,7 @@ class TestTournament(unittest.TestCase):
            turns=integers(min_value=2, max_value=50),
            repetitions=integers(min_value=2, max_value=4),
            rm=random_module())
-    @settings(max_examples=50, timeout=10)
+    @settings(max_examples=50, timeout=0)
     @example(s=test_strategies, turns=test_turns, repetitions=test_repetitions,
              rm=random.seed(0))
 
@@ -597,7 +597,7 @@ class TestProbEndTournament(unittest.TestCase):
            prob_end=floats(min_value=.1, max_value=.9),
            repetitions=integers(min_value=2, max_value=4),
            rm=random_module())
-    @settings(max_examples=50, timeout=10)
+    @settings(max_examples=50, timeout=0)
     @example(s=test_strategies, prob_end=.2, repetitions=test_repetitions,
              rm=random.seed(0))
 


### PR DESCRIPTION
DoubleCrosser says in its docstring that it defects on the last 2 rounds unconditionally but the code was defecting for the last three rounds. @uglyfruitcake confirms that the intention was for defection on the last two only.

This corrects that error and adds the use of the FinalTransformer decorator.