### PR TITLE
Fixing reset method for FSMs

### DIFF
--- a/axelrod/strategies/finite_state_machines.py
+++ b/axelrod/strategies/finite_state_machines.py
@@ -54,6 +54,7 @@ class FSMPlayer(Player):
             initial_state = 1
             initial_action = C
         Player.__init__(self)
+        self.initial_state = initial_state
         self.initial_action = initial_action
         self.fsm = SimpleFSM(transitions, initial_state)
 
@@ -66,6 +67,10 @@ class FSMPlayer(Player):
             # for the strategy to function
             self.state = self.fsm.state
             return action
+
+    def reset(self):
+        Player.reset(self)
+        self.fsm.state = self.initial_state
 
 
 class Fortress3(FSMPlayer):

--- a/axelrod/tests/integration/test_matches.py
+++ b/axelrod/tests/integration/test_matches.py
@@ -1,0 +1,25 @@
+"""Tests for some expected match behaviours"""
+import unittest
+import axelrod
+
+from hypothesis import given
+from hypothesis.strategies import integers
+from axelrod.tests.property import strategy_lists
+
+C, D = axelrod.Actions.C, axelrod.Actions.D
+
+deterministic_strategies = [s for s in axelrod.ordinary_strategies
+                            if not s().classifier['stochastic']]  # Well behaved strategies
+
+class TestMatchOutcomes(unittest.TestCase):
+
+    @given(strategies=strategy_lists(strategies=deterministic_strategies,
+                                     min_size=2, max_size=2),
+           turns=integers(min_value=1, max_value=20))
+    def test_outcome_repeats(self, strategies, turns):
+        """A test that if we repeat 3 matches with deterministic and well
+        behaved strategies then we get the same result"""
+        players = [s() for s in strategies]
+        matches = [axelrod.Match(players, turns) for _ in range(3)]
+        self.assertEqual(matches[0].play(), matches[1].play())
+        self.assertEqual(matches[1].play(), matches[2].play())

--- a/axelrod/tests/unit/test_finite_state_machines.py
+++ b/axelrod/tests/unit/test_finite_state_machines.py
@@ -111,6 +111,12 @@ class TestFSMPlayer(TestPlayer):
         fsm = player.fsm
         self.assertTrue(check_state_transitions(fsm.state_transitions))
 
+    def test_reset_initial_state(self):
+        player = self.player()
+        player.fsm.state = -1
+        player.reset()
+        self.assertFalse(player.fsm.state == -1)
+
 
 class TestFortress3(TestFSMPlayer):
 


### PR DESCRIPTION
Closes #637 

This also adds an integration test that checks that repeating matches with deterministic well behaved players gives the same outcome (this is how I found #637).

This 98d1837 adds the test (which should fail assuming hypothesis stumbles on the same error I was getting locally). f263ac5949e8fc57c5b5afb0a76dd5bce825d8ec fixes the finite state machines.