### PR TITLE
Move Setting of attributes from tournament to match

### DIFF
--- a/axelrod/match.py
+++ b/axelrod/match.py
@@ -15,8 +15,8 @@ def is_stochastic(players, noise):
 
 class Match(object):
 
-    def __init__(
-        self, players, turns, game=None, deterministic_cache=None, noise=0):
+    def __init__(self, players, turns, game=None, deterministic_cache=None,
+                 noise=0):
         """
         Parameters
         ----------
@@ -32,18 +32,18 @@ class Match(object):
             The probability that a player's intended action should be flipped
         """
         self.result = []
-        self.players = list(players)
+        self.turns = turns
         self._classes = (players[0].__class__, players[1].__class__)
-        self._turns = turns
         if game is None:
             self.game = Game()
         else:
             self.game = game
+        self.noise = noise
+        self.players = list(players)
         if deterministic_cache is None:
             self._cache = DeterministicCache()
         else:
             self._cache = deterministic_cache
-        self._noise = noise
 
     @property
     def players(self):
@@ -67,7 +67,7 @@ class Match(object):
         A boolean to show whether a match between two players would be
         stochastic
         """
-        return is_stochastic(self.players, self._noise)
+        return is_stochastic(self.players, self.noise)
 
     @property
     def _cache_update_required(self):
@@ -75,7 +75,7 @@ class Match(object):
         A boolean to show whether the deterministic cache should be updated
         """
         return (
-            not self._noise and
+            not self.noise and
             self._cache.mutable and not (
                 any(p.classifier['stochastic'] for p in self.players)
                 )
@@ -103,9 +103,9 @@ class Match(object):
             turn = 0
             for p in self.players:
                 p.reset()
-            while turn < self._turns:
+            while turn < self.turns:
                 turn += 1
-                self.players[0].play(self.players[1], self._noise)
+                self.players[0].play(self.players[1], self.noise)
             result = list(
                 zip(self.players[0].history, self.players[1].history))
 
@@ -150,4 +150,4 @@ class Match(object):
         return iu.compute_sparklines(self.result, c_symbol, d_symbol)
 
     def __len__(self):
-        return self._turns
+        return self.turns

--- a/axelrod/match_generator.py
+++ b/axelrod/match_generator.py
@@ -8,7 +8,7 @@ class MatchGenerator(object):
 
     clone_opponents = True
 
-    def __init__(self, players, turns, deterministic_cache):
+    def __init__(self, players, turns, game, deterministic_cache):
         """
         A class to generate matches. This is used by the Tournament class which
         is in charge of playing the matches and collecting the results.
@@ -19,12 +19,15 @@ class MatchGenerator(object):
             A list of axelrod.Player objects
         turns : integer
             The number of turns per match
+        game : axelrod.Game
+            The game object used to score the match
         deterministic_cache : an instance of axelrod.DeterministicCache
         class
             A cache of resulting actions for deterministic matches
         """
         self.players = players
         self.turns = turns
+        self.game = game
         self.deterministic_cache = deterministic_cache
         self.opponents = players
 
@@ -77,14 +80,15 @@ class RoundRobinMatches(MatchGenerator):
 
     def build_single_match(self, pair, noise=0):
         """Create a single match for a given pair"""
-        return Match(pair, self.turns, self.deterministic_cache, noise)
+        return Match(
+            pair, self.turns, self.game, self.deterministic_cache, noise)
 
 
 class ProbEndRoundRobinMatches(RoundRobinMatches):
 
     clone_opponents = True
 
-    def __init__(self, players, prob_end, deterministic_cache):
+    def __init__(self, players, prob_end, game, deterministic_cache):
         """
         A class that generates matches for which the players do not
         know the length of the Match (to their knowledge it is infinite) but
@@ -96,18 +100,20 @@ class ProbEndRoundRobinMatches(RoundRobinMatches):
             A list of axelrod.Player objects
         prob_end : float
             The probability that a turn of a Match is the last
+        game : axelrod.Game
+            The game object used to score the match
         deterministic_cache : an instance of axelrod.DeterministicCache
             A cache of resulting actions for deterministic matches
         """
         super(ProbEndRoundRobinMatches, self).__init__(
-            players, turns=float("inf"),
+            players, turns=float("inf"), game=game,
             deterministic_cache=deterministic_cache)
         self.deterministic_cache.mutable = False
         self.prob_end = prob_end
 
     def build_single_match(self, pair, noise=0):
         """Create a single match for a given pair"""
-        return Match(pair, self.sample_length(self.prob_end),
+        return Match(pair, self.sample_length(self.prob_end), self.game,
                      self.deterministic_cache, noise)
 
     def sample_length(self, prob_end):

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -87,15 +87,15 @@ class Player(object):
         self.cooperations = 0
         self.defections = 0
         self.init_args = ()
-        self.set_tournament_attributes()
+        self.set_match_attributes()
 
-    def receive_tournament_attributes(self):
+    def receive_match_attributes(self):
         # Overwrite this function if your strategy needs
-        # to make use of tournament_attributes such as
+        # to make use of match_attributes such as
         # the game matrix, the number of rounds or the noise
         pass
 
-    def set_tournament_attributes(self, length=-1, game=None, noise=0):
+    def set_match_attributes(self, length=-1, game=None, noise=0):
         if not game:
             game = DefaultGame
         self.tournament_attributes = {

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -141,7 +141,7 @@ class Player(object):
         # Consider overriding in special cases only if necessary
         cls = self.__class__
         new_player = cls(*self.init_args)
-        new_player.tournament_attributes = copy.copy(self.tournament_attributes)
+        new_player.match_attributes = copy.copy(self.match_attributes)
         return new_player
 
     def reset(self):

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -98,7 +98,7 @@ class Player(object):
     def set_match_attributes(self, length=-1, game=None, noise=0):
         if not game:
             game = DefaultGame
-        self.tournament_attributes = {
+        self.match_attributes = {
             "length": length,
             "game": game,
             "noise": noise

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -103,7 +103,7 @@ class Player(object):
             "game": game,
             "noise": noise
         }
-        self.receive_tournament_attributes()
+        self.receive_match_attributes()
 
     def __repr__(self):
         """The string method for the strategy."""

--- a/axelrod/strategies/axelrod_second.py
+++ b/axelrod/strategies/axelrod_second.py
@@ -26,7 +26,7 @@ class Champion(Player):
 
     def strategy(self, opponent):
         current_round = len(self.history)
-        expected_length = self.tournament_attributes['length']
+        expected_length = self.match_attributes['length']
         # Cooperate for the first 1/20-th of the game
         if current_round == 0:
             return C

--- a/axelrod/strategies/darwin.py
+++ b/axelrod/strategies/darwin.py
@@ -38,7 +38,7 @@ class Darwin(Player):
         self.response = Darwin.genome[0]
 
     def receive_match_attributes(self):
-        self.outcomes = self.tournament_attributes["game"].scores
+        self.outcomes = self.match_attributes["game"].scores
 
     def strategy(self, opponent):
         # Frustrate psychics and ensure that simulated rounds

--- a/axelrod/strategies/darwin.py
+++ b/axelrod/strategies/darwin.py
@@ -37,7 +37,7 @@ class Darwin(Player):
         super(Darwin, self).__init__()
         self.response = Darwin.genome[0]
 
-    def receive_tournament_attributes(self):
+    def receive_match_attributes(self):
         self.outcomes = self.tournament_attributes["game"].scores
 
     def strategy(self, opponent):

--- a/axelrod/strategies/memoryone.py
+++ b/axelrod/strategies/memoryone.py
@@ -116,7 +116,7 @@ class GTFT(MemoryOnePlayer):
         super(GTFT, self).__init__()
         self.init_args = (p,)
 
-    def receive_tournament_attributes(self):
+    def receive_match_attributes(self):
         (R, P, S, T) = self.tournament_attributes["game"].RPST()
         if self.p is None:
             self.p = min(1 - float(T - R) / (R - S), float(R - P) / (T - P))
@@ -200,7 +200,7 @@ class LRPlayer(MemoryOnePlayer):
     }
 
 
-    def receive_tournament_attributes(self, phi=0, s=None, l=None):
+    def receive_match_attributes(self, phi=0, s=None, l=None):
         """
         Parameters
 
@@ -247,10 +247,10 @@ class ZDExtort2(LRPlayer):
         self.s = s
         super(ZDExtort2, self).__init__()
 
-    def receive_tournament_attributes(self):
+    def receive_match_attributes(self):
         (R, P, S, T) = self.tournament_attributes["game"].RPST()
         self.l = P
-        super(ZDExtort2, self).receive_tournament_attributes(
+        super(ZDExtort2, self).receive_match_attributes(
             self.phi, self.s, self.l)
 
 
@@ -273,8 +273,8 @@ class ZDExtort2v2(LRPlayer):
         self.l = l
         super(ZDExtort2v2, self).__init__()
 
-    def receive_tournament_attributes(self):
-        super(ZDExtort2v2, self).receive_tournament_attributes(
+    def receive_match_attributes(self):
+        super(ZDExtort2v2, self).receive_match_attributes(
             self.phi, self.s, self.l)
 
 
@@ -298,8 +298,8 @@ class ZDExtort4(LRPlayer):
         self.l = l
         super(ZDExtort4, self).__init__()
 
-    def receive_tournament_attributes(self):
-        super(ZDExtort4, self).receive_tournament_attributes(
+    def receive_match_attributes(self):
+        super(ZDExtort4, self).receive_match_attributes(
             self.phi, self.s, self.l)
 
 
@@ -322,8 +322,8 @@ class ZDGen2(LRPlayer):
         self.l = l
         super(ZDGen2, self).__init__()
 
-    def receive_tournament_attributes(self):
-        super(ZDGen2, self).receive_tournament_attributes(
+    def receive_match_attributes(self):
+        super(ZDGen2, self).receive_match_attributes(
             self.phi, self.s, self.l)
 
 
@@ -345,10 +345,10 @@ class ZDGTFT2(LRPlayer):
         super(ZDGTFT2, self).__init__()
         self.init_args = (phi, s)
 
-    def receive_tournament_attributes(self):
+    def receive_match_attributes(self):
         (R, P, S, T) = self.tournament_attributes["game"].RPST()
         self.l = R
-        super(ZDGTFT2, self).receive_tournament_attributes(
+        super(ZDGTFT2, self).receive_match_attributes(
             self.phi, self.s, self.l)
 
 
@@ -371,8 +371,8 @@ class ZDSet2(LRPlayer):
         self.l = l
         super(ZDSet2, self).__init__()
 
-    def receive_tournament_attributes(self):
-        super(ZDSet2, self).receive_tournament_attributes(
+    def receive_match_attributes(self):
+        super(ZDSet2, self).receive_match_attributes(
             self.phi, self.s, self.l)
 
 

--- a/axelrod/strategies/memoryone.py
+++ b/axelrod/strategies/memoryone.py
@@ -117,7 +117,7 @@ class GTFT(MemoryOnePlayer):
         self.init_args = (p,)
 
     def receive_match_attributes(self):
-        (R, P, S, T) = self.tournament_attributes["game"].RPST()
+        (R, P, S, T) = self.match_attributes["game"].RPST()
         if self.p is None:
             self.p = min(1 - float(T - R) / (R - S), float(R - P) / (T - P))
         four_vector = [1, self.p, 1, self.p]
@@ -209,7 +209,7 @@ class LRPlayer(MemoryOnePlayer):
             parameterization of the strategies below.
         """
 
-        (R, P, S, T) = self.tournament_attributes["game"].RPST()
+        (R, P, S, T) = self.match_attributes["game"].RPST()
         if s is None:
             s = 1
         if l is None:
@@ -248,7 +248,7 @@ class ZDExtort2(LRPlayer):
         super(ZDExtort2, self).__init__()
 
     def receive_match_attributes(self):
-        (R, P, S, T) = self.tournament_attributes["game"].RPST()
+        (R, P, S, T) = self.match_attributes["game"].RPST()
         self.l = P
         super(ZDExtort2, self).receive_match_attributes(
             self.phi, self.s, self.l)
@@ -346,7 +346,7 @@ class ZDGTFT2(LRPlayer):
         self.init_args = (phi, s)
 
     def receive_match_attributes(self):
-        (R, P, S, T) = self.tournament_attributes["game"].RPST()
+        (R, P, S, T) = self.match_attributes["game"].RPST()
         self.l = R
         super(ZDGTFT2, self).receive_match_attributes(
             self.phi, self.s, self.l)

--- a/axelrod/strategies/meta.py
+++ b/axelrod/strategies/meta.py
@@ -140,7 +140,7 @@ class MetaWinner(MetaPlayer):
         # Update the running score for each player, before determining the next move.
         if len(self.history):
             for player in self.team:
-                game = self.tournament_attributes["game"]
+                game = self.match_attributes["game"]
                 last_round = (player.proposed_history[-1], opponent.history[-1])
                 s = game.scores[last_round][0]
                 player.score += s

--- a/axelrod/strategies/mindreader.py
+++ b/axelrod/strategies/mindreader.py
@@ -36,7 +36,7 @@ class MindReader(Player):
         if calname in ('strategy', 'simulate_match'):
             return D
 
-        game = self.tournament_attributes["game"]
+        game = self.match_attributes["game"]
 
         best_strategy = look_ahead(self, opponent, game)
 

--- a/axelrod/strategies/qlearner.py
+++ b/axelrod/strategies/qlearner.py
@@ -42,7 +42,7 @@ class RiskyQLearner(Player):
         self.prev_state = ''
 
     def receive_match_attributes(self):
-        (R, P, S, T) = self.tournament_attributes["game"].RPST()
+        (R, P, S, T) = self.match_attributes["game"].RPST()
         self.payoff_matrix = {C: {C: R, D: S}, D: {C: T, D: P}}
 
     def strategy(self, opponent):

--- a/axelrod/strategies/qlearner.py
+++ b/axelrod/strategies/qlearner.py
@@ -41,7 +41,7 @@ class RiskyQLearner(Player):
         self.Vs = OrderedDict({'': 0})
         self.prev_state = ''
 
-    def receive_tournament_attributes(self):
+    def receive_match_attributes(self):
         (R, P, S, T) = self.tournament_attributes["game"].RPST()
         self.payoff_matrix = {C: {C: R, D: S}, D: {C: T, D: P}}
 

--- a/axelrod/strategy_transformers.py
+++ b/axelrod/strategy_transformers.py
@@ -192,7 +192,7 @@ def final_sequence(player, opponent, action, seq):
     """Play the moves in `seq` first, ignoring the strategy's moves until the
     list is exhausted."""
 
-    length = player.tournament_attributes["length"]
+    length = player.match_attributes["length"]
     player.classifier["makes_use_of"].update(["length"])
 
     if length < 0:  # default is -1

--- a/axelrod/tests/unit/test_match.py
+++ b/axelrod/tests/unit/test_match.py
@@ -21,6 +21,10 @@ class TestMatch(unittest.TestCase):
         self.assertEqual(match.result, [])
         self.assertEqual(match.players, [p1, p2])
         self.assertEqual(
+            match.players[0].match_attributes['length'],
+            turns
+        )
+        self.assertEqual(
             match._classes, (axelrod.Cooperator, axelrod.Cooperator))
         self.assertEqual(match.turns, turns)
         self.assertEqual(match._cache, {})

--- a/axelrod/tests/unit/test_match.py
+++ b/axelrod/tests/unit/test_match.py
@@ -22,9 +22,9 @@ class TestMatch(unittest.TestCase):
         self.assertEqual(match.players, [p1, p2])
         self.assertEqual(
             match._classes, (axelrod.Cooperator, axelrod.Cooperator))
-        self.assertEqual(match._turns, turns)
+        self.assertEqual(match.turns, turns)
         self.assertEqual(match._cache, {})
-        self.assertEqual(match._noise, 0)
+        self.assertEqual(match.noise, 0)
 
     @given(turns=integers(min_value=1, max_value=200))
     @example(turns=5)
@@ -75,7 +75,7 @@ class TestMatch(unittest.TestCase):
     def test_play(self):
         cache = DeterministicCache()
         players = (axelrod.Cooperator(), axelrod.Defector())
-        match = axelrod.Match(players, 3, cache)
+        match = axelrod.Match(players, 3, deterministic_cache=cache)
         expected_result = [(C, D), (C, D), (C, D)]
         self.assertEqual(match.play(), expected_result)
         self.assertEqual(

--- a/axelrod/tests/unit/test_match.py
+++ b/axelrod/tests/unit/test_match.py
@@ -62,7 +62,7 @@ class TestMatch(unittest.TestCase):
 
         cache = DeterministicCache()
         cache.mutable = False
-        match = axelrod.Match((p1, p2), 5, cache)
+        match = axelrod.Match((p1, p2), 5, deterministic_cache=cache)
         self.assertFalse(match._cache_update_required)
 
         match = axelrod.Match((p1, p2), 5)
@@ -84,7 +84,7 @@ class TestMatch(unittest.TestCase):
         # a deliberately incorrect result so we can tell it came from the cache
         expected_result = [(C, C), (D, D), (D, C)]
         cache[(axelrod.Cooperator, axelrod.Defector)] = expected_result
-        match = axelrod.Match(players, 3, cache)
+        match = axelrod.Match(players, 3, deterministic_cache=cache)
         self.assertEqual(match.play(), expected_result)
 
     def test_scores(self):

--- a/axelrod/tests/unit/test_match_generator.py
+++ b/axelrod/tests/unit/test_match_generator.py
@@ -12,6 +12,7 @@ test_strategies = [
     axelrod.GoByMajority
 ]
 test_turns = 100
+test_game = axelrod.Game()
 
 
 class TestTournamentType(unittest.TestCase):
@@ -22,7 +23,7 @@ class TestTournamentType(unittest.TestCase):
 
     def test_init_with_clone(self):
         tt = axelrod.MatchGenerator(
-            self.players, test_turns, axelrod.DeterministicCache())
+            self.players, test_turns, test_game, axelrod.DeterministicCache())
         self.assertEqual(tt.players, self.players)
         self.assertEqual(tt.turns, test_turns)
         player = tt.players[0]
@@ -42,7 +43,7 @@ class TestRoundRobin(unittest.TestCase):
 
     def test_build_single_match(self):
         rr = axelrod.RoundRobinMatches(
-            self.players, test_turns, axelrod.DeterministicCache())
+            self.players, test_turns, test_game, axelrod.DeterministicCache())
         match = rr.build_single_match((self.players[0], self.players[1]))
         self.assertIsInstance(match, axelrod.Match)
         self.assertEqual(len(match), rr.turns)
@@ -50,7 +51,7 @@ class TestRoundRobin(unittest.TestCase):
 
     def test_build_matches(self):
         rr = axelrod.RoundRobinMatches(
-            self.players, test_turns, axelrod.DeterministicCache())
+            self.players, test_turns, test_game, axelrod.DeterministicCache())
         matches = rr.build_matches()
         match_definitions = [
             (index_pair) for index_pair, match in matches]
@@ -83,7 +84,7 @@ class TestProbEndRoundRobin(unittest.TestCase):
     @given(prob_end=floats(min_value=0, max_value=1), rm=random_module())
     def test_build_matches(self, prob_end, rm):
         rr = axelrod.ProbEndRoundRobinMatches(
-            self.players, prob_end, axelrod.DeterministicCache())
+            self.players, prob_end, test_game, axelrod.DeterministicCache())
         matches = rr.build_matches()
         match_definitions = [
             (index_pair) for index_pair, match in matches]
