### PR TITLE
Adding classifier that tests classification of class as well as player

### DIFF
--- a/axelrod/strategies/cycler.py
+++ b/axelrod/strategies/cycler.py
@@ -1,5 +1,6 @@
 from axelrod import Actions, Player, init_args
 
+import copy
 
 class AntiCycler(Player):
     """
@@ -74,18 +75,27 @@ class Cycler(Player):
 
 
 class CyclerCCD(Cycler):
+    classifier = copy.copy(Cycler.classifier)
+    classifier['memory_depth'] = 2
+
     @init_args
     def __init__(self, cycle="CCD"):
         Cycler.__init__(self, cycle=cycle)
 
 
 class CyclerCCCD(Cycler):
+    classifier = copy.copy(Cycler.classifier)
+    classifier['memory_depth'] = 3
+
     @init_args
     def __init__(self, cycle="CCCD"):
         Cycler.__init__(self, cycle=cycle)
 
 
 class CyclerCCCCCD(Cycler):
+    classifier = copy.copy(Cycler.classifier)
+    classifier['memory_depth'] = 5
+
     @init_args
     def __init__(self, cycle="CCCCCD"):
         Cycler.__init__(self, cycle=cycle)

--- a/axelrod/strategies/gobymajority.py
+++ b/axelrod/strategies/gobymajority.py
@@ -1,5 +1,7 @@
 from axelrod import Actions, Player, init_args
 
+import copy
+
 C, D = Actions.C, Actions.D
 
 
@@ -77,6 +79,8 @@ class GoByMajority40(GoByMajority):
     """
     GoByMajority player with a memory of 40.
     """
+    classifier = copy.copy(GoByMajority.classifier)
+    classifier['memory_depth'] = 40
 
     @init_args
     def __init__(self, memory_depth=40, soft=True):
@@ -88,6 +92,8 @@ class GoByMajority20(GoByMajority):
     """
     GoByMajority player with a memory of 20.
     """
+    classifier = copy.copy(GoByMajority.classifier)
+    classifier['memory_depth'] = 20
 
     @init_args
     def __init__(self, memory_depth=20, soft=True):
@@ -99,6 +105,8 @@ class GoByMajority10(GoByMajority):
     """
     GoByMajority player with a memory of 10.
     """
+    classifier = copy.copy(GoByMajority.classifier)
+    classifier['memory_depth'] = 10
 
     @init_args
     def __init__(self, memory_depth=10, soft=True):
@@ -110,6 +118,8 @@ class GoByMajority5(GoByMajority):
     """
     GoByMajority player with a memory of 5.
     """
+    classifier = copy.copy(GoByMajority.classifier)
+    classifier['memory_depth'] = 5
 
     @init_args
     def __init__(self, memory_depth=5, soft=True):
@@ -136,6 +146,8 @@ class HardGoByMajority40(HardGoByMajority):
     """
     HardGoByMajority player with a memory of 40.
     """
+    classifier = copy.copy(GoByMajority.classifier)
+    classifier['memory_depth'] = 40
 
     @init_args
     def __init__(self, memory_depth=40, soft=False):
@@ -147,6 +159,8 @@ class HardGoByMajority20(HardGoByMajority):
     """
     HardGoByMajority player with a memory of 20.
     """
+    classifier = copy.copy(GoByMajority.classifier)
+    classifier['memory_depth'] = 20
 
     @init_args
     def __init__(self, memory_depth=20, soft=False):
@@ -158,6 +172,8 @@ class HardGoByMajority10(HardGoByMajority):
     """
     HardGoByMajority player with a memory of 10.
     """
+    classifier = copy.copy(GoByMajority.classifier)
+    classifier['memory_depth'] = 10
 
     @init_args
     def __init__(self, memory_depth=10, soft=False):
@@ -169,6 +185,8 @@ class HardGoByMajority5(HardGoByMajority):
     """
     HardGoByMajority player with a memory of 5.
     """
+    classifier = copy.copy(GoByMajority.classifier)
+    classifier['memory_depth'] = 5
 
     @init_args
     def __init__(self, memory_depth=5, soft=False):

--- a/axelrod/strategies/meta.py
+++ b/axelrod/strategies/meta.py
@@ -289,6 +289,14 @@ class MetaMixer(MetaPlayer):
     """
 
     name = "Meta Mixer"
+    classifier = {
+        'memory_depth': float('inf'),  # Long memory
+        'stochastic': True,
+        'makes_use_of': set(),
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
 
     def __init__(self, team=None, distribution=None):
 

--- a/axelrod/tests/unit/test_gambler.py
+++ b/axelrod/tests/unit/test_gambler.py
@@ -8,6 +8,8 @@ import random
 from .test_player import TestPlayer, TestHeadsUp
 from axelrod import random_choice, Actions
 
+import copy
+
 C, D = axelrod.Actions.C, axelrod.Actions.D
 
 
@@ -24,6 +26,9 @@ class TestGambler(TestPlayer):
         'manipulates_source': False,
         'manipulates_state': False
     }
