### PR TITLE
Writing tournaments as each set of interactions occurs (currently: only at the end of all repetitions)

### DIFF
--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -446,7 +446,24 @@ class TestTournament(unittest.TestCase):
         tournament.play(filename=tmp_file.name)
         with open(tmp_file.name, 'r') as f:
             written_data = [r for r in csv.reader(f)]
-            expected_data = [['(0, 0)', '(0, 1)', '(0, 2)', '(0, 3)', '(0, 4)', '(1, 1)', '(1, 2)', '(1, 3)', '(1, 4)', '(2, 2)', '(2, 3)', '(2, 4)', '(3, 3)', '(3, 4)', '(4, 4)'], ['(Cooperator, Cooperator)', '(Cooperator, Tit For Tat)', '(Cooperator, Defector)', '(Cooperator, Grudger)', '(Cooperator, Soft Go By Majority)', '(Tit For Tat, Tit For Tat)', '(Tit For Tat, Defector)', '(Tit For Tat, Grudger)', '(Tit For Tat, Soft Go By Majority)', '(Defector, Defector)', '(Defector, Grudger)', '(Defector, Soft Go By Majority)', '(Grudger, Grudger)', '(Grudger, Soft Go By Majority)', '(Soft Go By Majority, Soft Go By Majority)'], ['CCCC', 'CCCC', 'CDCD', 'CCCC', 'CCCC', 'CCCC', 'CDDD', 'CCCC', 'CCCC', 'DDDD', 'DCDD', 'DCDD', 'CCCC', 'CCCC', 'CCCC'], ['CCCC', 'CCCC', 'CDCD', 'CCCC', 'CCCC', 'CCCC', 'CDDD', 'CCCC', 'CCCC', 'DDDD', 'DCDD', 'DCDD', 'CCCC', 'CCCC', 'CCCC']]
+            expected_data = [['(0, 0)', '(0, 1)', '(0, 2)', '(0, 3)',
+                              '(0, 4)', '(1, 1)', '(1, 2)', '(1, 3)',
+                              '(1, 4)', '(2, 2)', '(2, 3)', '(2, 4)',
+                              '(3, 3)', '(3, 4)', '(4, 4)'],
+                        ['(Cooperator, Cooperator)', '(Cooperator, Tit For Tat)',
+                         '(Cooperator, Defector)', '(Cooperator, Grudger)',
+                         '(Cooperator, Soft Go By Majority)', '(Tit For Tat, Tit For Tat)',
+                         '(Tit For Tat, Defector)', '(Tit For Tat, Grudger)',
+                         '(Tit For Tat, Soft Go By Majority)', '(Defector, Defector)',
+                         '(Defector, Grudger)', '(Defector, Soft Go By Majority)',
+                         '(Grudger, Grudger)', '(Grudger, Soft Go By Majority)',
+                         '(Soft Go By Majority, Soft Go By Majority)'],
+                        ['CCCC', 'CCCC', 'CDCD', 'CCCC', 'CCCC', 'CCCC',
+                         'CDDD', 'CCCC', 'CCCC', 'DDDD', 'DCDD', 'DCDD',
+                         'CCCC', 'CCCC', 'CCCC'],
+                        ['CCCC', 'CCCC', 'CDCD', 'CCCC', 'CCCC', 'CCCC',
+                         'CDDD', 'CCCC', 'CCCC', 'DDDD', 'DCDD', 'DCDD',
+                         'CCCC', 'CCCC', 'CCCC']]
             self.assertEqual(sorted(written_data), sorted(expected_data))
         # Test that no interactions are kept in memory:
         self.assertEqual(len(tournament.interactions), 0)
@@ -463,7 +480,24 @@ class TestTournament(unittest.TestCase):
         tournament.play(filename=tmp_file.name)
         with open(tmp_file.name, 'r') as f:
             written_data = [r for r in csv.reader(f)]
