### PR TITLE
FOR MARC: Changing the format of the interactions attribute for the tournament and result set.

### DIFF
--- a/axelrod/result_set.py
+++ b/axelrod/result_set.py
@@ -32,7 +32,7 @@ class ResultSet(object):
         self.players = players
         self.nplayers = len(players)
         self.interactions = interactions
-        self.nrepetitions = len(list(interactions.values())[0])
+        self.nrepetitions = max([len(rep) for rep in list(interactions.values())])
 
         # Calculate all attributes:
         self.build_all(with_morality)

--- a/axelrod/tests/unit/test_plot.py
+++ b/axelrod/tests/unit/test_plot.py
@@ -17,25 +17,24 @@ class TestPlot(unittest.TestCase):
     def setUpClass(cls):
         cls.players = (axelrod.Alternator(), axelrod.TitForTat(), axelrod.Defector())
         cls.turns = 5
-        cls.matches = [
-                       {
-                        (0,1): axelrod.Match((cls.players[0], cls.players[1]),
-                        turns=cls.turns),
-                        (0,2): axelrod.Match((cls.players[0], cls.players[2]),
-                        turns=cls.turns),
-                        (1,2): axelrod.Match((cls.players[1], cls.players[2]),
-                        turns=cls.turns)} for _ in range(3)
-                        ]  # This would not actually be a round robin tournament
+        cls.matches = {
+                        (0,1): [axelrod.Match((cls.players[0], cls.players[1]),
+                        turns=cls.turns) for _ in range(3)],
+                        (0,2): [axelrod.Match((cls.players[0], cls.players[2]),
+                        turns=cls.turns) for _ in range(3)],
+                        (1,2): [axelrod.Match((cls.players[1], cls.players[2]),
+                        turns=cls.turns) for _ in range(3)]}
+                          # This would not actually be a round robin tournament
                            # (no cloned matches)
 
-        for rep in cls.matches:
-            for match in rep.values():
+        cls.interactions = {}
+        for index_pair, matches in cls.matches.items():
+            for match in matches:
                 match.play()
-
-        cls.interactions = []
-        for rep in cls.matches:
-            cls.interactions.append({index_pair: match.result for
-                                     index_pair, match in rep.items()})
+                try:
+                    cls.interactions[index_pair].append(match.result)
+                except KeyError:
+                    cls.interactions[index_pair] = [match.result]
 
         cls.test_result_set = axelrod.ResultSet(cls.players, cls.interactions)
         cls.expected_boxplot_dataset = [

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -111,13 +111,8 @@ class TestTournament(unittest.TestCase):
             game=self.game,
             turns=200,
             repetitions=self.test_repetitions)
-        tournament._run_serial_repetitions = MagicMock(
-            name='_run_serial_repetitions')
-        tournament._run_parallel_repetitions = MagicMock(
-            name='_run_parallel_repetitions')
         tournament.play()
-        tournament._run_serial_repetitions.assert_called_once_with([])
-        self.assertFalse(tournament._run_parallel_repetitions.called)
+        self.assertEqual(len(tournament.interactions), 15)
 
     @given(s=lists(sampled_from(axelrod.strategies),
                    min_size=2,  # Errors are returned if less than 2 strategies
@@ -261,8 +256,9 @@ class TestTournament(unittest.TestCase):
             turns=200,
             repetitions=self.test_repetitions)
         tournament._run_single_repetition(interactions)
-        self.assertEqual(len(tournament.interactions), 1)
-        self.assertEqual(len(tournament.interactions[0]), 15)
+        self.assertEqual(len(tournament.interactions), 15)
+        for repetitions in tournament.interactions.values():
+            self.assertEqual(len(repetitions), 1)
 
     def test_run_serial_repetitions(self):
         interactions = []
@@ -273,10 +269,12 @@ class TestTournament(unittest.TestCase):
             turns=200,
             repetitions=self.test_repetitions)
         tournament._run_serial_repetitions(interactions)
