### PR TITLE
Add back in noise parameter to tournament

### DIFF
--- a/axelrod/tests/integration/test_tournament.py
+++ b/axelrod/tests/integration/test_tournament.py
@@ -54,3 +54,20 @@ class TestTournament(unittest.TestCase):
         scores = tournament.play(processes=2, progress_bar=False).scores
         actual_outcome = sorted(zip(self.player_names, scores))
         self.assertEqual(actual_outcome, self.expected_outcome)
+
+
+class TestNoisyTournament(unittest.TestCase):
+    def test_noisy_tournament(self):
+        # Defector should win for low noise
+        players = [axelrod.Cooperator(), axelrod.Defector()]
+        tournament = axelrod.Tournament(players, turns=20, repetitions=10,
+                                        with_morality=False, noise=0.)
+        results = tournament.play()
+        self.assertEqual(results.ranked_names[0], "Defector")
+
+        # If the noise is large enough, cooperator should win
+        players = [axelrod.Cooperator(), axelrod.Defector()]
+        tournament = axelrod.Tournament(players, turns=20, repetitions=10,
+                                        with_morality=False, noise=0.75)
+        results = tournament.play()
+        self.assertEqual(results.ranked_names[0], "Cooperator")

--- a/axelrod/tournament.py
+++ b/axelrod/tournament.py
@@ -126,7 +126,7 @@ class Tournament(object):
         progress_bar : bool
             Whether or not to update the tournament progress bar
         """
-        chunks = self.match_generator.build_match_chunks()
+        chunks = self.match_generator.build_match_chunks(noise=self.noise)
 
         for chunk in chunks:
             results = self._play_matches(chunk)
@@ -167,7 +167,7 @@ class Tournament(object):
         done_queue = Queue()
         workers = self._n_workers(processes=processes)
 
-        chunks = self.match_generator.build_match_chunks()
+        chunks = self.match_generator.build_match_chunks(noise=self.noise)
         for chunk in chunks:
             work_queue.put(chunk)
 


### PR DESCRIPTION
We lost the pass through of the noise parameter when tournament was refactored.