### PR TITLE
Revert "Updating zenodo badges."

### DIFF
--- a/CITATION.rst
+++ b/CITATION.rst
@@ -1,10 +1,16 @@
 Please use the following to cite the latest version of the Axelrod library::
 
-    @misc{axelrodproject,
-      author       = {{ {The Axelrod project developers} }}
-      title        = {Axelrod: <RELEASE TITLE>},
-      month        = apr,
-      year         = 2016,
-      doi          = {<DOI INFORMATION>},
-      url          = {http://dx.doi.org/10.5281/zenodo.<DOI NUMBER>}
-    }
+@misc{axelrodproject,
+  author       = {{ {The Axelrod project developers} }}
+  title        = {Axelrod: <RELEASE TITLE>},
+  month        = apr,
+  year         = 2016,
+  doi          = {<DOI INFORMATION>},
+  url          = {http://dx.doi.org/10.5281/zenodo.<DOI NUMBER>}
+}
+
+To check the details (RELEASE TITLE, DOI INFORMATION and DOI NUMBER) please view
+the Zenodo page for the project. Click on the badge/link below:
+
+.. image:: https://zenodo.org/badge/19509/Axelrod-Python/Axelrod.svg
+    :target: https://zenodo.org/badge/latestdoi/19509/Axelrod-Python/Axelrod

--- a/CITATION.rst
+++ b/CITATION.rst
@@ -1,13 +1,13 @@
 Please use the following to cite the latest version of the Axelrod library::
 
-@misc{axelrodproject,
-  author       = {{ {The Axelrod project developers} }}
-  title        = {Axelrod: <RELEASE TITLE>},
-  month        = apr,
-  year         = 2016,
-  doi          = {<DOI INFORMATION>},
-  url          = {http://dx.doi.org/10.5281/zenodo.<DOI NUMBER>}
-}
+    @misc{axelrodproject,
+      author       = {{ {The Axelrod project developers} }}
+      title        = {Axelrod: <RELEASE TITLE>},
+      month        = apr,
+      year         = 2016,
+      doi          = {<DOI INFORMATION>},
+      url          = {http://dx.doi.org/10.5281/zenodo.<DOI NUMBER>}
+    }
 
 To check the details (RELEASE TITLE, DOI INFORMATION and DOI NUMBER) please view
 the Zenodo page for the project. Click on the badge/link below:

--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,8 @@
 .. image:: https://travis-ci.org/Axelrod-Python/Axelrod.svg?branch=packaging
     :target: https://travis-ci.org/Axelrod-Python/Axelrod
 
-.. image:: https://zenodo.org/badge/doi/10.5281/zenodo.55509.svg
-   :target: http://dx.doi.org/10.5281/zenodo.55509
+.. image:: https://zenodo.org/badge/19509/Axelrod-Python/Axelrod.svg
+    :target: https://zenodo.org/badge/latestdoi/19509/Axelrod-Python/Axelrod
 
 |Join the chat at https://gitter.im/Axelrod-Python/Axelrod|
 


### PR DESCRIPTION
Closes #641 

@meatballs fixed the Zenodo issue (https://zenodo.org/record/56203 was automatic hooked). This just reverts a change I had made so that we go back to having the zenodo badge point at the latest doi.