-        self.assertEqual(len(tournament.interactions), self.test_repetitions)
+        self.assertEqual(len(tournament.interactions), 15)
+        for repetitions in tournament.interactions.values():
+            self.assertEqual(len(repetitions), self.test_repetitions)
 
     def test_run_parallel_repetitions(self):
-        interactions = []
+        interactions = {}
         tournament = axelrod.Tournament(
             name=self.test_name,
             players=self.players,
@@ -285,9 +283,9 @@ class TestTournament(unittest.TestCase):
             repetitions=self.test_repetitions,
             processes=2)
         tournament._run_parallel_repetitions(interactions)
-        self.assertEqual(len(interactions), self.test_repetitions)
-        for r in interactions:
-            self.assertEqual(len(r.values()), 15)
+        self.assertEqual(len(interactions), 15)
+        for r in interactions.values():
+            self.assertEqual(len(r), self.test_repetitions)
 
     def test_n_workers(self):
         max_processes = cpu_count()
@@ -350,19 +348,24 @@ class TestTournament(unittest.TestCase):
     def test_process_done_queue(self):
         workers = 2
         done_queue = Queue()
-        matches = []
+        interactions = {}
         tournament = axelrod.Tournament(
             name=self.test_name,
             players=self.players,
             game=self.game,
             turns=200,
             repetitions=self.test_repetitions)
-        for r in range(self.test_repetitions):
-            done_queue.put({})
+        d = {}
+        count = 0
+        for i, _ in enumerate(self.players):
+            for j, _ in enumerate(self.players):
+                d[(i, j)] = []
+                count += 1
+        done_queue.put(d)
         for w in range(workers):
             done_queue.put('STOP')
-        tournament._process_done_queue(workers, done_queue, matches)
-        self.assertEqual(len(matches), self.test_repetitions)
+        tournament._process_done_queue(workers, done_queue, interactions)
+        self.assertEqual(len(interactions), count)
 
     def test_worker(self):
         tournament = axelrod.Tournament(
@@ -395,6 +398,7 @@ class TestTournament(unittest.TestCase):
             game=self.game,
             turns=200,
             repetitions=self.test_repetitions)
+        tournament.play()
         results = tournament._build_result_set()
         self.assertIsInstance(results, axelrod.ResultSet)
 
@@ -446,26 +450,36 @@ class TestTournament(unittest.TestCase):
         tournament.play(filename=tmp_file.name)
         with open(tmp_file.name, 'r') as f:
             written_data = [[int(r[0]), int(r[1])] + r[2:] for r in csv.reader(f)]