@@ -116,7 +117,7 @@ class TestProbEndRoundRobin(unittest.TestCase):
         to sample all games with same length.
         """
         rr = axelrod.ProbEndRoundRobinMatches(
-            self.players, prob_end, axelrod.DeterministicCache())
+            self.players, prob_end, test_game, axelrod.DeterministicCache())
         matches = rr.build_matches()
         match_lengths = [len(match) for index_pair, match in matches]
         self.assertNotEqual(min(match_lengths), max(match_lengths))
@@ -124,7 +125,7 @@ class TestProbEndRoundRobin(unittest.TestCase):
     @given(prob_end=floats(min_value=0, max_value=1), rm=random_module())
     def test_sample_length(self, prob_end, rm):
         rr = axelrod.ProbEndRoundRobinMatches(
-            self.players, prob_end, axelrod.DeterministicCache())
+            self.players, prob_end, test_game, axelrod.DeterministicCache())
         self.assertGreaterEqual(rr.sample_length(prob_end), 1)
         try:
             self.assertIsInstance(rr.sample_length(prob_end), int)
@@ -134,7 +135,7 @@ class TestProbEndRoundRobin(unittest.TestCase):
     @given(prob_end=floats(min_value=.1, max_value=1), rm=random_module())
     def test_build_single_match(self, prob_end, rm):
         rr = axelrod.ProbEndRoundRobinMatches(
-            self.players, prob_end, axelrod.DeterministicCache())
+            self.players, prob_end, test_game, axelrod.DeterministicCache())
         match = rr.build_single_match((self.players[0], self.players[1]))
 
         self.assertIsInstance(match, axelrod.Match)

--- a/axelrod/tests/unit/test_memoryone.py
+++ b/axelrod/tests/unit/test_memoryone.py
@@ -174,7 +174,7 @@ class TestLRPlayer(unittest.TestCase):
     def test_exception(self):
         player = LRPlayer()
         with self.assertRaises(ValueError):
-            player.receive_tournament_attributes(0, 0, -float("inf"))
+            player.receive_match_attributes(0, 0, -float("inf"))
 
 
 class TestZDExtort2(TestPlayer):

--- a/axelrod/tests/unit/test_player.py
+++ b/axelrod/tests/unit/test_player.py
@@ -122,7 +122,7 @@ class TestPlayer(unittest.TestCase):
         if self.__class__ != TestPlayer:
             player = self.player()
             self.assertEqual(player.history, [])
-            self.assertEqual(player.tournament_attributes,
+            self.assertEqual(player.match_attributes,
                     {'length': -1, 'game': DefaultGame, 'noise': 0})
             self.assertEqual(player.cooperations, 0)
             self.assertEqual(player.defections, 0)
@@ -133,25 +133,25 @@ class TestPlayer(unittest.TestCase):
         if self.__class__ != TestPlayer:
             self.assertEqual(str(self.player()), self.name)
 
-    def test_tournament_attributes(self):
+    def test_match_attributes(self):
         player = self.player()
         # Default
-        player.set_tournament_attributes()
-        t_attrs = player.tournament_attributes
+        player.set_match_attributes()
+        t_attrs = player.match_attributes
         self.assertEqual(t_attrs['length'], -1)
         self.assertEqual(t_attrs['noise'], 0)
         self.assertEqual(t_attrs['game'].RPST(), (3, 1, 0, 5))
 
         # Common
-        player.set_tournament_attributes(length=200)
-        t_attrs = player.tournament_attributes
+        player.set_match_attributes(length=200)
+        t_attrs = player.match_attributes
         self.assertEqual(t_attrs['length'], 200)
         self.assertEqual(t_attrs['noise'], 0)
         self.assertEqual(t_attrs['game'].RPST(), (3, 1, 0, 5))
 
         # Noisy
-        player.set_tournament_attributes(length=200, noise=.5)
-        t_attrs = player.tournament_attributes
+        player.set_match_attributes(length=200, noise=.5)
+        t_attrs = player.match_attributes
         self.assertEqual(t_attrs['noise'], .5)
 
     def test_reset(self):
@@ -181,7 +181,7 @@ class TestPlayer(unittest.TestCase):
         self.assertEqual(p2.cooperations, 0)
         self.assertEqual(p2.defections, 0)
         self.assertEqual(p2.classifier, p1.classifier)
-        self.assertEqual(p2.tournament_attributes, p1.tournament_attributes)
+        self.assertEqual(p2.match_attributes, p1.match_attributes)
 
     def first_play_test(self, play, random_seed=None):
         """Tests first move of a strategy."""
@@ -213,9 +213,9 @@ class TestPlayer(unittest.TestCase):
         subsequent moves by player one to test.
         """
         P1 = self.player()