-            expected_data = [['(0, 0)', '(0, 1)', '(0, 2)', '(0, 3)', '(0, 4)', '(1, 1)', '(1, 2)', '(1, 3)', '(1, 4)', '(2, 2)', '(2, 3)', '(2, 4)', '(3, 3)', '(3, 4)', '(4, 4)'], ['(Cooperator, Cooperator)', '(Cooperator, Tit For Tat)', '(Cooperator, Defector)', '(Cooperator, Grudger)', '(Cooperator, Soft Go By Majority)', '(Tit For Tat, Tit For Tat)', '(Tit For Tat, Defector)', '(Tit For Tat, Grudger)', '(Tit For Tat, Soft Go By Majority)', '(Defector, Defector)', '(Defector, Grudger)', '(Defector, Soft Go By Majority)', '(Grudger, Grudger)', '(Grudger, Soft Go By Majority)', '(Soft Go By Majority, Soft Go By Majority)'], ['CCCC', 'CCCC', 'CDCD', 'CCCC', 'CCCC', 'CCCC', 'CDDD', 'CCCC', 'CCCC', 'DDDD', 'DCDD', 'DCDD', 'CCCC', 'CCCC', 'CCCC'], ['CCCC', 'CCCC', 'CDCD', 'CCCC', 'CCCC', 'CCCC', 'CDDD', 'CCCC', 'CCCC', 'DDDD', 'DCDD', 'DCDD', 'CCCC', 'CCCC', 'CCCC']]
+            expected_data = [['(0, 0)', '(0, 1)', '(0, 2)', '(0, 3)',
+                              '(0, 4)', '(1, 1)', '(1, 2)', '(1, 3)',
+                              '(1, 4)', '(2, 2)', '(2, 3)', '(2, 4)',
+                              '(3, 3)', '(3, 4)', '(4, 4)'],
+                        ['(Cooperator, Cooperator)', '(Cooperator, Tit For Tat)',
+                         '(Cooperator, Defector)', '(Cooperator, Grudger)',
+                         '(Cooperator, Soft Go By Majority)', '(Tit For Tat, Tit For Tat)',
+                         '(Tit For Tat, Defector)', '(Tit For Tat, Grudger)',
+                         '(Tit For Tat, Soft Go By Majority)', '(Defector, Defector)',
+                         '(Defector, Grudger)', '(Defector, Soft Go By Majority)',
+                         '(Grudger, Grudger)', '(Grudger, Soft Go By Majority)',
+                         '(Soft Go By Majority, Soft Go By Majority)'],
+                        ['CCCC', 'CCCC', 'CDCD', 'CCCC', 'CCCC', 'CCCC',
+                         'CDDD', 'CCCC', 'CCCC', 'DDDD', 'DCDD', 'DCDD',
+                         'CCCC', 'CCCC', 'CCCC'],
+                        ['CCCC', 'CCCC', 'CDCD', 'CCCC', 'CCCC', 'CCCC',
+                         'CDDD', 'CCCC', 'CCCC', 'DDDD', 'DCDD', 'DCDD',
+                         'CCCC', 'CCCC', 'CCCC']]
             self.assertEqual(sorted(written_data), sorted(expected_data))
         # Test that no interactions are kept in memory:
         self.assertEqual(len(tournament.interactions), 0)
@@ -481,8 +515,38 @@ class TestTournament(unittest.TestCase):
         tournament._write_csv_header(tmp_file.name, index_pairs)
         with open(tmp_file.name, 'r') as f:
             written_header = [r for r in csv.reader(f)]
