### PR TITLE
Adding remorseful prober

### DIFF
--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -44,7 +44,8 @@ from .memoryone import (
 from .mindcontrol import MindController, MindWarper, MindBender
 from .mindreader import MindReader, ProtectedMindReader, MirrorMindReader
 from .oncebitten import OnceBitten, FoolMeOnce, ForgetfulFoolMeOnce, FoolMeForever
-from .prober import Prober, Prober2, Prober3, HardProber, NaiveProber
+from .prober import (Prober, Prober2, Prober3, HardProber,
+                     NaiveProber, RemorsefulProber)
 from .punisher import Punisher, InversePunisher
 from .qlearner import RiskyQLearner, ArrogantQLearner, HesitantQLearner, CautiousQLearner
 from .rand import Random
@@ -157,6 +158,7 @@ strategies = [
     Raider,
     Random,
     RandomHunter,
+    RemorsefulProber,
     Retaliate,
     Retaliate2,
     Retaliate3,

--- a/axelrod/strategies/prober.py
+++ b/axelrod/strategies/prober.py
@@ -191,8 +191,12 @@ class RemorsefulProber(NaiveProber):
     and Graham Kendall.  IEEE TRANSACTIONS ON COMPUTATIONAL INTELLIGENCE AND AI
     IN GAMES, VOL. 3, NO. 4, DECEMBER 2011
 
-    A better description is given in the selfish gene:
-    https://books.google.co.uk/books?id=ekonDAAAQBAJ&pg=PA273&lpg=PA273&dq=remorseful+prober&source=bl&ots=kAeYRYg7GB&sig=RD5-XtDAxzTF9rxRZEWyFjwuKhc&hl=en&sa=X&ved=0ahUKEwiFg--H_qvNAhWXF8AKHQVTAzcQ6AEIKDAC#v=onepage&q=remorseful%20prober&f=false
+    A fuller description is given in "The Selfish Gene"
+    (https://books.google.co.uk/books?id=ekonDAAAQBAJ):
+
+    "Remorseful Prober remembers whether it has just spontaneously defected, and
+    whether the result was prompt retaliation. If so, it 'remorsefully' allows
+    its opponent 'one free hit' without retaliating."
     """
 
     name = 'Remorseful Prober'

--- a/axelrod/strategies/prober.py
+++ b/axelrod/strategies/prober.py
@@ -195,7 +195,7 @@ class RemorsefulProber(NaiveProber):
     https://books.google.co.uk/books?id=ekonDAAAQBAJ&pg=PA273&lpg=PA273&dq=remorseful+prober&source=bl&ots=kAeYRYg7GB&sig=RD5-XtDAxzTF9rxRZEWyFjwuKhc&hl=en&sa=X&ved=0ahUKEwiFg--H_qvNAhWXF8AKHQVTAzcQ6AEIKDAC#v=onepage&q=remorseful%20prober&f=false
     """
 
-    name = 'Remorseful Prober'  # Needed if want to use with the decorator
+    name = 'Remorseful Prober'
     classifier = {
         'memory_depth': 2,  # It remembers if it's previous move was random
         'stochastic': True,

--- a/axelrod/strategies/prober.py
+++ b/axelrod/strategies/prober.py
@@ -191,7 +191,7 @@ class RemorsefulProber(NaiveProber):
     and Graham Kendall.  IEEE TRANSACTIONS ON COMPUTATIONAL INTELLIGENCE AND AI
     IN GAMES, VOL. 3, NO. 4, DECEMBER 2011
 
-    A fuller description is given in "The Selfish Gene"
+    A more complete description is given in "The Selfish Gene"
     (https://books.google.co.uk/books?id=ekonDAAAQBAJ):
 
     "Remorseful Prober remembers whether it has just spontaneously defected, and

--- a/axelrod/tests/unit/test_prober.py
+++ b/axelrod/tests/unit/test_prober.py
@@ -1,8 +1,7 @@
 """Tests for prober strategies."""
 
-import random
-
 import axelrod
+import random
 
 from .test_player import TestPlayer, test_responses
 
@@ -162,3 +161,68 @@ class TestNaiveProber(TestPlayer):
         test_responses(self, player, opponent, [C], [D], [D])
         test_responses(self, player, opponent, [C, D], [D, C], [C])
         test_responses(self, player, opponent, [C, D], [D, D], [D])
+
+
+class TestRemorsefulProber(TestPlayer):
+
+    name = "Remorseful Prober: 0.1"
+    player = axelrod.RemorsefulProber
+    expected_classifier = {
+        'memory_depth': 2,
+        'stochastic': True,
+        'makes_use_of': set(),
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+
+    def test_strategy(self):
+        "Randomly defects (probes) and always retaliates like tit for tat."
+        self.first_play_test(C)
+
+        player = self.player(0.4)
+        opponent = axelrod.Random()
+        player.history = [C, C]
+        opponent.history = [C, D]
+        self.assertEqual(player.strategy(opponent), D)
+
+    def test_random_defection(self):
+        # Random defection
+        player = self.player(0.4)
+        opponent = axelrod.Random()
+        test_responses(self, player, opponent, [C], [C], [D], random_seed=1)
+
+    def test_remorse(self):
+        """After probing, if opponent retaliates, will offer a C"""
+        player = self.player(0.4)
+        opponent = axelrod.Random()
+
+        random.seed(0)
+        player.history = [C]
+        opponent.history = [C]
+        self.assertEqual(player.strategy(opponent), D)  # Random defection
+        self.assertEqual(player.probing, True)
+
+        player.history = [C, D]
+        opponent.history = [C, D]
+        self.assertEqual(player.strategy(opponent), C)  # Remorse
+        self.assertEqual(player.probing, False)
+
+        player.history = [C, D, C]
+        opponent.history = [C, D, D]
+        self.assertEqual(player.strategy(opponent), D)
+        self.assertEqual(player.probing, False)
+
+    def test_reduction_to_TFT(self):
+        player = self.player(0)
+        opponent = axelrod.Random()
+        test_responses(self, player, opponent, [C], [C], [C], random_seed=1)
+        test_responses(self, player, opponent, [C], [D], [D])
+        test_responses(self, player, opponent, [C, D], [D, C], [C])
+        test_responses(self, player, opponent, [C, D], [D, D], [D])
+
+    def test_reset_probing(self):
+        player = self.player(0.4)
+        player.probing = True
+        player.reset()
+        self.assertFalse(player.probing)

--- a/axelrod/tests/unit/test_prober.py
+++ b/axelrod/tests/unit/test_prober.py
@@ -197,21 +197,14 @@ class TestRemorsefulProber(TestPlayer):
         player = self.player(0.4)
         opponent = axelrod.Random()
 
-        random.seed(0)
-        player.history = [C]
-        opponent.history = [C]
-        self.assertEqual(player.strategy(opponent), D)  # Random defection
-        self.assertEqual(player.probing, True)
+        test_responses(self, player, opponent, [C], [C], [D], random_seed=0,
+                       attrs={'probing': True})
 
-        player.history = [C, D]
-        opponent.history = [C, D]
-        self.assertEqual(player.strategy(opponent), C)  # Remorse
-        self.assertEqual(player.probing, False)
+        test_responses(self, player, opponent, [C, D], [C, D], [C],
+                       attrs={'probing': False})
 
-        player.history = [C, D, C]
-        opponent.history = [C, D, D]
-        self.assertEqual(player.strategy(opponent), D)
-        self.assertEqual(player.probing, False)
+        test_responses(self, player, opponent, [C, D, C], [C, D, D], [D],
+                       attrs={'probing': False})
 
     def test_reduction_to_TFT(self):
         player = self.player(0)

--- a/axelrod/tests/unit/test_prober.py
+++ b/axelrod/tests/unit/test_prober.py
@@ -197,14 +197,21 @@ class TestRemorsefulProber(TestPlayer):
         player = self.player(0.4)
         opponent = axelrod.Random()
 
-        test_responses(self, player, opponent, [C], [C], [D], random_seed=0,
-                       attrs={'probing': True})
+        random.seed(0)
+        player.history = [C]
+        opponent.history = [C]
+        self.assertEqual(player.strategy(opponent), D)  # Random defection
+        self.assertEqual(player.probing, True)
 
-        test_responses(self, player, opponent, [C, D], [C, D], [C],
-                       attrs={'probing': False})
+        player.history = [C, D]
+        opponent.history = [C, D]
+        self.assertEqual(player.strategy(opponent), C)  # Remorse
+        self.assertEqual(player.probing, False)
 
-        test_responses(self, player, opponent, [C, D, C], [C, D, D], [D],
-                       attrs={'probing': False})
+        player.history = [C, D, C]
+        opponent.history = [C, D, D]
+        self.assertEqual(player.strategy(opponent), D)
+        self.assertEqual(player.probing, False)
 
     def test_reduction_to_TFT(self):
         player = self.player(0)

--- a/axelrod/tests/unit/test_prober.py
+++ b/axelrod/tests/unit/test_prober.py
@@ -216,10 +216,14 @@ class TestRemorsefulProber(TestPlayer):
     def test_reduction_to_TFT(self):
         player = self.player(0)
         opponent = axelrod.Random()
-        test_responses(self, player, opponent, [C], [C], [C], random_seed=1)
-        test_responses(self, player, opponent, [C], [D], [D])
-        test_responses(self, player, opponent, [C, D], [D, C], [C])
-        test_responses(self, player, opponent, [C, D], [D, D], [D])
+        test_responses(self, player, opponent, [C], [C], [C], random_seed=1,
+                       attrs={'probing': False})
+        test_responses(self, player, opponent, [C], [D], [D],
+                       attrs={'probing': False})
+        test_responses(self, player, opponent, [C, D], [D, C], [C],
+                       attrs={'probing': False})
+        test_responses(self, player, opponent, [C, D], [D, D], [D],
+                       attrs={'probing': False})
 
     def test_reset_probing(self):
         player = self.player(0.4)

--- a/docs/tutorials/advanced/classification_of_strategies.rst
+++ b/docs/tutorials/advanced/classification_of_strategies.rst
@@ -24,7 +24,7 @@ This allows us to, for example, quickly identify all the stochastic
 strategies::
 
     >>> len([s for s in axl.strategies if s().classifier['stochastic']])
-    40
+    41
 
 Or indeed find out how many strategy only use 1 turn worth of memory to
 make a decision::

--- a/docs/tutorials/advanced/strategy_transformers.rst
+++ b/docs/tutorials/advanced/strategy_transformers.rst
@@ -104,13 +104,13 @@ The library includes the following transformers:
     >>> ApologizingDefector = ApologyTransformer([D], [C])(axelrod.Defector)
     >>> player = ApologizingDefector()
 
-You can pass any two sequences in. In this example the player would apologize
-after two consequtive rounds of `(D, C)`::
+   You can pass any two sequences in. In this example the player would apologize
+   after two consequtive rounds of `(D, C)`::
 
-    >>> import axelrod
-    >>> from axelrod.strategy_transformers import ApologyTransformer
-    >>> ApologizingDefector = ApologyTransformer([D, D], [C, C])(axelrod.Defector)
-    >>> player = ApologizingDefector()
+       >>> import axelrod
+       >>> from axelrod.strategy_transformers import ApologyTransformer
+       >>> ApologizingDefector = ApologyTransformer([D, D], [C, C])(axelrod.Defector)
+       >>> player = ApologizingDefector()
 
 * :code:`DeadlockBreakingTransformer`: Attempts to break :code:`(D, C) -> (C, D)` deadlocks by cooperating::
 


### PR DESCRIPTION
This is the remaining strategy for the list from #387. There is another strategy on that list "contrite tft" but that strategy actually needs to know when a move against it was caused by noise. I suggest (after this) we close #387 and open another issue for that strategy as it will need a bit of a tweak to the `Match` class (or something).

Note that for some of the tests for this strategy I'm not using the helper functions. I didn't seem able to get the required behaviour with them: I got myself a big confused so found it easier to use the verbose calls. Not averse to spending time getting the helper functions working if we are keen to...