-        P1.tournament_attributes['length'] = tournament_length
+        P1.match_attributes['length'] = tournament_length
         P2 = TestOpponent()
-        P2.tournament_attributes['length'] = tournament_length
+        P2.match_attributes['length'] = tournament_length
         test_responses(
             self, P1, P2, history_1, history_2, responses,
             random_seed=random_seed, attrs=attrs)
@@ -223,7 +223,7 @@ class TestPlayer(unittest.TestCase):
         # Test that we get the same sequence after a reset
         P1.reset()
         P2 = TestOpponent()
-        P2.tournament_attributes['length'] = tournament_length
+        P2.match_attributes['length'] = tournament_length
         test_responses(
             self, P1, P2, history_1, history_2, responses,
             random_seed=random_seed, attrs=attrs)
@@ -231,7 +231,7 @@ class TestPlayer(unittest.TestCase):
         # Test that we get the same sequence after a clone
         P1 = P1.clone()
         P2 = TestOpponent()
-        P2.tournament_attributes['length'] = tournament_length
+        P2.match_attributes['length'] = tournament_length
         test_responses(
             self, P1, P2, history_1, history_2, responses,
             random_seed=random_seed, attrs=attrs)

--- a/axelrod/tests/unit/test_strategy_transformers.py
+++ b/axelrod/tests/unit/test_strategy_transformers.py
@@ -108,7 +108,7 @@ class TestTransformers(unittest.TestCase):
         # Final play transformer
         p1 = axelrod.Cooperator()
         p2 = FinalTransformer([D, D, D])(axelrod.Cooperator)()
