### PR TITLE
Creating hypothesis strategies

### DIFF
--- a/axelrod/game.py
+++ b/axelrod/game.py
@@ -30,4 +30,7 @@ class Game(object):
         """
         return self.scores[pair]
 
+    def __repr__(self):
+        return "Axelrod game: (R,P,S,T) = {}".format(self.RPST())
+
 DefaultGame = Game()

--- a/axelrod/tests/property.py
+++ b/axelrod/tests/property.py
@@ -1,0 +1,201 @@
+"""
+A module for creating hypothesis based strategies for property based testing
+"""
+import axelrod
+from hypothesis.strategies import composite, tuples, sampled_from, integers, floats, random_module, lists
+
+
+@composite
+def strategy_lists(draw, strategies=axelrod.strategies, min_size=1,
+                   max_size=len(axelrod.strategies)):
+    """
+    A hypothesis decorator to return a list of strategies
+
+    Parameters
+    ----------
+    min_size : integer
+        The minimum number of strategies to include
+    max_size : integer
+        The maximum number of strategies to include
+    """
+    strategies = draw(lists(sampled_from(strategies), min_size=min_size,
+                            max_size=max_size))
+    return strategies
+
+@composite
+def matches(draw, strategies=axelrod.strategies,
+            min_turns=1, max_turns=200,
+            min_noise=0, max_noise=1):
+    """
+    A hypothesis decorator to return a random match as well as a random seed (to
+    ensure reproducibility when instance of class need the random library).
+
+    Parameters
+    ----------
+    strategies : list
+        The strategies from which to sample the two the players
+    min_turns : integer
+        The minimum number of turns
+    max_turns : integer
+        The maximum number of turns
+    min_noise : float
+        The minimum noise
+    max_noise : float
+        The maximum noise
+
+    Returns
+    -------
+    tuple : a random match as well as a random seed
+    """
+    seed = draw(random_module())
+    strategies = draw(strategy_lists(min_size=2, max_size=2))
+    players = [s() for s in strategies]
+    turns = draw(integers(min_value=min_turns, max_value=max_turns))
+    noise = draw(floats(min_value=min_noise, max_value=max_noise))
+    match = axelrod.Match(players, turns=turns, noise=noise)
+    return match, seed
+
+@composite
+def tournaments(draw, strategies=axelrod.strategies,
+                min_size=1, max_size=10,
+                min_turns=1, max_turns=200,
+                min_noise=0, max_noise=1,
+                min_repetitions=1, max_repetitions=20,
+                max_processes=None):
+    """
+    A hypothesis decorator to return a tournament and a random seed (to ensure
+    reproducibility for strategies that make use of the random module when
+    initiating).
+
+    Parameters
+    ----------
+    min_size : integer
+        The minimum number of strategies to include
+    max_size : integer
+        The maximum number of strategies to include
+    min_turns : integer
+        The minimum number of turns
+    max_turns : integer
+        The maximum number of turns
+    min_noise : float
+        The minimum noise value
+    min_noise : float
+        The maximum noise value
+    min_repetitions : integer
+        The minimum number of repetitions
+    max_repetitions : integer
+        The maximum number of repetitions
+    max_processes : bool
+        Maximum number of processes to use
+    """
+    seed = draw(random_module())
+    strategies = draw(strategy_lists(strategies=strategies,
+                                     min_size=min_size,
+                                     max_size=max_size))
+    players = [s() for s in strategies]
+    turns = draw(integers(min_value=min_turns, max_value=max_turns))
+    repetitions = draw(integers(min_value=min_repetitions,
+                                max_value=max_repetitions))
+    noise = draw(floats(min_value=min_noise, max_value=max_noise))
+
+    if max_processes is not None:
+        processes = draw(integers(min_value=1, max_value=max_processes))
+    else:
+        processes = None
+
+    tournament = axelrod.Tournament(players, turns=turns,
+                                    repetitions=repetitions, noise=noise,
+                                    processes=processes)
+    return tournament, seed
+
+
+@composite
+def prob_end_tournaments(draw, strategies=axelrod.strategies,
+                        min_size=1, max_size=10,
+                        min_prob_end=0, max_prob_end=1,
+                        min_noise=0, max_noise=1,
+                        min_repetitions=1, max_repetitions=20,
+                        max_processes=None):
+    """
+    A hypothesis decorator to return a tournament and a random seed (to ensure
+    reproducibility for strategies that make use of the random module when
+    initiating).
+
+    Parameters
+    ----------
+    min_size : integer
+        The minimum number of strategies to include
+    max_size : integer
+        The maximum number of strategies to include
+    min_prob_end : float
+        The minimum probability of a match ending
+    max_prob_end : float
+        The maximum probability of a match ending
+    min_noise : float
+        The minimum noise value
+    min_noise : float
+        The maximum noise value
+    min_repetitions : integer
+        The minimum number of repetitions
+    max_repetitions : integer
+        The maximum number of repetitions
+    max_processes : bool
+        Maximum number of processes to use
+    """
+    seed = draw(random_module())
+    strategies = draw(strategy_lists(strategies=strategies,
+                                     min_size=min_size,
+                                     max_size=max_size))
+    players = [s() for s in strategies]
+    prob_end = draw(floats(min_value=min_prob_end, max_value=max_prob_end))
+    repetitions = draw(integers(min_value=min_repetitions,
+                                max_value=max_repetitions))
+    noise = draw(floats(min_value=min_noise, max_value=max_noise))
+
+    if max_processes is not None:
+        processes = draw(integers(min_value=1, max_value=max_processes))
+    else:
+        processes = None
+
+    tournament = axelrod.ProbEndTournament(players, prob_end=prob_end,
+                                           repetitions=repetitions, noise=noise,
+                                           processes=processes)
+    return tournament, seed
+
+
+@composite
+def games(draw, prisoners_dilemma=True, max_value=100):
+    """
+    A hypothesis decorator to return a random game.
+
+    Parameters
+    ----------
+    prisoners_dilemma : bool
+        If set not True the R,P,S,T values will be uniformly random. True by
+        default which ensures T > R > P > S and 2R > T + S.
+    max_value : the maximal payoff value
+    """
+
+    if prisoners_dilemma:
+        s_upper_bound = max_value - 4  # Ensures there is enough room
+        s = draw(integers(max_value=s_upper_bound))
+
+        t_lower_bound = s + 3  # Ensures there is enough room
+        t = draw(integers(min_value=t_lower_bound, max_value=max_value))
+
+        r_upper_bound = t - 1
+        r_lower_bound = min(max(int((t + s) / 2), s) + 2, r_upper_bound)
+        r = draw(integers(min_value=r_lower_bound, max_value=r_upper_bound))
+
+        p_lower_bound = s + 1
+        p_upper_bound = r - 1
+        p = draw(integers(min_value=p_lower_bound, max_value=p_upper_bound))
+
+    else:
+        s = draw(integers(max_value=max_value))
+        t = draw(integers(max_value=max_value))
+        r = draw(integers(max_value=max_value))
+        p = draw(integers(max_value=max_value))
+
+    game = axelrod.Game(r=r, s=s, t=t, p=p)
+    return game

--- a/axelrod/tests/unit/test_game.py
+++ b/axelrod/tests/unit/test_game.py
@@ -2,6 +2,8 @@ import unittest
 from hypothesis import given
 from hypothesis.strategies import integers, tuples
 
+from axelrod.tests.property import *
+
 import axelrod
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
@@ -50,3 +52,8 @@ class TestGame(unittest.TestCase):
         self.assertEqual(game.score((D, D)), (p, p))
         self.assertEqual(game.score((C, D)), (s, t))
         self.assertEqual(game.score((D, C)), (t, s))
+
+    @given(game=games())
+    def test_repr(self, game):
+        expected_repr = "Axelrod game: (R,P,S,T) = {}".format(game.RPST())
+        self.assertEqual(expected_repr, str(game))

--- a/axelrod/tests/unit/test_match.py
+++ b/axelrod/tests/unit/test_match.py
@@ -7,16 +7,18 @@ from axelrod.deterministic_cache import DeterministicCache
 from hypothesis import given, example
 from hypothesis.strategies import integers, floats, random_module, assume
 
+from axelrod.tests.property import games
+
 C, D = Actions.C, Actions.D
 
 
 class TestMatch(unittest.TestCase):
 
-    @given(turns=integers(min_value=1, max_value=200))
-    @example(turns=5)
-    def test_init(self, turns):
+    @given(turns=integers(min_value=1, max_value=200), game=games())
+    @example(turns=5, game=axelrod.DefaultGame)
+    def test_init(self, turns, game):
         p1, p2 = axelrod.Cooperator(), axelrod.Cooperator()
-        match = axelrod.Match((p1, p2), turns)
+        match = axelrod.Match((p1, p2), turns, game=game)
         self.assertEqual(match.result, [])
         self.assertEqual(match.players, [p1, p2])
         self.assertEqual(
@@ -28,6 +30,7 @@ class TestMatch(unittest.TestCase):
         self.assertEqual(match.turns, turns)
         self.assertEqual(match._cache, {})
         self.assertEqual(match.noise, 0)
+        self.assertEqual(match.game.RPST(), game.RPST())
 
     @given(turns=integers(min_value=1, max_value=200))
     @example(turns=5)

--- a/axelrod/tests/unit/test_moran.py
+++ b/axelrod/tests/unit/test_moran.py
@@ -7,7 +7,9 @@ from axelrod import MoranProcess
 from axelrod.moran import fitness_proportionate_selection
 
 from hypothesis import given, example, settings
-from hypothesis.strategies import integers, lists, sampled_from, random_module, floats
+from hypothesis.strategies import random_module
+
+from axelrod.tests.property import strategy_lists
 
 
 class TestMoranProcess(unittest.TestCase):
@@ -67,9 +69,7 @@ class TestMoranProcess(unittest.TestCase):
         self.assertEqual(populations, mp.populations)
         self.assertEqual(mp.winning_strategy_name, str(axelrod.Defector()))
 
-    @given(strategies=lists(sampled_from(axelrod.strategies),
-                   min_size=2,  # Errors are returned if less than 2 strategies
-                   max_size=5, unique=True),
+    @given(strategies=strategy_lists(min_size=2, max_size=5),
            rm=random_module())
     @settings(max_examples=5, timeout=0)  # Very low number of examples
 

--- a/axelrod/tests/unit/test_property.py
+++ b/axelrod/tests/unit/test_property.py
@@ -1,0 +1,202 @@
+from __future__ import absolute_import
+import unittest
+import axelrod
+from axelrod.tests.property import (strategy_lists,
+                                    matches, tournaments,
+                                    prob_end_tournaments, games)
+
+from hypothesis import given
+from hypothesis.strategies import random_module
+
+stochastic_strategies = [s for s in axelrod.strategies if
+                         s().classifier['stochastic']]
+
+
+class TestStrategyList(unittest.TestCase):
+
+    def test_call(self):
+        strategies = strategy_lists().example()
+        self.assertIsInstance(strategies, list)
+        for p in strategies:
+            self.assertIsInstance(p(), axelrod.Player)
+
+    @given(strategies=strategy_lists(min_size=1, max_size=50),
+           rm=random_module())
+    def test_decorator(self, strategies, rm):
+        self.assertIsInstance(strategies, list)
+        self.assertGreaterEqual(len(strategies), 1)
+        self.assertLessEqual(len(strategies), 50)
+        for strategy in strategies:
+            self.assertIsInstance(strategy(), axelrod.Player)
+
+    @given(strategies=strategy_lists(strategies=axelrod.basic_strategies),
+           rm=random_module())
+    def test_decorator_with_given_strategies(self, strategies, rm):
+        self.assertIsInstance(strategies, list)
+        basic_player_names = [str(s()) for s in axelrod.basic_strategies]
+        for strategy in strategies:
+            player = strategy()
+            self.assertIsInstance(player, axelrod.Player)
+            self.assertIn(str(player), basic_player_names)
+
+    @given(strategies=strategy_lists(strategies=stochastic_strategies),
+           rm=random_module())
+    def test_decorator_with_stochastic_strategies(self, strategies, rm):
+        self.assertIsInstance(strategies, list)
+        stochastic_player_names = [str(s()) for s in stochastic_strategies]
+        for strategy in strategies:
+            player = strategy()
+            self.assertIsInstance(player, axelrod.Player)
+            self.assertIn(str(player), stochastic_player_names)
+
+
+class TestMatch(unittest.TestCase):
+    """
+    Test that the composite method works
+    """
+
+    def test_call(self):
+        match, seed = matches().example()
+        self.assertTrue(str(seed).startswith('random.seed'))
+        self.assertIsInstance(match, axelrod.Match)
+
+    @given(match_and_seed=matches(min_turns=10, max_turns=50,
+                                  min_noise=0, max_noise=1))
+    def test_decorator(self, match_and_seed):
+        match, seed = match_and_seed
+        self.assertTrue(str(seed).startswith('random.seed'))
+
+        self.assertIsInstance(match, axelrod.Match)
+        self.assertGreaterEqual(len(match), 10)
+        self.assertLessEqual(len(match), 50)
+        self.assertGreaterEqual(match.noise, 0)
+        self.assertLessEqual(match.noise, 1)
+
+    @given(match_and_seed=matches(min_turns=10, max_turns=50,
+                                  min_noise=0, max_noise=0))
+    def test_decorator_with_no_noise(self, match_and_seed):
+        match, seed = match_and_seed
+        self.assertTrue(str(seed).startswith('random.seed'))
+
+        self.assertIsInstance(match, axelrod.Match)
+        self.assertGreaterEqual(len(match), 10)
+        self.assertLessEqual(len(match), 50)
+        self.assertEqual(match.noise, 0)
+
+
+class TestTournament(unittest.TestCase):
+
+    def test_call(self):
+        tournament, seed = tournaments().example()
+        self.assertTrue(str(seed).startswith('random.seed'))
+        self.assertIsInstance(tournament, axelrod.Tournament)
+
+    @given(tournament_and_seed=tournaments(min_turns=2, max_turns=50, min_noise=0,
+                                           max_noise=1, min_repetitions=2,
+                                           max_repetitions=50))
+    def test_decorator(self, tournament_and_seed):
+        tournament, seed = tournament_and_seed
+        self.assertTrue(str(seed).startswith('random.seed'))
+
+        self.assertIsInstance(tournament, axelrod.Tournament)
+        self.assertLessEqual(tournament.turns, 50)
+        self.assertGreaterEqual(tournament.turns, 2)
+        self.assertLessEqual(tournament.noise, 1)
+        self.assertGreaterEqual(tournament.noise, 0)
+        self.assertLessEqual(tournament.repetitions, 50)
+        self.assertGreaterEqual(tournament.repetitions, 2)
+        self.assertIsNone(tournament._processes)
+
+    @given(tournament_and_seed=tournaments(strategies=axelrod.basic_strategies))
+    def test_decorator_with_given_strategies(self, tournament_and_seed):
+        tournament, seed = tournament_and_seed
+        self.assertTrue(str(seed).startswith('random.seed'))
+
+        self.assertIsInstance(tournament, axelrod.Tournament)
+        basic_player_names = [str(s()) for s in axelrod.basic_strategies]
+        for p in tournament.players:
+            self.assertIn(str(p), basic_player_names)
+
+    @given(tournament_and_seed=tournaments(strategies=stochastic_strategies))
+    def test_decorator_with_stochastic_strategies(self, tournament_and_seed):
+        tournament, seed = tournament_and_seed
+        self.assertTrue(str(seed).startswith('random.seed'))
+
+        self.assertIsInstance(tournament, axelrod.Tournament)
+        stochastic_player_names = [str(s()) for s in stochastic_strategies]
+        for p in tournament.players:
+            self.assertIn(str(p), stochastic_player_names)
+
+    @given(tournament_and_seed=tournaments(max_processes=2))
+    def test_decorator_with_stochastic_strategies(self, tournament_and_seed):
+        tournament, seed = tournament_and_seed
+        self.assertGreaterEqual(tournament._processes, 1)
+        self.assertLessEqual(tournament._processes, 2)
+
+
+class TestProbEndTournament(unittest.TestCase):
+
+    def test_call(self):
+        tournament, seed = prob_end_tournaments().example()
+        self.assertTrue(str(seed).startswith('random.seed'))
+        self.assertIsInstance(tournament, axelrod.Tournament)
+
+    @given(tournament_and_seed=prob_end_tournaments(min_prob_end=0,
+                                                    max_prob_end=1,
+                                                    min_noise=0, max_noise=1,
+                                                    min_repetitions=2,
+                                                    max_repetitions=50))
+    def test_decorator(self, tournament_and_seed):
+        tournament, seed = tournament_and_seed
+        self.assertTrue(str(seed).startswith('random.seed'))
+
+        self.assertIsInstance(tournament, axelrod.ProbEndTournament)
+        self.assertLessEqual(tournament.prob_end, 1)
+        self.assertGreaterEqual(tournament.prob_end, 0)
+        self.assertLessEqual(tournament.noise, 1)
+        self.assertGreaterEqual(tournament.noise, 0)
+        self.assertLessEqual(tournament.repetitions, 50)
+        self.assertGreaterEqual(tournament.repetitions, 2)
+        self.assertIsNone(tournament._processes)
+
+    @given(tournament_and_seed=prob_end_tournaments(strategies=axelrod.basic_strategies))
+    def test_decorator_with_given_strategies(self, tournament_and_seed):
+        tournament, seed = tournament_and_seed
+        self.assertTrue(str(seed).startswith('random.seed'))
+
+        self.assertIsInstance(tournament, axelrod.ProbEndTournament)
+        basic_player_names = [str(s()) for s in axelrod.basic_strategies]
+        for p in tournament.players:
+            self.assertIn(str(p), basic_player_names)
+
+    @given(tournament_and_seed=prob_end_tournaments(strategies=stochastic_strategies))
+    def test_decorator_with_stochastic_strategies(self, tournament_and_seed):
+        tournament, seed = tournament_and_seed
+        self.assertTrue(str(seed).startswith('random.seed'))
+
+        self.assertIsInstance(tournament, axelrod.ProbEndTournament)
+        stochastic_player_names = [str(s()) for s in stochastic_strategies]
+        for p in tournament.players:
+            self.assertIn(str(p), stochastic_player_names)
+
+    @given(tournament_and_seed=prob_end_tournaments(max_processes=2))
+    def test_decorator_with_stochastic_strategies(self, tournament_and_seed):
+        tournament, seed = tournament_and_seed
+        self.assertGreaterEqual(tournament._processes, 1)
+        self.assertLessEqual(tournament._processes, 2)
+
+class TestGame(unittest.TestCase):
+
+    def test_call(self):
+        game = games().example()
+        self.assertIsInstance(game, axelrod.Game)
+
+    @given(game=games())
+    def test_decorator(self, game):
+        self.assertIsInstance(game, axelrod.Game)
+        r, p, s, t = game.RPST()
+        self.assertTrue((2 * r) > (t + s) and (t > r > p > s))
+
+    @given(game=games(prisoners_dilemma=False))
+    def test_decorator_unconstrained(self, game):
+        self.assertIsInstance(game, axelrod.Game)

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -10,6 +10,7 @@ import warnings
 
 from hypothesis import given, example, settings
 from hypothesis.strategies import integers, lists, sampled_from, random_module, floats
+from axelrod.tests.property import tournaments, prob_end_tournaments
 
 import axelrod
 
@@ -191,38 +192,35 @@ class TestTournament(unittest.TestCase):
         results = tournament.play(progress_bar=True)
         self.assertIsInstance(results, axelrod.ResultSet)
 
-    @given(s=lists(sampled_from(axelrod.strategies),
-                   min_size=2,  # Errors are returned if less than 2 strategies
-                   max_size=5, unique=True),
-           turns=integers(min_value=2, max_value=50),
-           repetitions=integers(min_value=2, max_value=4),
-           rm=random_module())
+    @given(tournament_and_seed=tournaments(min_size=2, max_size=5, min_turns=2,
+                                           max_turns=50, min_repetitions=2,
+                                           max_repetitions=4))
     @settings(max_examples=50, timeout=0)
-    @example(s=test_strategies, turns=test_turns, repetitions=test_repetitions,
-             rm=random.seed(0))
+    @example(tournament_and_seed=(axelrod.Tournament(players=[s() for s in
+        test_strategies], turns=test_turns, repetitions=test_repetitions),
+        random.seed(0)))
+
     # These two examples are to make sure #465 is fixed.
     # As explained there: https://github.com/Axelrod-Python/Axelrod/issues/465,
     # these two examples were identified by hypothesis.
-    @example(s=[axelrod.BackStabber, axelrod.MindReader], turns=2, repetitions=1,
-             rm=random.seed(0))
-    @example(s=[axelrod.ThueMorse, axelrod.MindReader], turns=2, repetitions=1,
-             rm=random.seed(0))
-    def test_property_serial_play(self, s, turns, repetitions, rm):
+    @example(tournament_and_seed=(
+        axelrod.Tournament(players=[axelrod.BackStabber(),
+                                    axelrod.MindReader()],
+                           turns=2, repetitions=1),
+        random.seed(0)))
+    @example(tournament_and_seed=(
+        axelrod.Tournament(players=[axelrod.BackStabber(),
+                                    axelrod.ThueMorse()],
+                           turns=2, repetitions=1),
+        random.seed(0)))
+    def test_property_serial_play(self, tournament_and_seed):
         """Test serial play using hypothesis"""
         # Test that we get an instance of ResultSet
-
-        players = [strat() for strat in s]
-
-        tournament = axelrod.Tournament(
-            name=self.test_name,
-            players=players,
-            game=self.game,
-            turns=turns,
-            repetitions=repetitions)
+        tournament, _ = tournament_and_seed  # Discarding the seed
         results = tournament.play(progress_bar=False)
         self.assertIsInstance(results, axelrod.ResultSet)
-        self.assertEqual(results.nplayers, len(players))
-        self.assertEqual(results.players, [str(p) for p in players])
+        self.assertEqual(results.nplayers, len(tournament.players))
+        self.assertEqual(results.players, [str(p) for p in tournament.players])
 
     def test_parallel_play(self):
         # Test that we get an instance of ResultSet
@@ -530,38 +528,37 @@ class TestProbEndTournament(unittest.TestCase):
         anonymous_tournament = axelrod.Tournament(players=self.players)
         self.assertEqual(anonymous_tournament.name, 'axelrod')
 
-    @given(s=lists(sampled_from(axelrod.strategies),
-                   min_size=2,  # Errors are returned if less than 2 strategies
-                   max_size=5, unique=True),
-           prob_end=floats(min_value=.1, max_value=.9),
-           repetitions=integers(min_value=2, max_value=4),
-           rm=random_module())
+    @given(tournament_and_seed=prob_end_tournaments(min_size=2, max_size=5,
+                                                    min_prob_end=.1,
+                                                    max_prob_end=.9,
+                                                    min_repetitions=2,
+                                                    max_repetitions=4))
     @settings(max_examples=50, timeout=0)
-    @example(s=test_strategies, prob_end=.2, repetitions=test_repetitions,
-             rm=random.seed(0))
+    @example(tournament_and_seed=(
+        axelrod.ProbEndTournament(players=[s() for s in test_strategies],
+                                  prob_end=.2, repetitions=test_repetitions),
+        random.seed(0)))
 
     # These two examples are to make sure #465 is fixed.
     # As explained there: https://github.com/Axelrod-Python/Axelrod/issues/465,
     # these two examples were identified by hypothesis.
-    @example(s=[axelrod.BackStabber, axelrod.MindReader], prob_end=.2, repetitions=1,
-             rm=random.seed(0))
-    @example(s=[axelrod.ThueMorse, axelrod.MindReader], prob_end=.2, repetitions=1,
-             rm=random.seed(0))
-    def test_property_serial_play(self, s, prob_end, repetitions, rm):
+    @example(tournament_and_seed=(
+        axelrod.ProbEndTournament(players=[axelrod.BackStabber(),
+                                           axelrod.MindReader()],
+                                  prob_end=.2, repetitions=1),
+        random.seed(0)))
+    @example(tournament_and_seed=(
+        axelrod.ProbEndTournament(players=[axelrod.ThueMorse(),
+                                           axelrod.MindReader()],
+                                  prob_end=.2, repetitions=1),
+        random.seed(0)))
+    def test_property_serial_play(self, tournament_and_seed):
         """Test serial play using hypothesis"""
         # Test that we get an instance of ResultSet
-
-        players = [strat() for strat in s]
-
-        tournament = axelrod.ProbEndTournament(
-            name=self.test_name,
-            players=players,
-            game=self.game,
-            prob_end=prob_end,
-            repetitions=repetitions)
+        tournament, _ = tournament_and_seed
         results = tournament.play(progress_bar=False)
         self.assertIsInstance(results, axelrod.ResultSet)
-        self.assertEqual(results.nplayers, len(players))
-        self.assertEqual(results.players, [str(p) for p in players])
+        self.assertEqual(results.nplayers, len(tournament.players))
+        self.assertEqual(results.players, [str(p) for p in tournament.players])
         for rep in results.interactions.values():
-            self.assertEqual(len(rep), repetitions)
+            self.assertEqual(len(rep), tournament.repetitions)


### PR DESCRIPTION
Closes #570 

This means that instead of having to use a combination of hypothesis calls to build a tournament (for example), we can now just write:

```
@given(tournament_and_seed=@tournaments())
def test_...
```

This make no changes to the library itself.

The seed is because in that particular instance (creating a tournament) some strategy instances will use the random library when they are created so hypothesis will also let us know the random seed it used.

As well as building these things I've written tests for them and also replaced some of the tests. 

The module lives in `axelrod/tests/property.py`. Not sure if that's the best place?