-            expected_data = [[0, 1, 'Cooperator', 'Tit For Tat', 'CCCC', 'CCCC'],
-                             [1, 2, 'Tit For Tat', 'Defector', 'CDDD', 'CDDD'],
-                             [0, 0, 'Cooperator', 'Cooperator', 'CCCC', 'CCCC'],
-                             [3, 3, 'Grudger', 'Grudger', 'CCCC', 'CCCC'],
-                             [2, 2, 'Defector', 'Defector', 'DDDD', 'DDDD'],
-                             [4, 4, 'Soft Go By Majority', 'Soft Go By Majority',
-                              'CCCC', 'CCCC'],
-                             [1, 4, 'Tit For Tat', 'Soft Go By Majority',
-                              'CCCC', 'CCCC'],
-                             [1, 1, 'Tit For Tat', 'Tit For Tat', 'CCCC', 'CCCC'],
-                             [1, 3, 'Tit For Tat', 'Grudger', 'CCCC', 'CCCC'],
-                             [2, 3, 'Defector', 'Grudger', 'DCDD', 'DCDD'],
-                             [0, 4, 'Cooperator', 'Soft Go By Majority',
-                              'CCCC', 'CCCC'],
-                             [2, 4, 'Defector', 'Soft Go By Majority',
-                              'DCDD', 'DCDD'],
-                             [0, 3, 'Cooperator', 'Grudger', 'CCCC', 'CCCC'],
-                             [3, 4, 'Grudger', 'Soft Go By Majority',
-                              'CCCC', 'CCCC'],
-                             [0, 2, 'Cooperator', 'Defector', 'CDCD', 'CDCD']]
+            expected_data = [[0, 1, 'Cooperator', 'Tit For Tat', 'CCCC'],
+                             [0, 1, 'Cooperator', 'Tit For Tat', 'CCCC'],
+                             [1, 2, 'Tit For Tat', 'Defector', 'CDDD'],
+                             [1, 2, 'Tit For Tat', 'Defector', 'CDDD'],
+                             [0, 0, 'Cooperator', 'Cooperator', 'CCCC'],
+                             [0, 0, 'Cooperator', 'Cooperator', 'CCCC'],
+                             [3, 3, 'Grudger', 'Grudger', 'CCCC'],
+                             [3, 3, 'Grudger', 'Grudger', 'CCCC'],
+                             [2, 2, 'Defector', 'Defector', 'DDDD'],
+                             [2, 2, 'Defector', 'Defector', 'DDDD'],
+                             [4, 4, 'Soft Go By Majority', 'Soft Go By Majority', 'CCCC'],
+                             [4, 4, 'Soft Go By Majority', 'Soft Go By Majority', 'CCCC'],
+                             [1, 4, 'Tit For Tat', 'Soft Go By Majority', 'CCCC'],
+                             [1, 4, 'Tit For Tat', 'Soft Go By Majority', 'CCCC'],
+                             [1, 1, 'Tit For Tat', 'Tit For Tat', 'CCCC'],
+                             [1, 1, 'Tit For Tat', 'Tit For Tat', 'CCCC'],
+                             [1, 3, 'Tit For Tat', 'Grudger', 'CCCC'],
+                             [1, 3, 'Tit For Tat', 'Grudger', 'CCCC'],
+                             [2, 3, 'Defector', 'Grudger', 'DCDD'],
+                             [2, 3, 'Defector', 'Grudger', 'DCDD'],
+                             [0, 4, 'Cooperator', 'Soft Go By Majority', 'CCCC'],
+                             [0, 4, 'Cooperator', 'Soft Go By Majority', 'CCCC'],
+                             [2, 4, 'Defector', 'Soft Go By Majority', 'DCDD'],
+                             [2, 4, 'Defector', 'Soft Go By Majority', 'DCDD'],
+                             [0, 3, 'Cooperator', 'Grudger', 'CCCC'],
+                             [0, 3, 'Cooperator', 'Grudger', 'CCCC'],
+                             [3, 4, 'Grudger', 'Soft Go By Majority', 'CCCC'],
+                             [3, 4, 'Grudger', 'Soft Go By Majority', 'CCCC'],
+                             [0, 2, 'Cooperator', 'Defector', 'CDCD'],
+                             [0, 2, 'Cooperator', 'Defector', 'CDCD']]
             self.assertEqual(sorted(written_data), sorted(expected_data))
 
     def test_write_to_csv(self):
@@ -480,26 +494,36 @@ class TestTournament(unittest.TestCase):
         tournament._write_to_csv(tmp_file.name)
         with open(tmp_file.name, 'r') as f:
             written_data = [[int(r[0]), int(r[1])] + r[2:] for r in csv.reader(f)]
