### PR TITLE
Adding a progress bar to reading data.

### DIFF
--- a/axelrod/result_set.py
+++ b/axelrod/result_set.py
@@ -771,8 +771,8 @@ class ResultSetFromFile(ResultSet):
             if not num_interactions:
                 # If number of interactions is not known:
                 num_interactions = sum(1 for line in open(filename))
-            progress_bar = tqdm.tqdm(total=num_interactions,
-                                     desc="Reading interactions")
+            self.read_progress_bar = tqdm.tqdm(total=num_interactions,
+                                               desc="Reading interactions")
 
         interactions = defaultdict(list)
         players_d = {}
@@ -789,10 +789,10 @@ class ResultSetFromFile(ResultSet):
                     if index not in players:
                         players_d[index] = player
                 if progress_bar:
-                    progress_bar.update()
+                    self.read_progress_bar.update()
 
         if progress_bar:
-            progress_bar.close()
+            self.read_progress_bar.close()
 
         # Create an ordered list of players
         players = []

--- a/axelrod/result_set.py
+++ b/axelrod/result_set.py
@@ -736,7 +736,7 @@ class ResultSetFromFile(ResultSet):
         self.build_all()
 
     def _read_csv(self, filename, progress_bar=False,
-                  num_interactions=False):
+                  num_interactions=None):
         """
         Reads from a csv file of the format:
 

--- a/axelrod/tests/unit/test_resultset.py
+++ b/axelrod/tests/unit/test_resultset.py
@@ -388,6 +388,15 @@ class TestResultSetFromFile(unittest.TestCase):
                                  (1, 1): [[('C', 'C'), ('C', 'C')]]}
         self.assertEqual(rs.interactions, expected_interactions)
 
+    def test_progres_bar(self):
+        rs = axelrod.ResultSetFromFile(self.tmp_file.name, progress_bar=True)
+        self.assertEqual(rs.read_progress_bar.total, 6)
+
+        # Test that can give length
+        rs = axelrod.ResultSetFromFile(self.tmp_file.name, progress_bar=True,
+                                       num_interactions=6)
+        self.assertEqual(rs.read_progress_bar.total, 6)
+
 
 class TestDecorator(unittest.TestCase):
     def test_update_progress_bar(self):

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -119,6 +119,7 @@ class TestTournament(unittest.TestCase):
             repetitions=self.test_repetitions)
         results = tournament.play(progress_bar=False)
         self.assertEqual(len(results.interactions), 15)
+        self.assertEqual(tournament.num_interactions, 150)
 
     def test_no_progress_bar_play(self):
         """Test that progress bar is not created for progress_bar=False"""
@@ -228,6 +229,7 @@ class TestTournament(unittest.TestCase):
             repetitions=self.test_repetitions)
         results = tournament.play(processes=2, progress_bar=False)
         self.assertIsInstance(results, axelrod.ResultSet)
+        self.assertEqual(tournament.num_interactions, 75)
 
         # The following relates to #516
         players = [axelrod.Cooperator(), axelrod.Defector(),

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -119,7 +119,7 @@ class TestTournament(unittest.TestCase):
             repetitions=self.test_repetitions)
         results = tournament.play(progress_bar=False)
         self.assertEqual(len(results.interactions), 15)
-        self.assertEqual(tournament.num_interactions, 150)
+        self.assertEqual(tournament.num_interactions, 75)
 
     def test_no_progress_bar_play(self):
         """Test that progress bar is not created for progress_bar=False"""

--- a/axelrod/tournament.py
+++ b/axelrod/tournament.py
@@ -46,6 +46,7 @@ class Tournament(object):
         self.name = name
         self.turns = turns
         self.noise = noise
+        self.num_interactions = 0
         if game is not None:
             self.game = game
         self.players = players
@@ -67,7 +68,8 @@ class Tournament(object):
         # Save filename for loading ResultSet later
         self.filename = filename
 
-    def play(self, build_results=True, filename=None, processes=None, progress_bar=True):
+    def play(self, build_results=True, filename=None,
+             processes=None, progress_bar=True):
         """
         Plays the tournament and passes the results to the ResultSet class
 
@@ -116,7 +118,8 @@ class Tournament(object):
         """
         result_set = ResultSetFromFile(
             filename=self.filename,
-            progress_bar=progress_bar)
+            progress_bar=progress_bar,
+            num_interactions=self.num_interactions)
         self.outputfile.close()
         return result_set
 
@@ -153,6 +156,7 @@ class Tournament(object):
                 row.append(history1)
                 row.append(history2)
                 self.writer.writerow(row)
+                self.num_interactions += 1
 
     def _run_parallel(self, processes=2, progress_bar=False):
         """
@@ -286,6 +290,7 @@ class Tournament(object):
         match = Match(*params)
         for _ in range(repetitions):
             match.play()
+            self.num_interactions += 1
             interactions[index_pair].append(match.result)
         return interactions
 

--- a/axelrod/tournament.py
+++ b/axelrod/tournament.py
@@ -290,7 +290,6 @@ class Tournament(object):
         match = Match(*params)
         for _ in range(repetitions):
             match.play()
-            self.num_interactions += 1
             interactions[index_pair].append(match.result)
         return interactions
 


### PR DESCRIPTION
Closes #617 

- Done by keeping track of the interactions in the tournament and
  passing this to the ResultSetFromFile.
- If this is created by directly reading from file (so that we do not
  know how many rows of data there are) then a quick count of
  the size of the file is done (this is slightly inefficient but is
  worth it as it gives some user feedback).

Here's a gif of it reading in the file when it's not given the size of the file (there's a small delay as it counts the size of the file):

![](http://g.recordit.co/uwtOXIDsde.gif)

Here's a gif of it reading it in when it's given the size of the file:

![](http://g.recordit.co/E21jI1fgqG.gif)

We can also call it with `progress_bar=False`:

![](http://g.recordit.co/ZvjZXrKueW.gif)