### PR TITLE
Implemented a naive prober strategy (like tit for tat, but randomly defects).

### DIFF
--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -44,6 +44,7 @@ from .mindcontrol import MindController, MindWarper, MindBender
 from .mindreader import MindReader, ProtectedMindReader, MirrorMindReader
 from .oncebitten import OnceBitten, FoolMeOnce, ForgetfulFoolMeOnce, FoolMeForever
 from .prober import Prober, Prober2, Prober3, HardProber
+from .naiveprober import NaiveProber
 from .punisher import Punisher, InversePunisher
 from .qlearner import RiskyQLearner, ArrogantQLearner, HesitantQLearner, CautiousQLearner
 from .rand import Random

--- a/axelrod/strategies/naiveprober.py
+++ b/axelrod/strategies/naiveprober.py
@@ -1,0 +1,39 @@
+from axelrod import Actions, Player, init_args, random_choice
+from axelrod.strategy_transformers import RetaliateUntilApologyTransformer
+
+C, D = Actions.C, Actions.D
+
+
+@RetaliateUntilApologyTransformer
+class NaiveProber(Player):
+    """
+    Like tit-for-tat, but it occasionally defects with a small probability.
+    """
+
+    name = 'Naive Prober'
+    classifier = {
+        'memory_depth': 1,  # Four-Vector = (1.,0.,1.,0.)
+        'stochastic': True,
+        'makes_use_of': set(),
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+
+    @init_args
+    def __init__(self, p=0.1):
+        """
+        Parameters
+        ----------
+        p, float
+            The probability to defect without provoking
+        """
+        Player.__init__(self)
+        self.p = p
+
+    def strategy(self, opponent):
+        choice = random_choice(1-self.p)
+        return choice
+
+    def __repr__(self):
+        return "%s: %s" % (self.name, round(self.p, 2))

--- a/axelrod/tests/unit/test_naiveprober.py
+++ b/axelrod/tests/unit/test_naiveprober.py
@@ -1,0 +1,29 @@
+"""Test for the Naive Prober strategy."""
+
+import axelrod
+from .test_player import TestPlayer
+
+C, D = axelrod.Actions.C, axelrod.Actions.D
+
+
+class TestNaiveProber(TestPlayer):
+
+    name = "RUA Naive Prober: 0.1"
+    player = axelrod.NaiveProber
+    expected_classifier = {
+        'memory_depth': 1,
+        'stochastic': True,
+        'makes_use_of': set(),
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+
+    def test_strategy(self):
+        "Randomly defects and always retaliates like tit for tat."
+        self.first_play_test(C, random_seed=1)
+        self.first_play_test(D, random_seed=2)
+        # Random defection
+        self.responses_test([C] * 10, [C] * 10, [D], random_seed=3)
+        # Always retaliate a defection
+        self.responses_test([C] * 2, [C, D], [D])

--- a/docs/reference/overview_of_strategies.rst
+++ b/docs/reference/overview_of_strategies.rst
@@ -1000,3 +1000,23 @@ HardProber is implemented in the library::
     ['D', 'D', 'C', 'C', 'D']
     >>> p2.history
     ['C', 'C', 'C', 'C', 'C']
+
+NaiveProber
+^^^^^^^^^^^
+
+NAIVE_PROBER is a modification of Tit For Tat strategy which with a small
+probability randomly defects. Default value for a probability of defection is
+0.1.
+
+Here is how NaiveProber is implemented in the library::
+
+    >>> import axelrod
+    >>> p1 = axelrod.NaiveProber()  # Create a Prober3 player
+    >>> p2 = axelrod.Random()  # Create a player that always cooperates
+    >>> for round in range(5):
+    ...     p1.play(p2)
+
+    >>> p1.history
+    ['C', 'C', 'C', 'C', 'D']
+    >>> p2.history
+    ['C', 'C', 'C', 'C', 'D']


### PR DESCRIPTION
Implemented as randomly defecting strategy for #379 (with a relatively small probability) which was decorated with Tit For Tat style defection using RetaliateUntilApologyTransformer. At first, I wanted to start with a Tit For Tat and decorate that with a random flip transformer, but that would flip some Ds to Cs. Is this good or maybe if I could add some better tests, it would be visible how this strategy is inaccurate?