-            expected_data = [[0, 1, 'Cooperator', 'Tit For Tat', 'CCCC', 'CCCC'],
-                             [1, 2, 'Tit For Tat', 'Defector', 'CDDD', 'CDDD'],
-                             [0, 0, 'Cooperator', 'Cooperator', 'CCCC', 'CCCC'],
-                             [3, 3, 'Grudger', 'Grudger', 'CCCC', 'CCCC'],
-                             [2, 2, 'Defector', 'Defector', 'DDDD', 'DDDD'],
-                             [4, 4, 'Soft Go By Majority', 'Soft Go By Majority',
-                              'CCCC', 'CCCC'],
-                             [1, 4, 'Tit For Tat', 'Soft Go By Majority',
-                              'CCCC', 'CCCC'],
-                             [1, 1, 'Tit For Tat', 'Tit For Tat', 'CCCC', 'CCCC'],
-                             [1, 3, 'Tit For Tat', 'Grudger', 'CCCC', 'CCCC'],
-                             [2, 3, 'Defector', 'Grudger', 'DCDD', 'DCDD'],
-                             [0, 4, 'Cooperator', 'Soft Go By Majority',
-                              'CCCC', 'CCCC'],
-                             [2, 4, 'Defector', 'Soft Go By Majority',
-                              'DCDD', 'DCDD'],
-                             [0, 3, 'Cooperator', 'Grudger', 'CCCC', 'CCCC'],
-                             [3, 4, 'Grudger', 'Soft Go By Majority',
-                              'CCCC', 'CCCC'],
-                             [0, 2, 'Cooperator', 'Defector', 'CDCD', 'CDCD']]
+            expected_data = [[0, 1, 'Cooperator', 'Tit For Tat', 'CCCC'],
+                             [0, 1, 'Cooperator', 'Tit For Tat', 'CCCC'],
+                             [1, 2, 'Tit For Tat', 'Defector', 'CDDD'],
+                             [1, 2, 'Tit For Tat', 'Defector', 'CDDD'],
+                             [0, 0, 'Cooperator', 'Cooperator', 'CCCC'],
+                             [0, 0, 'Cooperator', 'Cooperator', 'CCCC'],
+                             [3, 3, 'Grudger', 'Grudger', 'CCCC'],
+                             [3, 3, 'Grudger', 'Grudger', 'CCCC'],
+                             [2, 2, 'Defector', 'Defector', 'DDDD'],
+                             [2, 2, 'Defector', 'Defector', 'DDDD'],
+                             [4, 4, 'Soft Go By Majority', 'Soft Go By Majority', 'CCCC'],
+                             [4, 4, 'Soft Go By Majority', 'Soft Go By Majority', 'CCCC'],
+                             [1, 4, 'Tit For Tat', 'Soft Go By Majority', 'CCCC'],
+                             [1, 4, 'Tit For Tat', 'Soft Go By Majority', 'CCCC'],
+                             [1, 1, 'Tit For Tat', 'Tit For Tat', 'CCCC'],
+                             [1, 1, 'Tit For Tat', 'Tit For Tat', 'CCCC'],
+                             [1, 3, 'Tit For Tat', 'Grudger', 'CCCC'],
+                             [1, 3, 'Tit For Tat', 'Grudger', 'CCCC'],
+                             [2, 3, 'Defector', 'Grudger', 'DCDD'],
+                             [2, 3, 'Defector', 'Grudger', 'DCDD'],
+                             [0, 4, 'Cooperator', 'Soft Go By Majority', 'CCCC'],
+                             [0, 4, 'Cooperator', 'Soft Go By Majority', 'CCCC'],
+                             [2, 4, 'Defector', 'Soft Go By Majority', 'DCDD'],
+                             [2, 4, 'Defector', 'Soft Go By Majority', 'DCDD'],
+                             [0, 3, 'Cooperator', 'Grudger', 'CCCC'],
+                             [0, 3, 'Cooperator', 'Grudger', 'CCCC'],
+                             [3, 4, 'Grudger', 'Soft Go By Majority', 'CCCC'],
+                             [3, 4, 'Grudger', 'Soft Go By Majority', 'CCCC'],
+                             [0, 2, 'Cooperator', 'Defector', 'CDCD'],
+                             [0, 2, 'Cooperator', 'Defector', 'CDCD']]
             self.assertEqual(sorted(written_data), sorted(expected_data))
 
     def test_data_for_csv(self):
@@ -510,26 +534,36 @@ class TestTournament(unittest.TestCase):
             turns=2,
             repetitions=2)
         tournament.play()
