### PR TITLE
Dropping support for py3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: python
 python:
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
 before_install:


### PR DESCRIPTION
Closes #554 (I think?)

And we stick with the policy of the last py2.7 (for now) and the last 2 py3s?