### PR TITLE
Adding tutorial about cache and also ability to pass a cache directly to the tournament

### DIFF
--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -80,6 +80,19 @@ class TestTournament(unittest.TestCase):
         anonymous_tournament = axelrod.Tournament(players=self.players)
         self.assertEqual(anonymous_tournament.name, 'axelrod')
 
+        # Test init when passing a cache:
+        cache = axelrod.DeterministicCache()
+        tournament = axelrod.Tournament(
+            name=self.test_name,
+            players=self.players,
+            game=self.game,
+            turns=self.test_turns,
+            processes=4,
+            noise=0.2,
+            deterministic_cache=cache)
+        self.assertEqual(tournament.deterministic_cache, cache)
+        self.assertTrue(tournament.prebuilt_cache)
+
     def test_serial_play(self):
         # Test that we get an instance of ResultSet
         tournament = axelrod.Tournament(

--- a/axelrod/tournament.py
+++ b/axelrod/tournament.py
@@ -15,8 +15,8 @@ class Tournament(object):
 
     def __init__(self, players, match_generator=RoundRobinMatches,
                  name='axelrod', game=None, turns=200, repetitions=10,
-                 processes=None, prebuilt_cache=False, noise=0,
-                 with_morality=True):
+                 processes=None, deterministic_cache=None, prebuilt_cache=False,
+                 noise=0, with_morality=True):
         """
         Parameters
         ----------
@@ -34,6 +34,8 @@ class Tournament(object):
             The number of times the round robin should be repeated
         processes : integer
             The number of processes to be used for parallel processing
+        deterministic_cache : instance
+            An instance of the axelrod.DeterministicCache class
         prebuilt_cache : boolean
             Whether a cache has been passed in from an external object
         noise : float
@@ -48,8 +50,12 @@ class Tournament(object):
             self.game = game
         self.players = players
         self.repetitions = repetitions
-        self.prebuilt_cache = prebuilt_cache
-        self.deterministic_cache = DeterministicCache()
+        if deterministic_cache is not None:
+            self.prebuilt_cache = True
+            self.deterministic_cache = deterministic_cache
+        else:
+            self.prebuilt_cache = prebuilt_cache
+            self.deterministic_cache = DeterministicCache()
         self.match_generator = match_generator(
             players, turns, self.game, self.deterministic_cache)
         self._with_morality = with_morality

--- a/docs/tutorials/advanced/index.rst
+++ b/docs/tutorials/advanced/index.rst
@@ -12,3 +12,4 @@ Contents:
    strategy_transformers.rst
    making_tournaments.rst
    reading_and_writing_interactions.rst
+   using_the_cache.rst

--- a/docs/tutorials/advanced/using_the_cache.rst
+++ b/docs/tutorials/advanced/using_the_cache.rst
@@ -8,24 +8,34 @@ different result, for deterministic strategies, when there is no noise there is
 no need to re run the match. The library has a :code:`DeterministicCache` class
 that allows us to quickly replay matches.
 
-Here is how to create a new empty cache::
-
-    >>> import axelrod as axl
-    >>> cache = axl.DeterministicCache()
-    >>> len(cache)
-    0
 
 Caching a Match
 ---------------
 
-We can use this cache in a Match, let us also time the execution::
+To illustrate this, let us time the play of a match **without** a cache::
 
+    >>> import axelrod as axl
     >>> import timeit
     >>> def run_match():
     ...     p1, p2 = axl.GoByMajority(), axl.Alternator()
-    ...     match = axl.Match((p1, p2), deterministic_cache=cache, turns=200)
+    ...     match = axl.Match((p1, p2), turns=200)
     ...     return match.play()
-    >>> time_with_empty_cache = timeit.timeit(run_match, number=500)
+    >>> time_with_no_cache = timeit.timeit(run_match, number=500)
+    >>> time_with_no_cache  # doctest: +SKIP
+    2.2295279502868652
+
+Here is how to create a new empty cache::
+
+    >>> cache = axl.DeterministicCache()
+    >>> len(cache)
+    0
+
+Let us rerun the above match but using the cache::
+
+    >>> p1, p2 = axl.GoByMajority(), axl.Alternator()
+    >>> match = axl.Match((p1, p2), turns=200, deterministic_cache=cache)
+    >>> match.play()  # doctest: +ELLIPSIS
+    [('C', 'C'), ..., ('C', 'D')]
 
 We can take a look at the cache::
 
@@ -37,15 +47,17 @@ We can take a look at the cache::
 This maps a triplet of 2 player classes and the match length to the resulting
 interactions.  We can rerun the code and compare the timing::
 
-    >>> time_with_full_cache = timeit.timeit(run_match, number=200)
-    >>> time_with_empty_cache  # doctest: +SKIP
-    0.039147138595581055
-    >>> time_with_full_cache  # doctest: +SKIP
-    0.014961004257202148
-    >>> time_with_full_cache < time_with_empty_cache
+    >>> def run_match_with_cache():
+    ...     p1, p2 = axl.GoByMajority(), axl.Alternator()
+    ...     match = axl.Match((p1, p2), turns=200, deterministic_cache=cache)
+    ...     return match.play()
+    >>> time_with_cache = timeit.timeit(run_match_with_cache, number=500)
+    >>> time_with_cache  # doctest: +SKIP
+    0.04215192794799805
+    >>> time_with_cache < time_with_no_cache
     True
 
-Note that we can write the cache to file::
+We can write the cache to file::
 
     >>> cache.save("cache.txt")
     True

--- a/docs/tutorials/advanced/using_the_cache.rst
+++ b/docs/tutorials/advanced/using_the_cache.rst
@@ -1,0 +1,99 @@
+.. _using-the-cache:
+
+Using the cache
+===============
+
+Whilst for stochastic strategies every repetition of a Match will give a
+different result. For deterministic strategies, when there is no noise there is
+no need to re run the match. The library has a :code:`DeterministicCache` class
+that allows us to quickly replay matches.
+
+Here is how to create a new empty cache::
+
+    >>> import axelrod as axl
+    >>> cache = axl.DeterministicCache()
+    >>> len(cache)
+    0
+
+Caching a Match
+---------------
+
+We can use this cache in a Match, let us also time the execution::
+
+    >>> import timeit
+    >>> def run_match():
+    ...     p1, p2 = axl.GoByMajority(), axl.Alternator()
+    ...     match = axl.Match((p1, p2), deterministic_cache=cache, turns=200)
+    ...     return match.play()
+    >>> time_with_empty_cache = timeit.timeit(run_match, number=500)
+
+We can take a look at the cache::
+
+    >>> cache  # doctest: +ELLIPSIS
+    {(<class 'axelrod.strategies.gobymajority.GoByMajority'>, <class 'axelrod.strategies.alternator.Alternator'>, 200): [('C', 'C'), ..., ('C', 'D')]}
+    >>> len(cache)
+    1
+
+Note, that is maps triplets of players and match lengths to interactions.
+We can rerun the code and compare the timing::
+
+    >>> time_with_full_cache = timeit.timeit(run_match, number=200)
+    >>> time_with_empty_cache  # doctest: +SKIP
+    0.039147138595581055
+    >>> time_with_full_cache  # doctest: +SKIP
+    0.014961004257202148
+    >>> time_with_full_cache < time_with_empty_cache
+    True
+
+Note that we can write the cache to file::
+
+    >>> cache.save("cache.txt")
+    True
+
+Caching a Tournament
+--------------------
+
+We can use a prebuilt cache in a tournament (by default a new cache is used). Firstly,
+let us read in the previous cache from file::
+
+    >>> cache = axl.DeterministicCache("cache.txt")
+    >>> cache  # doctest: +ELLIPSIS
+    {(<class 'axelrod.strategies.gobymajority.GoByMajority'>, <class 'axelrod.strategies.alternator.Alternator'>, 200): [('C', 'C'), ...]}
+
+Let us create a tournament including :code:`GoByMajority` and :code:`Alternator`
+to be able to make use of the cache::
+
+    >>> players = [axl.GoByMajority(), axl.Alternator(), axl.Cooperator()]
+    >>> tournament = axl.Tournament(players, turns=200, repetitions=5, deterministic_cache=cache)
+    >>> results = tournament.play()
+
+The cache has not only been used for this but has now also been updated with the
+new matches::
+
+    >>> len(cache)
+    6
+
+Caching a Moran Process
+-----------------------
+
+A prebuilt cache can also be used in a Moran process (by default a new cache is
+used)::
+
+    >>> players = [axl.GoByMajority(), axl.Alternator(),
+    ...            axl.Cooperator(), axl.Grudger()]
+    >>> mp = axl.MoranProcess(players, deterministic_cache=cache)
+    >>> populations = mp.play()
+    >>> mp.winning_strategy_name   # doctest: +SKIP
+    Defector
+
+Again we see that the cache has been augmented, although note that this
+particular number will depend on the stochastic behaviour of the Moran process::
+
+    >>> len(cache)  # doctest: +SKIP
+    18
+
+Although, in this case the length of matches are not all the same (the default
+match length in the Moran process is 100)::
+
+    >>> list(set([length for p1, p2, length in cache.keys()]))
+    [200, 100]

--- a/docs/tutorials/advanced/using_the_cache.rst
+++ b/docs/tutorials/advanced/using_the_cache.rst
@@ -3,8 +3,8 @@
 Using the cache
 ===============
 
-Whilst for stochastic strategies every repetition of a Match will give a
-different result. For deterministic strategies, when there is no noise there is
+Whilst for stochastic strategies, every repetition of a Match will give a
+different result, for deterministic strategies, when there is no noise there is
 no need to re run the match. The library has a :code:`DeterministicCache` class
 that allows us to quickly replay matches.
 
@@ -34,8 +34,8 @@ We can take a look at the cache::
     >>> len(cache)
     1
 
-Note, that is maps triplets of players and match lengths to interactions.
-We can rerun the code and compare the timing::
+This maps a triplet of 2 player classes and the match length to the resulting
+interactions.  We can rerun the code and compare the timing::
 
     >>> time_with_full_cache = timeit.timeit(run_match, number=200)
     >>> time_with_empty_cache  # doctest: +SKIP


### PR DESCRIPTION
Closes #547 

**This is on top of #546, so that should be merged/reviewed first. (Merging this will merge #546)**

Note that to make things in line with the match and the Moran process I've added the ability to pass a cache directly to the `Tournament` class. So the following works (as shown in the tutorial):

```
>>> cache = axl.DeterministicCache(filename)  # Read in some prebuilt cache
>>> players = [axl.GoByMajority(), axl.Alternator(), axl.Cooperator()]
>>> tournament = axl.Tournament(players, turns=200, repetitions=5, deterministic_cache=cache)
>>> results = tournament.play()
```

I haven't gotten rid of the `prebuilt_cache` argument as I didn't want to get in to the `TournamentManager` (I think that's where it's used). That could potentially be made simpler with this though?