-        expected_data = [[0, 1, 'Cooperator', 'Tit For Tat', 'CCCC', 'CCCC'],
-                         [1, 2, 'Tit For Tat', 'Defector', 'CDDD', 'CDDD'],
-                         [0, 0, 'Cooperator', 'Cooperator', 'CCCC', 'CCCC'],
-                         [3, 3, 'Grudger', 'Grudger', 'CCCC', 'CCCC'],
-                         [2, 2, 'Defector', 'Defector', 'DDDD', 'DDDD'],
-                         [4, 4, 'Soft Go By Majority', 'Soft Go By Majority',
-                          'CCCC', 'CCCC'],
-                         [1, 4, 'Tit For Tat', 'Soft Go By Majority',
-                          'CCCC', 'CCCC'],
-                         [1, 1, 'Tit For Tat', 'Tit For Tat', 'CCCC', 'CCCC'],
-                         [1, 3, 'Tit For Tat', 'Grudger', 'CCCC', 'CCCC'],
-                         [2, 3, 'Defector', 'Grudger', 'DCDD', 'DCDD'],
-                         [0, 4, 'Cooperator', 'Soft Go By Majority',
-                          'CCCC', 'CCCC'],
-                         [2, 4, 'Defector', 'Soft Go By Majority',
-                          'DCDD', 'DCDD'],
-                         [0, 3, 'Cooperator', 'Grudger', 'CCCC', 'CCCC'],
-                         [3, 4, 'Grudger', 'Soft Go By Majority',
-                          'CCCC', 'CCCC'],
-                         [0, 2, 'Cooperator', 'Defector', 'CDCD', 'CDCD']]
+        expected_data = [[0, 1, 'Cooperator', 'Tit For Tat', 'CCCC'],
+                         [0, 1, 'Cooperator', 'Tit For Tat', 'CCCC'],
+                         [1, 2, 'Tit For Tat', 'Defector', 'CDDD'],
+                         [1, 2, 'Tit For Tat', 'Defector', 'CDDD'],
+                         [0, 0, 'Cooperator', 'Cooperator', 'CCCC'],
+                         [0, 0, 'Cooperator', 'Cooperator', 'CCCC'],
+                         [3, 3, 'Grudger', 'Grudger', 'CCCC'],
+                         [3, 3, 'Grudger', 'Grudger', 'CCCC'],
+                         [2, 2, 'Defector', 'Defector', 'DDDD'],
+                         [2, 2, 'Defector', 'Defector', 'DDDD'],
+                         [4, 4, 'Soft Go By Majority', 'Soft Go By Majority', 'CCCC'],
+                         [4, 4, 'Soft Go By Majority', 'Soft Go By Majority', 'CCCC'],
+                         [1, 4, 'Tit For Tat', 'Soft Go By Majority', 'CCCC'],
+                         [1, 4, 'Tit For Tat', 'Soft Go By Majority', 'CCCC'],
+                         [1, 1, 'Tit For Tat', 'Tit For Tat', 'CCCC'],
+                         [1, 1, 'Tit For Tat', 'Tit For Tat', 'CCCC'],
+                         [1, 3, 'Tit For Tat', 'Grudger', 'CCCC'],
+                         [1, 3, 'Tit For Tat', 'Grudger', 'CCCC'],
+                         [2, 3, 'Defector', 'Grudger', 'DCDD'],
+                         [2, 3, 'Defector', 'Grudger', 'DCDD'],
+                         [0, 4, 'Cooperator', 'Soft Go By Majority', 'CCCC'],
+                         [0, 4, 'Cooperator', 'Soft Go By Majority', 'CCCC'],
+                         [2, 4, 'Defector', 'Soft Go By Majority', 'DCDD'],
+                         [2, 4, 'Defector', 'Soft Go By Majority', 'DCDD'],
+                         [0, 3, 'Cooperator', 'Grudger', 'CCCC'],
+                         [0, 3, 'Cooperator', 'Grudger', 'CCCC'],
+                         [3, 4, 'Grudger', 'Soft Go By Majority', 'CCCC'],
+                         [3, 4, 'Grudger', 'Soft Go By Majority', 'CCCC'],
+                         [0, 2, 'Cooperator', 'Defector', 'CDCD'],
+                         [0, 2, 'Cooperator', 'Defector', 'CDCD']]
         generator_data = tournament._data_for_csv()
         for row, expected_row in zip(sorted(generator_data), sorted(expected_data)):
             self.assertEqual(row, expected_row)