+
+    expected_class_classifier = copy.copy(expected_classifier)
+    expected_class_classifier['memory_depth'] = float('inf')
 
     def test_init(self):
         # Test empty table

--- a/axelrod/tests/unit/test_gobymajority.py
+++ b/axelrod/tests/unit/test_gobymajority.py
@@ -126,6 +126,15 @@ def factory_TestGoByRecentMajority(L, soft=True):
             name = "Hard Go By Majority: %i" % L
             player = getattr(axelrod, 'HardGoByMajority%i' % L)
 
+            expected_classifier = {
+                'stochastic': False,
+                'memory_depth': L,
+                'makes_use_of': set(),
+                'inspects_source': False,
+                'manipulates_source': False,
+                'manipulates_state': False
+            }
+
             def test_initial_strategy(self):
                 """Starts by defecting."""
                 self.first_play_test(D)

--- a/axelrod/tests/unit/test_lookerup.py
+++ b/axelrod/tests/unit/test_lookerup.py
@@ -4,6 +4,8 @@ import axelrod
 from .test_player import TestPlayer, TestHeadsUp
 from axelrod.strategies.lookerup import create_lookup_table_keys
 
+import copy
+
 C, D = axelrod.Actions.C, axelrod.Actions.D
 
 
@@ -13,13 +15,16 @@ class TestLookerUp(TestPlayer):
     player = axelrod.LookerUp
 
     expected_classifier = {
-        'memory_depth': 1, # Default TFT table
+        'memory_depth': 1,  # Default TfT
         'stochastic': False,
         'makes_use_of': set(),
         'inspects_source': False,
         'manipulates_source': False,
         'manipulates_state': False
     }
+
+    expected_class_classifier = copy.copy(expected_classifier)
+    expected_class_classifier['memory_depth'] = float('inf')
 
     def test_init(self):
         # Test empty table
@@ -111,6 +116,7 @@ class TestLookerUp(TestPlayer):
         self.responses_test([D, D, D], [D, C, C], [D])
         self.responses_test([C, C, C], [D, D, C], [D])
         self.responses_test([C, C, D], [D, D, C], [D])
+
 
 
 class TestEvolvedLookerUp(TestPlayer):

--- a/axelrod/tests/unit/test_meta.py
+++ b/axelrod/tests/unit/test_meta.py
@@ -26,7 +26,7 @@ class TestMetaPlayer(TestPlayer):
         'manipulates_state': False
     }
 
-    def classifier_test(self):
+    def classifier_test(self, expected_class_classifier=None):
         player = self.player()
         classifier = dict()
         for key in ['stochastic',
@@ -46,6 +46,12 @@ class TestMetaPlayer(TestPlayer):
                              classifier[key],
                              msg="%s - Behaviour: %s != Expected Behaviour: %s" %
                              (key, player.classifier[key], classifier[key]))
+
+        # Test that player has same classifier as it's class unless otherwise
+        # specified
+        if expected_class_classifier is None:
+            expected_class_classifier = player.classifier
+        self.assertEqual(expected_class_classifier, self.player.classifier)
 
     def test_reset(self):
         p1 = self.player()

--- a/axelrod/tests/unit/test_meta.py
+++ b/axelrod/tests/unit/test_meta.py
@@ -3,7 +3,7 @@
 import random
 
 import axelrod
-import unittest
+import copy
 
 from .test_player import TestPlayer
 
@@ -76,6 +76,10 @@ class TestMetaMajority(TestMetaPlayer):
         'manipulates_state': False
     }
 
+    expected_class_classifier = copy.copy(expected_classifier)
+    expected_class_classifier['stochastic'] = False
+    expected_class_classifier['makes_use_of'] = set([])
+
     def test_strategy(self):
 
         P1 = axelrod.MetaMajority()
@@ -101,6 +105,10 @@ class TestMetaMinority(TestMetaPlayer):
         'manipulates_source': False,
         'manipulates_state': False
     }
+
+    expected_class_classifier = copy.copy(expected_classifier)
+    expected_class_classifier['stochastic'] = False
+    expected_class_classifier['makes_use_of'] = set([])
 
     def test_team(self):
         team = [axelrod.Cooperator]
@@ -132,6 +140,10 @@ class TestMetaWinner(TestMetaPlayer):
         'manipulates_source': False,
         'manipulates_state': False
     }
+
+    expected_class_classifier = copy.copy(expected_classifier)
+    expected_class_classifier['stochastic'] = False
+    expected_class_classifier['makes_use_of'] = set([])
 
     def test_strategy(self):
 
@@ -212,6 +224,10 @@ class TestMetaMajorityMemoryOne(TestMetaPlayer):
         'manipulates_state': False
     }
 