-            expected_header = [['(0, 0)', '(0, 1)', '(0, 2)', '(0, 3)', '(0, 4)', '(1, 1)', '(1, 2)', '(1, 3)', '(1, 4)', '(2, 2)', '(2, 3)', '(2, 4)', '(3, 3)', '(3, 4)', '(4, 4)'], ['(Cooperator, Cooperator)', '(Cooperator, Tit For Tat)', '(Cooperator, Defector)', '(Cooperator, Grudger)', '(Cooperator, Soft Go By Majority)', '(Tit For Tat, Tit For Tat)', '(Tit For Tat, Defector)', '(Tit For Tat, Grudger)', '(Tit For Tat, Soft Go By Majority)', '(Defector, Defector)', '(Defector, Grudger)', '(Defector, Soft Go By Majority)', '(Grudger, Grudger)', '(Grudger, Soft Go By Majority)', '(Soft Go By Majority, Soft Go By Majority)']]
+            expected_header = [['(0, 0)', '(0, 1)', '(0, 2)', '(0, 3)',
+                                '(0, 4)', '(1, 1)', '(1, 2)', '(1, 3)',
+                                '(1, 4)', '(2, 2)', '(2, 3)', '(2, 4)',
+                                '(3, 3)', '(3, 4)', '(4, 4)'],
+                          ['(Cooperator, Cooperator)', '(Cooperator, Tit For Tat)',
+                           '(Cooperator, Defector)', '(Cooperator, Grudger)',
+                           '(Cooperator, Soft Go By Majority)', '(Tit For Tat, Tit For Tat)',
+                           '(Tit For Tat, Defector)', '(Tit For Tat, Grudger)',
+                           '(Tit For Tat, Soft Go By Majority)', '(Defector, Defector)',
+                           '(Defector, Grudger)', '(Defector, Soft Go By Majority)',
+                           '(Grudger, Grudger)', '(Grudger, Soft Go By Majority)',
+                           '(Soft Go By Majority, Soft Go By Majority)']]
             self.assertEqual(written_header, expected_header)
+
+    def test_write_csv_interactions(self):
+        tournament = axelrod.Tournament(
+            name=self.test_name,
+            players=self.players,
+            game=self.game,
+            turns=2,
+            repetitions=2)
+        tournament.play()
+        tmp_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
+        interactions = tournament.interactions[0]
+        tournament._write_csv_interactions(tmp_file.name, interactions)
+        with open(tmp_file.name, 'r') as f:
+            written_interactions = [r for r in csv.reader(f)]
+            expected_interactions = [['CCCC', 'CCCC', 'CDCD', 'CCCC', 'CCCC',
+                                      'CCCC', 'CDDD', 'CCCC', 'CCCC', 'DDDD',
+                                      'DCDD', 'DCDD', 'CCCC', 'CCCC', 'CCCC']]
+            self.assertEqual(written_interactions, expected_interactions)
+
 
 
 class TestProbEndTournament(unittest.TestCase):

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -116,7 +116,7 @@ class TestTournament(unittest.TestCase):
         tournament._run_parallel_repetitions = MagicMock(
             name='_run_parallel_repetitions')
         tournament.play()
