### PR TITLE
Make results set not build for full tournament in the integration test.

### DIFF
--- a/axelrod/tests/integration/test_tournament.py
+++ b/axelrod/tests/integration/test_tournament.py
@@ -1,6 +1,6 @@
 import unittest
-import os
 import axelrod
+import warnings
 
 
 class TestTournament(unittest.TestCase):
@@ -32,7 +32,9 @@ class TestTournament(unittest.TestCase):
         tournament = axelrod.Tournament(name='test', players=strategies,
                                         game=self.game, turns=2,
                                         repetitions=2)
-        results = tournament.play(progress_bar=False, build_results=False)
+        with warnings.catch_warnings(record=True) as w:
+            results = tournament.play(progress_bar=False, build_results=False)
+            self.assertEqual(len(w), 1)
         self.assertIsNone(results)
 
     def test_serial_play(self):

--- a/axelrod/tests/integration/test_tournament.py
+++ b/axelrod/tests/integration/test_tournament.py
@@ -29,9 +29,11 @@ class TestTournament(unittest.TestCase):
     def test_full_tournament(self):
         """A test to check that tournament runs with all non cheating strategies."""
         strategies = [strategy() for strategy in axelrod.ordinary_strategies]
-        tournament = axelrod.Tournament(name='test', players=strategies, game=self.game, turns=20, repetitions=2)
-        results = tournament.play(progress_bar=False)
-        self.assertIsInstance(results, axelrod.ResultSet)
+        tournament = axelrod.Tournament(name='test', players=strategies,
+                                        game=self.game, turns=2,
+                                        repetitions=2)
+        results = tournament.play(progress_bar=False, build_results=False)
+        self.assertIsNone(results)
 
     def test_serial_play(self):
         tournament = axelrod.Tournament(

--- a/axelrod/tests/integration/test_tournament.py
+++ b/axelrod/tests/integration/test_tournament.py
@@ -1,6 +1,6 @@
 import unittest
 import axelrod
-import warnings
+import tempfile
 
 
 class TestTournament(unittest.TestCase):
@@ -32,10 +32,10 @@ class TestTournament(unittest.TestCase):
         tournament = axelrod.Tournament(name='test', players=strategies,
                                         game=self.game, turns=2,
                                         repetitions=2)
-        with warnings.catch_warnings(record=True) as w:
-            results = tournament.play(progress_bar=False, build_results=False)
-            self.assertEqual(len(w), 1)
-        self.assertIsNone(results)
+        tmp_file = tempfile.NamedTemporaryFile()
+        self.assertIsNone(tournament.play(progress_bar=False,
+                                          filename=tmp_file.name,
+                                          build_results=False))
 
     def test_serial_play(self):
         tournament = axelrod.Tournament(

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -79,7 +79,6 @@ class TestTournament(unittest.TestCase):
         self.assertEqual(anonymous_tournament.name, 'axelrod')
 
     def test_warning(self):
-        # Test that we get an instance of ResultSet
         tournament = axelrod.Tournament(
             name=self.test_name,
             players=self.players,
@@ -93,8 +92,8 @@ class TestTournament(unittest.TestCase):
             self.assertEqual(len(w), 1)
 
         with warnings.catch_warnings(record=True) as w:
-            # Check that no warning is raised if no results set is built and no
-            # filename given
+            # Check that no warning is raised if no results set is built and a
+            # is filename given
             tmp_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
             results = tournament.play(build_results=False,
                                       filename=tmp_file.name, progress_bar=False)


### PR DESCRIPTION
This was causing travis to timeout on py2 (it was also hanging on py2 for my own machine).

Have reduced the size of things as well: less turns. This test just needs to check that everything runs, everything else is well tested elsewhere.