+    expected_class_classifier = copy.copy(expected_classifier)
+    expected_class_classifier['stochastic'] = False
+    expected_class_classifier['makes_use_of'] = set([])
+
     def test_strategy(self):
         self.first_play_test(C)
 
@@ -228,6 +244,10 @@ class TestMetaWinnerMemoryOne(TestMetaPlayer):
         'manipulates_state': False
     }
 
+    expected_class_classifier = copy.copy(expected_classifier)
+    expected_class_classifier['stochastic'] = False
+    expected_class_classifier['makes_use_of'] = set([])
+
     def test_strategy(self):
         self.first_play_test(C)
 
@@ -242,6 +262,11 @@ class TestMetaMajorityFiniteMemory(TestMetaPlayer):
         'manipulates_source': False,
         'manipulates_state': False
     }
+
+    expected_class_classifier = copy.copy(expected_classifier)
+    expected_class_classifier['stochastic'] = False
+    expected_class_classifier['makes_use_of'] = set([])
+
 
     def test_strategy(self):
         self.first_play_test(C)
@@ -258,6 +283,11 @@ class TestMetaWinnerFiniteMemory(TestMetaPlayer):
         'manipulates_state': False
     }
 
+    expected_class_classifier = copy.copy(expected_classifier)
+    expected_class_classifier['stochastic'] = False
+    expected_class_classifier['makes_use_of'] = set([])
+
+
     def test_strategy(self):
         self.first_play_test(C)
 
@@ -273,6 +303,11 @@ class TestMetaMajorityLongMemory(TestMetaPlayer):
         'manipulates_state': False
     }
 
+    expected_class_classifier = copy.copy(expected_classifier)
+    expected_class_classifier['stochastic'] = False
+    expected_class_classifier['makes_use_of'] = set([])
+
+
     def test_strategy(self):
         self.first_play_test(C)
 
@@ -287,6 +322,10 @@ class TestMetaWinnerLongMemory(TestMetaPlayer):
         'manipulates_source': False,
         'manipulates_state': False
     }
+
+    expected_class_classifier = copy.copy(expected_classifier)
+    expected_class_classifier['stochastic'] = False
+    expected_class_classifier['makes_use_of'] = set([])
 
     def test_strategy(self):
         self.first_play_test(C)

--- a/axelrod/tests/unit/test_meta.py
+++ b/axelrod/tests/unit/test_meta.py
@@ -343,6 +343,9 @@ class TestMetaMixer(TestMetaPlayer):
         'manipulates_state': False
     }
 
+    expected_class_classifier = copy.copy(expected_classifier)
+    expected_class_classifier['makes_use_of'] = set()
+
     def test_strategy(self):
 
         team = [axelrod.TitForTat, axelrod.Cooperator, axelrod.Grudger]

--- a/axelrod/tests/unit/test_player.py
+++ b/axelrod/tests/unit/test_player.py
@@ -116,6 +116,7 @@ class TestOpponent(Player):
 class TestPlayer(unittest.TestCase):
     "A Test class from which other player test classes are inherited"
     player = TestOpponent
+    expected_class_classifier = None
 
     def test_initialisation(self):
         """Test that the player initiates correctly."""
@@ -126,7 +127,7 @@ class TestPlayer(unittest.TestCase):
                     {'length': -1, 'game': DefaultGame, 'noise': 0})
             self.assertEqual(player.cooperations, 0)
             self.assertEqual(player.defections, 0)
-            self.classifier_test()
+            self.classifier_test(self.expected_class_classifier)
 
     def test_repr(self):
         """Test that the representation is correct."""
@@ -237,12 +238,19 @@ class TestPlayer(unittest.TestCase):
             random_seed=random_seed, attrs=attrs)
 
 
-    def classifier_test(self):
+    def classifier_test(self, expected_class_classifier=None):
         """Test that the keys in the expected_classifier dictionary give the
         expected values in the player classifier dictionary. Also checks that
         two particular keys (memory_depth and stochastic) are in the
         dictionary."""
         player = self.player()
+
+        # Test that player has same classifier as it's class unless otherwise
+        # specified
+        if expected_class_classifier is None:
+            expected_class_classifier = player.classifier
+        self.assertEqual(expected_class_classifier, self.player.classifier)
+
         self.assertTrue('memory_depth' in player.classifier,
                         msg="memory_depth not in classifier")
         self.assertTrue('stochastic' in player.classifier,


### PR DESCRIPTION
Closes #512 

EDIT: The main thing this does is add a test testing not only the instance classifier but also the class itself.

By default it assumes the class and instance have the same classification however I've added the ability to add to the test player a `expected_class_classifier` that can be different.

It would be worth checking that for some of the classes I've done that in a satisfactory way: I've kept the commits relatively tidy so it should be easy enough to check through those but let me know if not.