@@ -614,4 +648,5 @@ class TestProbEndTournament(unittest.TestCase):
         self.assertIsInstance(results, axelrod.ResultSet)
         self.assertEqual(results.nplayers, len(players))
         self.assertEqual(results.players, players)
-        self.assertEqual(len(results.interactions), repetitions)
+        for rep in results.interactions.values():
+            self.assertEqual(len(rep), repetitions)

--- a/docs/tutorials/advanced/reading_and_writing_interactions.rst
+++ b/docs/tutorials/advanced/reading_and_writing_interactions.rst
@@ -13,42 +13,78 @@ a :code:`filename` argument to the :code:`play` method of a tournament::
 This will create a file `basic_tournament.csv` with data that looks something
 like::
 
-    1,2,Anti Tit For Tat,Bully,CDCDCDCD,CDCDCDCD
-    4,7,Defector,Win-Stay Lose-Shift,DCDDDCDD,DCDDDCDD
-    0,0,Alternator,Alternator,CCDDCCDD,CCDDCCDD
-    6,6,Tit For Tat,Tit For Tat,CCCCCCCC,CCCCCCCC
-    4,5,Defector,Suspicious Tit For Tat,DDDDDDDD,DDDDDDDD
-    2,2,Bully,Bully,DDCCDDCC,DDCCDDCC
-    2,7,Bully,Win-Stay Lose-Shift,DCDDCCDC,DCDDCCDC
-    0,7,Alternator,Win-Stay Lose-Shift,CCDCCDDD,CCDCCDDD
-    4,6,Defector,Tit For Tat,DCDDDDDD,DCDDDDDD
-    5,6,Suspicious Tit For Tat,Tit For Tat,DCCDDCCD,DCCDDCCD
-    2,6,Bully,Tit For Tat,DCDDCDCC,DCDDCDCC
-    0,5,Alternator,Suspicious Tit For Tat,CDDCCDDC,CDDCCDDC
-    1,4,Anti Tit For Tat,Defector,CDCDCDCD,CDCDCDCD
-    3,7,Cooperator,Win-Stay Lose-Shift,CCCCCCCC,CCCCCCCC
-    0,4,Alternator,Defector,CDDDCDDD,CDDDCDDD
-    2,5,Bully,Suspicious Tit For Tat,DDCDCCDC,DDCDCCDC
-    5,7,Suspicious Tit For Tat,Win-Stay Lose-Shift,DCCDDDDC,DCCDDDDC
-    0,3,Alternator,Cooperator,CCDCCCDC,CCDCCCDC
-    3,5,Cooperator,Suspicious Tit For Tat,CDCCCCCC,CDCCCCCC
-    0,1,Alternator,Anti Tit For Tat,CCDDCCDD,CCDDCCDD
-    7,7,Win-Stay Lose-Shift,Win-Stay Lose-Shift,CCCCCCCC,CCCCCCCC
-    0,2,Alternator,Bully,CDDDCCDD,CDDDCCDD
-    3,3,Cooperator,Cooperator,CCCCCCCC,CCCCCCCC
-    6,7,Tit For Tat,Win-Stay Lose-Shift,CCCCCCCC,CCCCCCCC
-    0,6,Alternator,Tit For Tat,CCDCCDDC,CCDCCDDC
-    5,5,Suspicious Tit For Tat,Suspicious Tit For Tat,DDDDDDDD,DDDDDDDD
-    4,4,Defector,Defector,DDDDDDDD,DDDDDDDD
-    1,6,Anti Tit For Tat,Tit For Tat,CCDCDDCD,CCDCDDCD
-    1,1,Anti Tit For Tat,Anti Tit For Tat,CCDDCCDD,CCDDCCDD
-    1,5,Anti Tit For Tat,Suspicious Tit For Tat,CDCCDCDD,CDCCDCDD
-    3,6,Cooperator,Tit For Tat,CCCCCCCC,CCCCCCCC
-    1,7,Anti Tit For Tat,Win-Stay Lose-Shift,CCDCDDCC,CCDCDDCC
-    1,3,Anti Tit For Tat,Cooperator,CCDCDCDC,CCDCDCDC
-    2,3,Bully,Cooperator,DCDCDCDC,DCDCDCDC
-    3,4,Cooperator,Defector,CDCDCDCD,CDCDCDCD
-    2,4,Bully,Defector,DDCDCDCD,DDCDCDCD
+    1,2,Anti Tit For Tat,Bully,CDCDCDCD
+    1,2,Anti Tit For Tat,Bully,CDCDCDCD
+    4,7,Defector,Win-Stay Lose-Shift,DCDDDCDD
+    4,7,Defector,Win-Stay Lose-Shift,DCDDDCDD
+    0,0,Alternator,Alternator,CCDDCCDD
+    0,0,Alternator,Alternator,CCDDCCDD
+    6,6,Tit For Tat,Tit For Tat,CCCCCCCC
+    6,6,Tit For Tat,Tit For Tat,CCCCCCCC
+    4,5,Defector,Suspicious Tit For Tat,DDDDDDDD
+    4,5,Defector,Suspicious Tit For Tat,DDDDDDDD
+    2,2,Bully,Bully,DDCCDDCC
+    2,2,Bully,Bully,DDCCDDCC
+    2,7,Bully,Win-Stay Lose-Shift,DCDDCCDC
+    2,7,Bully,Win-Stay Lose-Shift,DCDDCCDC
+    0,7,Alternator,Win-Stay Lose-Shift,CCDCCDDD
+    0,7,Alternator,Win-Stay Lose-Shift,CCDCCDDD
+    4,6,Defector,Tit For Tat,DCDDDDDD
+    4,6,Defector,Tit For Tat,DCDDDDDD
+    5,6,Suspicious Tit For Tat,Tit For Tat,DCCDDCCD
+    5,6,Suspicious Tit For Tat,Tit For Tat,DCCDDCCD
+    2,6,Bully,Tit For Tat,DCDDCDCC
+    2,6,Bully,Tit For Tat,DCDDCDCC
+    0,5,Alternator,Suspicious Tit For Tat,CDDCCDDC
+    0,5,Alternator,Suspicious Tit For Tat,CDDCCDDC
+    1,4,Anti Tit For Tat,Defector,CDCDCDCD
+    1,4,Anti Tit For Tat,Defector,CDCDCDCD
+    3,7,Cooperator,Win-Stay Lose-Shift,CCCCCCCC
+    3,7,Cooperator,Win-Stay Lose-Shift,CCCCCCCC
+    0,4,Alternator,Defector,CDDDCDDD
+    0,4,Alternator,Defector,CDDDCDDD
+    2,5,Bully,Suspicious Tit For Tat,DDCDCCDC
+    2,5,Bully,Suspicious Tit For Tat,DDCDCCDC
+    5,7,Suspicious Tit For Tat,Win-Stay Lose-Shift,DCCDDDDC
+    5,7,Suspicious Tit For Tat,Win-Stay Lose-Shift,DCCDDDDC
+    0,3,Alternator,Cooperator,CCDCCCDC
+    0,3,Alternator,Cooperator,CCDCCCDC
+    3,5,Cooperator,Suspicious Tit For Tat,CDCCCCCC
+    3,5,Cooperator,Suspicious Tit For Tat,CDCCCCCC
+    0,1,Alternator,Anti Tit For Tat,CCDDCCDD
+    0,1,Alternator,Anti Tit For Tat,CCDDCCDD
+    7,7,Win-Stay Lose-Shift,Win-Stay Lose-Shift,CCCCCCCC
+    7,7,Win-Stay Lose-Shift,Win-Stay Lose-Shift,CCCCCCCC
+    0,2,Alternator,Bully,CDDDCCDD
+    0,2,Alternator,Bully,CDDDCCDD
+    3,3,Cooperator,Cooperator,CCCCCCCC
+    3,3,Cooperator,Cooperator,CCCCCCCC
+    6,7,Tit For Tat,Win-Stay Lose-Shift,CCCCCCCC
+    6,7,Tit For Tat,Win-Stay Lose-Shift,CCCCCCCC
+    0,6,Alternator,Tit For Tat,CCDCCDDC
+    0,6,Alternator,Tit For Tat,CCDCCDDC
+    5,5,Suspicious Tit For Tat,Suspicious Tit For Tat,DDDDDDDD
+    5,5,Suspicious Tit For Tat,Suspicious Tit For Tat,DDDDDDDD
+    4,4,Defector,Defector,DDDDDDDD
+    4,4,Defector,Defector,DDDDDDDD
+    1,6,Anti Tit For Tat,Tit For Tat,CCDCDDCD
+    1,6,Anti Tit For Tat,Tit For Tat,CCDCDDCD
+    1,1,Anti Tit For Tat,Anti Tit For Tat,CCDDCCDD
+    1,1,Anti Tit For Tat,Anti Tit For Tat,CCDDCCDD
+    1,5,Anti Tit For Tat,Suspicious Tit For Tat,CDCCDCDD
+    1,5,Anti Tit For Tat,Suspicious Tit For Tat,CDCCDCDD
+    3,6,Cooperator,Tit For Tat,CCCCCCCC
+    3,6,Cooperator,Tit For Tat,CCCCCCCC
+    1,7,Anti Tit For Tat,Win-Stay Lose-Shift,CCDCDDCC
+    1,7,Anti Tit For Tat,Win-Stay Lose-Shift,CCDCDDCC
+    1,3,Anti Tit For Tat,Cooperator,CCDCDCDC
+    1,3,Anti Tit For Tat,Cooperator,CCDCDCDC
+    2,3,Bully,Cooperator,DCDCDCDC
+    2,3,Bully,Cooperator,DCDCDCDC
+    3,4,Cooperator,Defector,CDCDCDCD
+    3,4,Cooperator,Defector,CDCDCDCD
+    2,4,Bully,Defector,DDCDCDCD
+    2,4,Bully,Defector,DDCDCDCD
 
 The columns of this file are of the form:
 