-        tournament._run_serial_repetitions.assert_called_once_with([])
+        tournament._run_serial_repetitions.assert_called_once_with([], None)
         self.assertFalse(tournament._run_parallel_repetitions.called)
 
     @given(s=lists(sampled_from(axelrod.strategies),
@@ -248,7 +248,7 @@ class TestTournament(unittest.TestCase):
         tournament._run_single_repetition = MagicMock(
             name='_run_single_repetition')
         tournament._build_cache([])
-        tournament._run_single_repetition.assert_called_once_with([])
+        tournament._run_single_repetition.assert_called_once_with([], None)
         self.assertEqual(
             tournament._parallel_repetitions, self.test_repetitions - 1)
 
@@ -445,30 +445,30 @@ class TestTournament(unittest.TestCase):
         tmp_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
         tournament.play(filename=tmp_file.name)
         with open(tmp_file.name, 'r') as f:
-            written_data = [[int(r[0]), int(r[1])] + r[2:] for r in csv.reader(f)]
-            expected_data = [[0, 1, 'Cooperator', 'Tit For Tat', 'CCCC', 'CCCC'],
-                             [1, 2, 'Tit For Tat', 'Defector', 'CDDD', 'CDDD'],
-                             [0, 0, 'Cooperator', 'Cooperator', 'CCCC', 'CCCC'],
-                             [3, 3, 'Grudger', 'Grudger', 'CCCC', 'CCCC'],
-                             [2, 2, 'Defector', 'Defector', 'DDDD', 'DDDD'],
-                             [4, 4, 'Soft Go By Majority', 'Soft Go By Majority',
-                              'CCCC', 'CCCC'],
-                             [1, 4, 'Tit For Tat', 'Soft Go By Majority',
-                              'CCCC', 'CCCC'],
-                             [1, 1, 'Tit For Tat', 'Tit For Tat', 'CCCC', 'CCCC'],
-                             [1, 3, 'Tit For Tat', 'Grudger', 'CCCC', 'CCCC'],
-                             [2, 3, 'Defector', 'Grudger', 'DCDD', 'DCDD'],
-                             [0, 4, 'Cooperator', 'Soft Go By Majority',
-                              'CCCC', 'CCCC'],
-                             [2, 4, 'Defector', 'Soft Go By Majority',
-                              'DCDD', 'DCDD'],
-                             [0, 3, 'Cooperator', 'Grudger', 'CCCC', 'CCCC'],
-                             [3, 4, 'Grudger', 'Soft Go By Majority',
-                              'CCCC', 'CCCC'],
-                             [0, 2, 'Cooperator', 'Defector', 'CDCD', 'CDCD']]
+            written_data = [r for r in csv.reader(f)]
+            expected_data = [['(0, 0)', '(0, 1)', '(0, 2)', '(0, 3)', '(0, 4)', '(1, 1)', '(1, 2)', '(1, 3)', '(1, 4)', '(2, 2)', '(2, 3)', '(2, 4)', '(3, 3)', '(3, 4)', '(4, 4)'], ['(Cooperator, Cooperator)', '(Cooperator, Tit For Tat)', '(Cooperator, Defector)', '(Cooperator, Grudger)', '(Cooperator, Soft Go By Majority)', '(Tit For Tat, Tit For Tat)', '(Tit For Tat, Defector)', '(Tit For Tat, Grudger)', '(Tit For Tat, Soft Go By Majority)', '(Defector, Defector)', '(Defector, Grudger)', '(Defector, Soft Go By Majority)', '(Grudger, Grudger)', '(Grudger, Soft Go By Majority)', '(Soft Go By Majority, Soft Go By Majority)'], ['CCCC', 'CCCC', 'CDCD', 'CCCC', 'CCCC', 'CCCC', 'CDDD', 'CCCC', 'CCCC', 'DDDD', 'DCDD', 'DCDD', 'CCCC', 'CCCC', 'CCCC'], ['CCCC', 'CCCC', 'CDCD', 'CCCC', 'CCCC', 'CCCC', 'CDDD', 'CCCC', 'CCCC', 'DDDD', 'DCDD', 'DCDD', 'CCCC', 'CCCC', 'CCCC']]
             self.assertEqual(sorted(written_data), sorted(expected_data))
+        # Test that no interactions are kept in memory:
+        self.assertEqual(len(tournament.interactions), 0)
 
-    def test_write_to_csv(self):
+    def test_parallel_play_and_write_to_csv(self):
+        tournament = axelrod.Tournament(
+            name=self.test_name,
+            players=self.players,
+            game=self.game,
+            turns=2,
+            repetitions=2,
+            processes=2)
+        tmp_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
+        tournament.play(filename=tmp_file.name)
+        with open(tmp_file.name, 'r') as f:
+            written_data = [r for r in csv.reader(f)]
+            expected_data = [['(0, 0)', '(0, 1)', '(0, 2)', '(0, 3)', '(0, 4)', '(1, 1)', '(1, 2)', '(1, 3)', '(1, 4)', '(2, 2)', '(2, 3)', '(2, 4)', '(3, 3)', '(3, 4)', '(4, 4)'], ['(Cooperator, Cooperator)', '(Cooperator, Tit For Tat)', '(Cooperator, Defector)', '(Cooperator, Grudger)', '(Cooperator, Soft Go By Majority)', '(Tit For Tat, Tit For Tat)', '(Tit For Tat, Defector)', '(Tit For Tat, Grudger)', '(Tit For Tat, Soft Go By Majority)', '(Defector, Defector)', '(Defector, Grudger)', '(Defector, Soft Go By Majority)', '(Grudger, Grudger)', '(Grudger, Soft Go By Majority)', '(Soft Go By Majority, Soft Go By Majority)'], ['CCCC', 'CCCC', 'CDCD', 'CCCC', 'CCCC', 'CCCC', 'CDDD', 'CCCC', 'CCCC', 'DDDD', 'DCDD', 'DCDD', 'CCCC', 'CCCC', 'CCCC'], ['CCCC', 'CCCC', 'CDCD', 'CCCC', 'CCCC', 'CCCC', 'CDDD', 'CCCC', 'CCCC', 'DDDD', 'DCDD', 'DCDD', 'CCCC', 'CCCC', 'CCCC']]
+            self.assertEqual(sorted(written_data), sorted(expected_data))
+        # Test that no interactions are kept in memory:
+        self.assertEqual(len(tournament.interactions), 0)
+
+    def test_write_csv_header(self):
         tournament = axelrod.Tournament(
             name=self.test_name,
             players=self.players,
@@ -477,62 +477,12 @@ class TestTournament(unittest.TestCase):
             repetitions=2)
         tournament.play()
         tmp_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
-        tournament._write_to_csv(tmp_file.name)
+        index_pairs = sorted(tournament.interactions[0].keys())
+        tournament._write_csv_header(tmp_file.name, index_pairs)
         with open(tmp_file.name, 'r') as f:
-            written_data = [[int(r[0]), int(r[1])] + r[2:] for r in csv.reader(f)]
-            expected_data = [[0, 1, 'Cooperator', 'Tit For Tat', 'CCCC', 'CCCC'],
-                             [1, 2, 'Tit For Tat', 'Defector', 'CDDD', 'CDDD'],
-                             [0, 0, 'Cooperator', 'Cooperator', 'CCCC', 'CCCC'],
-                             [3, 3, 'Grudger', 'Grudger', 'CCCC', 'CCCC'],
-                             [2, 2, 'Defector', 'Defector', 'DDDD', 'DDDD'],
-                             [4, 4, 'Soft Go By Majority', 'Soft Go By Majority',
-                              'CCCC', 'CCCC'],
-                             [1, 4, 'Tit For Tat', 'Soft Go By Majority',
-                              'CCCC', 'CCCC'],
-                             [1, 1, 'Tit For Tat', 'Tit For Tat', 'CCCC', 'CCCC'],
-                             [1, 3, 'Tit For Tat', 'Grudger', 'CCCC', 'CCCC'],
-                             [2, 3, 'Defector', 'Grudger', 'DCDD', 'DCDD'],
-                             [0, 4, 'Cooperator', 'Soft Go By Majority',
-                              'CCCC', 'CCCC'],
-                             [2, 4, 'Defector', 'Soft Go By Majority',
-                              'DCDD', 'DCDD'],
-                             [0, 3, 'Cooperator', 'Grudger', 'CCCC', 'CCCC'],
-                             [3, 4, 'Grudger', 'Soft Go By Majority',
-                              'CCCC', 'CCCC'],
-                             [0, 2, 'Cooperator', 'Defector', 'CDCD', 'CDCD']]
-            self.assertEqual(sorted(written_data), sorted(expected_data))
-
-    def test_data_for_csv(self):
-        tournament = axelrod.Tournament(
-            name=self.test_name,
-            players=self.players,
-            game=self.game,
-            turns=2,
-            repetitions=2)
-        tournament.play()
-        expected_data = [[0, 1, 'Cooperator', 'Tit For Tat', 'CCCC', 'CCCC'],
-                         [1, 2, 'Tit For Tat', 'Defector', 'CDDD', 'CDDD'],
-                         [0, 0, 'Cooperator', 'Cooperator', 'CCCC', 'CCCC'],
-                         [3, 3, 'Grudger', 'Grudger', 'CCCC', 'CCCC'],
-                         [2, 2, 'Defector', 'Defector', 'DDDD', 'DDDD'],
-                         [4, 4, 'Soft Go By Majority', 'Soft Go By Majority',
-                          'CCCC', 'CCCC'],
-                         [1, 4, 'Tit For Tat', 'Soft Go By Majority',
-                          'CCCC', 'CCCC'],
-                         [1, 1, 'Tit For Tat', 'Tit For Tat', 'CCCC', 'CCCC'],
-                         [1, 3, 'Tit For Tat', 'Grudger', 'CCCC', 'CCCC'],
-                         [2, 3, 'Defector', 'Grudger', 'DCDD', 'DCDD'],
-                         [0, 4, 'Cooperator', 'Soft Go By Majority',
-                          'CCCC', 'CCCC'],
-                         [2, 4, 'Defector', 'Soft Go By Majority',
-                          'DCDD', 'DCDD'],
-                         [0, 3, 'Cooperator', 'Grudger', 'CCCC', 'CCCC'],
-                         [3, 4, 'Grudger', 'Soft Go By Majority',
-                          'CCCC', 'CCCC'],
-                         [0, 2, 'Cooperator', 'Defector', 'CDCD', 'CDCD']]
-        generator_data = tournament._data_for_csv()
-        for row, expected_row in zip(sorted(generator_data), sorted(expected_data)):
-            self.assertEqual(row, expected_row)
+            written_header = [r for r in csv.reader(f)]
+            expected_header = [['(0, 0)', '(0, 1)', '(0, 2)', '(0, 3)', '(0, 4)', '(1, 1)', '(1, 2)', '(1, 3)', '(1, 4)', '(2, 2)', '(2, 3)', '(2, 4)', '(3, 3)', '(3, 4)', '(4, 4)'], ['(Cooperator, Cooperator)', '(Cooperator, Tit For Tat)', '(Cooperator, Defector)', '(Cooperator, Grudger)', '(Cooperator, Soft Go By Majority)', '(Tit For Tat, Tit For Tat)', '(Tit For Tat, Defector)', '(Tit For Tat, Grudger)', '(Tit For Tat, Soft Go By Majority)', '(Defector, Defector)', '(Defector, Grudger)', '(Defector, Soft Go By Majority)', '(Grudger, Grudger)', '(Grudger, Soft Go By Majority)', '(Soft Go By Majority, Soft Go By Majority)']]
+            self.assertEqual(written_header, expected_header)
 
 
 class TestProbEndTournament(unittest.TestCase):

--- a/axelrod/tournament.py
+++ b/axelrod/tournament.py
@@ -68,9 +68,15 @@ class Tournament(object):
         """
         Plays the tournament and passes the results to the ResultSet class
 
+        Parameters
+        ----------
+            filename : string
+                A path to write the interactions to file. This can be used to
+                save memory for large tournaments.
+
         Returns
         -------
-        axelrod.ResultSet
+            axelrod.ResultSet
         """
         if filename is not None:
             index_pairs = [pair for pair, match in
@@ -121,6 +127,9 @@ class Tournament(object):
         ----------
         matches : list
             The list of matches to update
+
+        filename : string
+            Path to write interactions to file.
         """
         self._logger.debug('Playing first round robin to build cache')
         self._run_single_repetition(matches, filename)
@@ -129,6 +138,12 @@ class Tournament(object):
     def _run_single_repetition(self, interactions, filename=None):
         """
         Runs a single round robin and updates the matches list.
+
+        Parameters
+        ----------
+
+        filename : string
+            Path to write interactions to file.
         """
         new_matches = self.match_generator.build_matches(noise=self.noise)
         interactions = self._play_matches(new_matches)
@@ -136,7 +151,7 @@ class Tournament(object):
         if filename is None:
             self.interactions.append(interactions)
         else:
-            self._write_csv_interaction(filename, interactions)
+            self._write_csv_interactions(filename, interactions)
 
 
     def _run_serial_repetitions(self, interactions, filename=None):
@@ -147,6 +162,8 @@ class Tournament(object):
         ----------
         ineractions : list
             The list of interactions per repetition to update with results
+        filename : string
+            Path to write interactions to file.
         """
         self._logger.debug('Playing %d round robins' % self.repetitions)
         for repetition in range(self.repetitions):
@@ -161,6 +178,9 @@ class Tournament(object):
         ----------
         interactions : list
             The list of interactions per repetition to update with results
+
+        filename : string
+            Path to write interactions to file.
         """
         # At first sight, it might seem simpler to use the multiprocessing Pool
         # Class rather than Processes and Queues. However, Pool can only accept
@@ -215,7 +235,8 @@ class Tournament(object):
             process.start()
         return True
 
-    def _process_done_queue(self, workers, done_queue, interactions, filename=None):
+    def _process_done_queue(self, workers, done_queue,
+                            interactions, filename=None):
         """
         Retrieves the matches from the parallel sub-processes
 
@@ -227,6 +248,8 @@ class Tournament(object):
             A queue containing the output dictionaries from each round robin
         interactions : list
             The list of interactions per repetition to update with results
+        filename : string
+            Path to write interactions to file.
         """
         stops = 0
         while stops < workers:
@@ -238,7 +261,7 @@ class Tournament(object):
                 if filename is None:
                     interactions.append(results)
                 else:
-                    self._write_csv_interaction(filename, results)
+                    self._write_csv_interactions(filename, results)
         return True
 
     def _worker(self, work_queue, done_queue):
@@ -306,7 +329,7 @@ class Tournament(object):
             writer.writerow(index_pairs)
             writer.writerow(player_names)
 
-    def _write_csv_interaction(self, filename, interactions):
+    def _write_csv_interactions(self, filename, interactions):
         """Write interactions to file"""
         index_pairs = sorted(interactions.keys())
         with open(filename, 'a') as csvfile:

--- a/axelrod/tournament.py
+++ b/axelrod/tournament.py
@@ -72,17 +72,21 @@ class Tournament(object):
         -------
         axelrod.ResultSet
         """
+        if filename is not None:
+            index_pairs = [pair for pair, match in
+                           self.match_generator.build_matches()]
+            self._write_csv_header(filename, index_pairs)
+
         if self._processes is None:
-            self._run_serial_repetitions(self.interactions)
+            self._run_serial_repetitions(self.interactions, filename)
         else:
             if self._build_cache_required():
-                self._build_cache(self.interactions)
-            self._run_parallel_repetitions(self.interactions)
+                self._build_cache(self.interactions, filename)
+            self._run_parallel_repetitions(self.interactions, filename)
 
         if filename is None:
             self.result_set = self._build_result_set()
             return self.result_set
-        self._write_to_csv(filename)
 
     def _build_result_set(self):
         """
@@ -108,7 +112,7 @@ class Tournament(object):
                 len(self.deterministic_cache) == 0 or
                 not self.prebuilt_cache))
 
-    def _build_cache(self, matches):
+    def _build_cache(self, matches, filename=None):
         """
         For parallel processing, this runs a single round robin in order to
         build the deterministic cache.
@@ -119,18 +123,23 @@ class Tournament(object):
             The list of matches to update
         """
         self._logger.debug('Playing first round robin to build cache')
-        self._run_single_repetition(matches)
+        self._run_single_repetition(matches, filename)
         self._parallel_repetitions -= 1
 
-    def _run_single_repetition(self, interactions):
+    def _run_single_repetition(self, interactions, filename=None):
         """
         Runs a single round robin and updates the matches list.
         """
         new_matches = self.match_generator.build_matches(noise=self.noise)
         interactions = self._play_matches(new_matches)
-        self.interactions.append(interactions)
 
-    def _run_serial_repetitions(self, interactions):
+        if filename is None:
+            self.interactions.append(interactions)
+        else:
+            self._write_csv_interaction(filename, interactions)
+
+
+    def _run_serial_repetitions(self, interactions, filename=None):
         """
         Runs all repetitions of the round robin in serial.
 
@@ -141,10 +150,10 @@ class Tournament(object):
         """
         self._logger.debug('Playing %d round robins' % self.repetitions)
         for repetition in range(self.repetitions):
-            self._run_single_repetition(interactions)
+            self._run_single_repetition(interactions, filename)
         return True
 
-    def _run_parallel_repetitions(self, interactions):
+    def _run_parallel_repetitions(self, interactions, filename=None):
         """
         Run all except the first round robin using parallel processing.
 
@@ -167,7 +176,7 @@ class Tournament(object):
             'Playing %d round robins with %d parallel processes' %
             (self._parallel_repetitions, workers))
         self._start_workers(workers, work_queue, done_queue)
-        self._process_done_queue(workers, done_queue, interactions)
+        self._process_done_queue(workers, done_queue, interactions, filename)
 
         return True
 
@@ -206,7 +215,7 @@ class Tournament(object):
             process.start()
         return True
 
-    def _process_done_queue(self, workers, done_queue, interactions):
+    def _process_done_queue(self, workers, done_queue, interactions, filename=None):
         """
         Retrieves the matches from the parallel sub-processes
 
@@ -226,7 +235,10 @@ class Tournament(object):
             if results == 'STOP':
                 stops += 1
             else:
-                interactions.append(results)
+                if filename is None:
+                    interactions.append(results)
+                else:
+                    self._write_csv_interaction(filename, results)
         return True
 
     def _worker(self, work_queue, done_queue):
@@ -269,35 +281,43 @@ class Tournament(object):
             interactions[index_pair] = match.result
         return interactions
 
-    def _write_to_csv(self, filename):
-        """Write the interactions to csv."""
+    def _write_csv_header(self, filename, index_pairs):
+        """
+        Write the head for the csv file:
+
+        This will be of the form:
+
+        indices, (0, 0), (0, 1), (1, 1), ...
+        names, (Defector, Defector), (Defector, Cooperator),...
+
+        Parameters
+        ----------
+
+        filename : string
+            Path to the filename
+        index_pairs : list
+            A list of player index tuples
+        """
+        index_pairs.sort()
+        player_names = [(self.players[i1], self.players[i2]) for i1, i2 in
+                        index_pairs]
         with open(filename, 'w') as csvfile:
             writer = csv.writer(csvfile)
-            for row in self._data_for_csv():
-                writer.writerow(row)
+            writer.writerow(index_pairs)
+            writer.writerow(player_names)
 
-    def _data_for_csv(self):
-        """
-        Returns
-        -------
-        A generator of the interactions to a list of lists of the form:
-
-        [p1index, p2index, p1name, p2name, p1rep1ac1p2rep1ac1p1rep1ac2p2rep1ac2,
-        ...]
-        [0, 1, Defector, Cooperator, DCDCDC, DCDCDC, DCDCDC,...]
-        [0, 2, Defector, Alternator, DCDDDC, DCDDDC, DCDDDC,...]
-        [1, 2, Cooperator, Alternator, CCCDCC, CCCDCC, CCCDCC,...]
-        """
-        index_pairs = self.interactions[0].keys()
-        for index_pair in index_pairs:
-            p1, p2 = index_pair
-            row = [p1, p2, self.players[p1].name, self.players[p2].name]
-            for rep in self.interactions:
-                interaction = rep[index_pair]
+    def _write_csv_interaction(self, filename, interactions):
+        """Write interactions to file"""
+        index_pairs = sorted(interactions.keys())
+        with open(filename, 'a') as csvfile:
+            writer = csv.writer(csvfile)
+            row = []
+            for index_pair in index_pairs:
+                interaction = interactions[index_pair]
                 matchstringrep = ''.join([act for inter in interaction
                                           for act in inter])
                 row.append(matchstringrep)
-            yield row
+            writer.writerow(row)
 
 
 class ProbEndTournament(Tournament):


### PR DESCRIPTION
This aims to further address #520.

I transpose the current data file format (rows now correspond to repetitions and columns to matches).