### PR TITLE
Adding contrite TfT

### DIFF
--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -56,7 +56,7 @@ from .sequence_player import SequencePlayer, ThueMorse, ThueMorseInverse
 from .titfortat import (
     TitForTat, TitFor2Tats, TwoTitsForTat, Bully, SneakyTitForTat,
     SuspiciousTitForTat, AntiTitForTat, HardTitForTat, HardTitFor2Tats,
-    OmegaTFT, Gradual)
+    OmegaTFT, Gradual, ContriteTitForTat)
 
 
 # Note: Meta* strategies are handled in .__init__.py
@@ -79,6 +79,7 @@ strategies = [
     Calculator,
     CautiousQLearner,
     Champion,
+    ContriteTitForTat,
     Cooperator,
     CooperatorHunter,
     CycleHunter,

--- a/axelrod/strategies/finite_state_machines.py
+++ b/axelrod/strategies/finite_state_machines.py
@@ -54,6 +54,7 @@ class FSMPlayer(Player):
             initial_state = 1
             initial_action = C
         Player.__init__(self)
+        self.initial_state = initial_state
         self.initial_action = initial_action
         self.fsm = SimpleFSM(transitions, initial_state)
 
@@ -66,6 +67,10 @@ class FSMPlayer(Player):
             # for the strategy to function
             self.state = self.fsm.state
             return action
+
+    def reset(self):
+        Player.reset(self)
+        self.fsm.state = self.initial_state
 
 
 class Fortress3(FSMPlayer):

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -365,7 +365,7 @@ class ContriteTitForTat(Player):
         if not opponent.history:
             return C
 
-        # If contrite and but managed to cooperate: apologise.
+        # If contrite but managed to cooperate: apologise.
         if self.contrite and self.history[-1] == C:
             self.contrite = False
             return C

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -1,5 +1,5 @@
 from axelrod import Actions, Player, init_args, flip_action
-from axelrod.strategy_transformers import TrackHistoryTransformer
+from axelrod.strategy_transformers import StrategyTransformerFactory, history_track_wrapper
 
 C, D = Actions.C, Actions.D
 
@@ -334,7 +334,11 @@ class Gradual(Player):
         self.punishment_limit = 0
 
 
-@TrackHistoryTransformer
+Transformer = StrategyTransformerFactory(
+    history_track_wrapper, name_prefix=None)()
+
+
+@Transformer
 class ContriteTitForTat(Player):
     """
     A player that corresponds to Tit For Tat if there is no noise. In the case

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -1,5 +1,6 @@
 from axelrod import Actions, Player, init_args, flip_action
-from axelrod.strategy_transformers import StrategyTransformerFactory, history_track_wrapper
+from axelrod.strategy_transformers import (StrategyTransformerFactory,
+                                           history_track_wrapper)
 
 C, D = Actions.C, Actions.D
 

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -1,4 +1,5 @@
 from axelrod import Actions, Player, init_args, flip_action
+from axelrod.strategy_transformers import TrackHistoryTransformer
 
 C, D = Actions.C, Actions.D
 
@@ -331,3 +332,52 @@ class Gradual(Player):
         self.punishing = False
         self.punishment_count = 0
         self.punishment_limit = 0
+
+
+@TrackHistoryTransformer
+class ContriteTitForTat(Player):
+    """
+    A player that corresponds to Tit For Tat if there is no noise. In the case
+    of a noisy match: if the opponent defects as a result of a noisy defection
+    then ContriteTitForTat will become 'contrite' until it successfully
+    cooperates..
+
+    Reference: "How to Cope with Noise In the Iterated Prisoner's Dilemma" by
+    Wu and Axelrod. Published in Journal of Conflict Resolution, 39 (March
+    1995), pp. 183-189.
+
+    http://www-personal.umich.edu/~axe/research/How_to_Cope.pdf
+    """
+
+    name = "Contrite Tit For Tat"
+    classifier = {
+        'memory_depth': 3,
+        'stochastic': False,
+        'makes_use_of': set(),
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+    contrite = False
+
+    def strategy(self, opponent):
+
+        if not opponent.history:
+            return C
+
+        # If contrite and but managed to cooperate: apologise.
+        if self.contrite and self.history[-1] == C:
+            self.contrite = False
+            return C
+
+        # Check if noise provoked opponent
+        if self._recorded_history[-1] != self.history[-1]:  # Check if noise
+            if self.history[-1] == D and opponent.history[-1] == C:
+                self.contrite = True
+
+        return opponent.history[-1]
+
+    def reset(self):
+        Player.reset(self)
+        self.contrite = False
+        self._recorded_history = []

--- a/axelrod/strategy_transformers.py
+++ b/axelrod/strategy_transformers.py
@@ -221,8 +221,7 @@ def history_track_wrapper(player, opponent, action):
         player._recorded_history = [action]
     return action
 
-TrackHistoryTransformer = StrategyTransformerFactory(
-    history_track_wrapper, name_prefix="HistoryTracking")()
+TrackHistoryTransformer = StrategyTransformerFactory(history_track_wrapper)()
 
 
 def deadlock_break_wrapper(player, opponent, action):

--- a/axelrod/strategy_transformers.py
+++ b/axelrod/strategy_transformers.py
@@ -221,7 +221,8 @@ def history_track_wrapper(player, opponent, action):
         player._recorded_history = [action]
     return action
 
-TrackHistoryTransformer = StrategyTransformerFactory(history_track_wrapper)()
+TrackHistoryTransformer = StrategyTransformerFactory(
+    history_track_wrapper, name_prefix="HistoryTracking")()
 
 
 def deadlock_break_wrapper(player, opponent, action):

--- a/axelrod/tests/integration/test_matches.py
+++ b/axelrod/tests/integration/test_matches.py
@@ -1,0 +1,25 @@
+"""Tests for some expected match behaviours"""
+import unittest
+import axelrod
+
+from hypothesis import given
+from hypothesis.strategies import integers
+from axelrod.tests.property import strategy_lists
+
+C, D = axelrod.Actions.C, axelrod.Actions.D
+
+deterministic_strategies = [s for s in axelrod.ordinary_strategies
+                            if not s().classifier['stochastic']]  # Well behaved strategies
+
+class TestMatchOutcomes(unittest.TestCase):
+
+    @given(strategies=strategy_lists(strategies=deterministic_strategies,
+                                     min_size=2, max_size=2),
+           turns=integers(min_value=1, max_value=20))
+    def test_outcome_repeats(self, strategies, turns):
+        """A test that if we repeat 3 matches with deterministic and well
+        behaved strategies then we get the same result"""
+        players = [s() for s in strategies]
+        matches = [axelrod.Match(players, turns) for _ in range(3)]
+        self.assertEqual(matches[0].play(), matches[1].play())
+        self.assertEqual(matches[1].play(), matches[2].play())

--- a/axelrod/tests/unit/test_finite_state_machines.py
+++ b/axelrod/tests/unit/test_finite_state_machines.py
@@ -111,6 +111,12 @@ class TestFSMPlayer(TestPlayer):
         fsm = player.fsm
         self.assertTrue(check_state_transitions(fsm.state_transitions))
 
+    def test_reset_initial_state(self):
+        player = self.player()
+        player.fsm.state = -1
+        player.reset()
+        self.assertFalse(player.fsm.state == -1)
+
 
 class TestFortress3(TestFSMPlayer):
 

--- a/axelrod/tests/unit/test_titfortat.py
+++ b/axelrod/tests/unit/test_titfortat.py
@@ -3,6 +3,12 @@
 import axelrod
 from .test_player import TestHeadsUp, TestPlayer
 
+from hypothesis import given
+from hypothesis.strategies import integers
+from axelrod.tests.property import strategy_lists
+
+import random
+
 C, D = axelrod.Actions.C, axelrod.Actions.D
 
 
@@ -362,3 +368,72 @@ class TestGradual(TestPlayer):
         match = axelrod.Match((player, opp2), 1000)
         match.play()
         self.assertEqual(match.final_score(), (3472, 767))
+
+
+class TestContriteTitForTat(TestPlayer):
+
+    name = "Contrite Tit For Tat"
+    player = axelrod.ContriteTitForTat
+    expected_classifier = {
+        'memory_depth': 3,
+        'stochastic': False,
+        'makes_use_of': set(),
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+
+    deterministic_strategies = [s for s in axelrod.ordinary_strategies
+                                if not s().classifier['stochastic']]
+
+    @given(strategies=strategy_lists(strategies=deterministic_strategies,
+                                     max_size=1),
+           turns=integers(min_value=1, max_value=20))
+    def test_is_tit_for_tat_with_no_noise(self, strategies, turns):
+        tft = axelrod.TitForTat()
+        ctft = self.player()
+        opponent = strategies[0]()
+        m1 = axelrod.Match((tft, opponent), turns)
+        m2 = axelrod.Match((ctft, opponent), turns)
+        self.assertEqual(m1.play(), m2.play())
+
+    def test_strategy_with_noise(self):
+        ctft = self.player()
+        opponent = axelrod.Defector()
+        self.assertEqual(ctft.strategy(opponent), C)
+        self.assertEqual(ctft._recorded_history, [C])
+        ctft.reset()  # Clear the recorded history
+        self.assertEqual(ctft._recorded_history, [])
+
+        random.seed(0)
+        ctft.play(opponent, noise=.9)
+        self.assertEqual(ctft.history, [D])
+        self.assertEqual(ctft._recorded_history, [C])
+        self.assertEqual(opponent.history, [C])
+
+        # After noise: is contrite
+        ctft.play(opponent)
+        self.assertEqual(ctft.history, [D, C])
+        self.assertEqual(ctft._recorded_history, [C, C])
+        self.assertEqual(opponent.history, [C, D])
+        self.assertTrue(ctft.contrite)
+
+        # Cooperates and no longer contrite
+        ctft.play(opponent)
+        self.assertEqual(ctft.history, [D, C, C])
+        self.assertEqual(ctft._recorded_history, [C, C, C])
+        self.assertEqual(opponent.history, [C, D, D])
+        self.assertFalse(ctft.contrite)
+
+        # Goes back to playing tft
+        ctft.play(opponent)
+        self.assertEqual(ctft.history, [D, C, C, D])
+        self.assertEqual(ctft._recorded_history, [C, C, C, D])
+        self.assertEqual(opponent.history, [C, D, D, D])
+        self.assertFalse(ctft.contrite)
+
+    def test_reset_cleans_all(self):
+        p = self.player()
+        p.contrite = True
+        p.reset()
+        self.assertFalse(p.contrite)


### PR DESCRIPTION
Closes #636 

A strategy that plays like TfT if there is no noise. If there is noise and it defects because of noise (intending to cooperate), if the opponent cooperates but defects as a result of the noisy defection then it cooperates to try and bring back mutual cooperation.

Wasn't sure if there was a better way to handling the renaming from the `TrackHistoryTransformer` (without my change it adds a prefix to the strategy)?

Note that this is on top of #638 (as it needed that fix to work for the 'reduce to tft' test to work).