### PR TITLE
Update Moran process reset method to also reset players

### DIFF
--- a/axelrod/moran.py
+++ b/axelrod/moran.py
@@ -107,6 +107,9 @@ class MoranProcess(object):
         self.winning_strategy_name = None
         self.populations = [self.populations[0]]
         self.score_history = []
+        # Reset all the players
+        for player in self.players:
+            player.reset()
 
     def play(self):
         """Play the process out to completion."""

--- a/axelrod/tests/unit/test_moran.py
+++ b/axelrod/tests/unit/test_moran.py
@@ -98,5 +98,5 @@ class TestMoranProcess(unittest.TestCase):
         self.assertEqual(mp.winning_strategy_name, None)
         self.assertEqual(mp.score_history, [])
         # Check that players reset
-        for player in mp.players
+        for player in mp.players:
             self.assertEqual(len(player.history), 0)

--- a/axelrod/tests/unit/test_moran.py
+++ b/axelrod/tests/unit/test_moran.py
@@ -97,3 +97,6 @@ class TestMoranProcess(unittest.TestCase):
         self.assertEqual(len(mp), 1)
         self.assertEqual(mp.winning_strategy_name, None)
         self.assertEqual(mp.score_history, [])
+        # Check that players reset
+        for player in mp.players
+            self.assertEqual(len(player.history), 0)


### PR DESCRIPTION
Simple PR to make the action of `reset()` in the Moran process more logical by also resetting the players.