-        p2.tournament_attributes["length"] = 6
+        p2.match_attributes["length"] = 6
         for _ in range(6):
             p1.play(p2)
         self.assertEqual(p2.history, [C, C, C, D, D, D])
@@ -135,7 +135,7 @@ class TestTransformers(unittest.TestCase):
         cls2 = FinalTransformer([D, D])(cls1)
         p1 = cls2()
         p2 = axelrod.Cooperator()
-        p1.tournament_attributes["length"] = 8
+        p1.match_attributes["length"] = 8
         for _ in range(8):
             p1.play(p2)
         self.assertEqual(p1.history, [D, D, C, C, C, C, D, D])
@@ -143,7 +143,7 @@ class TestTransformers(unittest.TestCase):
         cls1 = FinalTransformer([D, D])(InitialTransformer([D, D])(axelrod.Cooperator))
         p1 = cls1()
         p2 = axelrod.Cooperator()
-        p1.tournament_attributes["length"] = 8
+        p1.match_attributes["length"] = 8
         for _ in range(8):
             p1.play(p2)
         self.assertEqual(p1.history, [D, D, C, C, C, C, D, D])
@@ -152,7 +152,7 @@ class TestTransformers(unittest.TestCase):
         cls1 = compose_transformers(FinalTransformer([D, D]), InitialTransformer([D, D]))
         p1 = cls1(axelrod.Cooperator)()
         p2 = axelrod.Cooperator()
