### PR TITLE
Adding a simple read of the requirements.txt. to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,13 @@
 from setuptools import setup
 
+# Read in the requirements.txt file
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
 
 setup(
     name='Axelrod',
     version='0.0.31',
+    install_requires=requirements,
     author='Vince Knight, Owen Campbell, Karol Langner, Marc Harper',
     author_email=('axelrod-python@googlegroups.com'),
     packages=['axelrod', 'axelrod.strategies', 'axelrod.tests'],


### PR DESCRIPTION
Closes #525 

Before, when running `pip install axelrod`, you needed to also install the requirements. This was potentially confusing for some reading through the installation documentation. 

Have tested this in virtual envs.