@@ -56,7 +92,10 @@ The columns of this file are of the form:
 2. Index of second player
 3. Name of first player
 4. Name of second player
-5. All further columns are interactions written in a compressed format.
+5. Interaction written in a compressed format
+
+Note that depending on the order in which the matches have been played, the rows
+could also be in a different order.
 
 Alternator versus TitForTat has the following interactions: :code:`CCDCCDDC`:
 

--- a/docs/tutorials/getting_started/interactions.rst
+++ b/docs/tutorials/getting_started/interactions.rst
@@ -20,7 +20,7 @@ interactions between the players.
 turn, has a list of Match objects). These can be used to view the history of the
 interactions::
 
-    >>> for index_pair, interaction in tournament.interactions[0].items():
+    >>> for index_pair, interaction in tournament.interactions.items():
     ...     player1 = tournament.players[index_pair[0]]
     ...     player2 = tournament.players[index_pair[1]]
     ...     print('%s vs %s: %s' % (player1, player2, interaction)) # doctest: +SKIP
@@ -40,7 +40,7 @@ a variety of available methods for analysis (more information can be found in
 :ref:`creating_matches`)::
 
     >>> matches = []
-    >>> for index_pair, interaction in tournament.interactions[0].items():
+    >>> for index_pair, interaction in tournament.interactions.items():
     ...     player1 = tournament.players[index_pair[0]]
     ...     player2 = tournament.players[index_pair[1]]
     ...     match = axl.Match([player1, player2], turns=3)


### PR DESCRIPTION
**This is a PR to @marcharper's `parallel` branch for #520**, (although it could actually go in to master too...).

This simplifies the interactions structure and data file format. The interactions become a dictionary mapping `index_tuples` to lists of repetitions of interactions:

```
{(0,1):[[('C', 'D'), ('D', 'C')], [('C', 'D'), ('D', 'C')]], 
 (0,2):[[('C', 'C'), ('D', 'C')], [('C', 'D'), ('D', 'C')]]}
```

This "should" make it easier for you Marc to get the outcomes on a match by match basis (regardless of the order in which they are run). It should also have the tests updated/ready for you too.

HTH