-        p1.tournament_attributes["length"] = 8
+        p1.match_attributes["length"] = 8
         for _ in range(8):
             p1.play(p2)
         self.assertEqual(p1.history, [D, D, C, C, C, C, D, D])

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -63,12 +63,8 @@ class TestTournament(unittest.TestCase):
             processes=4,
             noise=0.2)
         self.assertEqual(len(tournament.players), len(test_strategies))
-        self.assertEqual(
-            tournament.players[0].tournament_attributes['length'],
-            self.test_turns
-        )
         self.assertIsInstance(
-            tournament.players[0].tournament_attributes['game'], axelrod.Game
+            tournament.players[0].match_attributes['game'], axelrod.Game
         )
         self.assertEqual(tournament.game.score(('C', 'C')), (3, 3))
         self.assertEqual(tournament.turns, self.test_turns)
@@ -545,13 +541,6 @@ class TestProbEndTournament(unittest.TestCase):
             noise=0.2)
         self.assertEqual(tournament.match_generator.prob_end, tournament.prob_end)
         self.assertEqual(len(tournament.players), len(test_strategies))
-        self.assertEqual(
-            tournament.players[0].tournament_attributes['length'],
-            float("inf")
-        )
-        self.assertIsInstance(
-            tournament.players[0].tournament_attributes['game'], axelrod.Game
-        )
         self.assertEqual(tournament.game.score(('C', 'C')), (3, 3))
         self.assertEqual(tournament.turns, float("inf"))
         self.assertEqual(tournament.repetitions, 10)

