### PR TITLE
Removing the run_axelrod script from setup.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ setup(
     author='Vince Knight, Owen Campbell, Karol Langner, Marc Harper',
     author_email=('axelrod-python@googlegroups.com'),
     packages=['axelrod', 'axelrod.strategies', 'axelrod.tests'],
-    scripts=['run_axelrod'],
     url='http://axelrod.readthedocs.org/',
     license='The MIT License (MIT)',
     description='Reproduce the Axelrod iterated prisoners dilemma tournament',


### PR DESCRIPTION
This was causing rtd to fail:

```
...
ing build/bdist.linux-x86_64/egg/EGG-INFO
installing scripts to build/bdist.linux-x86_64/egg/EGG-INFO/scripts
running install_scripts
running build_scripts
creating build/scripts-2.7
error: file '/home/docs/checkouts/readthedocs.org/user_builds/axelrod/checkouts/latest/run_axelrod' does not exist
Command time: 0s Return: 1
```