### PR TITLE
Test: players do not know length in prob end

### DIFF
--- a/axelrod/tests/integration/test_sample_tournaments.py
+++ b/axelrod/tests/integration/test_sample_tournaments.py
@@ -21,7 +21,7 @@ class TestSampleTournaments(unittest.TestCase):
         # Play the tournament and build the actual outcome tuples.
         tournament = axelrod.Tournament(
             players=players, game=cls.game, turns=turns, repetitions=1)
-        results = tournament.play()
+        results = tournament.play(progress_bar=False)
         scores = [score[0] for score in results.scores]
         outcome = zip(names, scores)
 

--- a/axelrod/tests/integration/test_tournament.py
+++ b/axelrod/tests/integration/test_tournament.py
@@ -2,6 +2,7 @@ import unittest
 import axelrod
 import tempfile
 
+from axelrod.strategy_transformers import FinalTransformer
 
 class TestTournament(unittest.TestCase):
 
@@ -66,12 +67,28 @@ class TestNoisyTournament(unittest.TestCase):
         players = [axelrod.Cooperator(), axelrod.Defector()]
         tournament = axelrod.Tournament(players, turns=20, repetitions=10,
                                         with_morality=False, noise=0.)
-        results = tournament.play()
+        results = tournament.play(progress_bar=False)
         self.assertEqual(results.ranked_names[0], "Defector")
 
         # If the noise is large enough, cooperator should win
         players = [axelrod.Cooperator(), axelrod.Defector()]
         tournament = axelrod.Tournament(players, turns=20, repetitions=10,
                                         with_morality=False, noise=0.75)
-        results = tournament.play()
+        results = tournament.play(progress_bar=False)
         self.assertEqual(results.ranked_names[0], "Cooperator")
+
+
+class TestProbEndTournament(unittest.TestCase):
+    def test_players_do_not_know_match_length(self):
+        """Create two players who should cooperate on last two turns if they
+        know when those last two turns are.
+        """
+        p1 = FinalTransformer(['D', 'D'])(axelrod.Cooperator)()
+        p2 = FinalTransformer(['D', 'D'])(axelrod.Cooperator)()
+        players = [p1, p2]
+        tournament = axelrod.ProbEndTournament(players, prob_end=.1,
+                                               repetitions=1)
+        results = tournament.play(progress_bar=False)
+        # Check that both plays always cooperated
+        for rating in results.cooperating_rating:
+            self.assertEqual(rating, 1)

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -11,6 +11,7 @@ import warnings
 from hypothesis import given, example, settings
 from hypothesis.strategies import integers
 from axelrod.tests.property import tournaments, prob_end_tournaments
+from axelrod.strategy_transformers import FinalTransformer
 
 import axelrod
 
@@ -551,3 +552,17 @@ class TestProbEndTournament(unittest.TestCase):
         self.assertEqual(results.players, [str(p) for p in tournament.players])
         for rep in results.interactions.values():
             self.assertEqual(len(rep), tournament.repetitions)
+
+    def test_players_do_not_know_match_length(self):
+        """Create two players who should cooperate on last to turns if they
+        know when those last two turns are.
+        """
+        p1 = FinalTransformer(['D', 'D'])(axelrod.Cooperator)()
+        p2 = FinalTransformer(['D', 'D'])(axelrod.Cooperator)()
+        players = [p1, p2]
+        tournament = axelrod.ProbEndTournament(players, prob_end=.1,
+                                               repetitions=1)
+        results = tournament.play()
+        # Check that both plays always cooperated
+        for rating in results.cooperating_rating:
+            self.assertEqual(rating, 1)

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -554,7 +554,7 @@ class TestProbEndTournament(unittest.TestCase):
             self.assertEqual(len(rep), tournament.repetitions)
 
     def test_players_do_not_know_match_length(self):
-        """Create two players who should cooperate on last to turns if they
+        """Create two players who should cooperate on last two turns if they
         know when those last two turns are.
         """
         p1 = FinalTransformer(['D', 'D'])(axelrod.Cooperator)()

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -11,7 +11,6 @@ import warnings
 from hypothesis import given, example, settings
 from hypothesis.strategies import integers
 from axelrod.tests.property import tournaments, prob_end_tournaments
-from axelrod.strategy_transformers import FinalTransformer
 
 import axelrod
 
@@ -552,17 +551,3 @@ class TestProbEndTournament(unittest.TestCase):
         self.assertEqual(results.players, [str(p) for p in tournament.players])
         for rep in results.interactions.values():
             self.assertEqual(len(rep), tournament.repetitions)
-
-    def test_players_do_not_know_match_length(self):
-        """Create two players who should cooperate on last two turns if they
-        know when those last two turns are.
-        """
-        p1 = FinalTransformer(['D', 'D'])(axelrod.Cooperator)()
-        p2 = FinalTransformer(['D', 'D'])(axelrod.Cooperator)()
-        players = [p1, p2]
-        tournament = axelrod.ProbEndTournament(players, prob_end=.1,
-                                               repetitions=1)
-        results = tournament.play()
-        # Check that both plays always cooperated
-        for rating in results.cooperating_rating:
-            self.assertEqual(rating, 1)


### PR DESCRIPTION
Just to check that the expected behaviour has kicked in. A cooperation
rating of 1 implies that they never defected as expected.