--- a/axelrod/tournament.py
+++ b/axelrod/tournament.py
@@ -13,9 +13,10 @@ from .match_generator import RoundRobinMatches, ProbEndRoundRobinMatches
 class Tournament(object):
     game = Game()
 
-    def __init__(self, players, match_generator=RoundRobinMatches, name='axelrod',
-                 game=None, turns=200, repetitions=10, processes=None,
-                 prebuilt_cache=False, noise=0, with_morality=True):
+    def __init__(self, players, match_generator=RoundRobinMatches,
+                 name='axelrod', game=None, turns=200, repetitions=10,
+                 processes=None, prebuilt_cache=False, noise=0,
+                 with_morality=True):
         """
         Parameters
         ----------
@@ -50,28 +51,12 @@ class Tournament(object):
         self.prebuilt_cache = prebuilt_cache
         self.deterministic_cache = DeterministicCache()
         self.match_generator = match_generator(
-            players, turns, self.deterministic_cache)
+            players, turns, self.game, self.deterministic_cache)
         self._with_morality = with_morality
         self._parallel_repetitions = repetitions
         self._processes = processes
         self._logger = logging.getLogger(__name__)
         self.interactions = []
-
-    @property
-    def players(self):
-        return self._players
-
-    @players.setter
-    def players(self, players):
-        """Ensure that players are passed the tournament attributes"""
-        newplayers = []
-        for player in players:
-            player.set_tournament_attributes(
-                length=self.turns,
-                 game=self.game,
-                 noise=self.noise)
-            newplayers.append(player)
-        self._players = newplayers
 
     def play(self, filename=None):
         """
@@ -353,7 +338,7 @@ class ProbEndTournament(Tournament):
 
         self.prob_end = prob_end
         self.match_generator = ProbEndRoundRobinMatches(
-            players, prob_end, self.deterministic_cache)
+            players, prob_end, self.game, self.deterministic_cache)
 
     def _build_cache_required(self):
         """


### PR DESCRIPTION
#493 

This PR moves the responsibility for passing match attributes (e.g. length) from the tournament class to the match itself. (They were previously known as tournament_attributes and have also been renamed).

It doesn't add any of the potential new functionality discussed in #493.