### PR TITLE
Removing csv method from Result set.

### DIFF
--- a/axelrod/result_set.py
+++ b/axelrod/result_set.py
@@ -683,25 +683,6 @@ class ResultSet(object):
 
         return eigenvector.tolist()
 
-    def csv(self):
-        """
-        Returns:
-        --------
-
-        The string of the total scores per player (columns) per repetition
-        (rows).
-        """
-        csv_string = StringIO()
-        header = ",".join(self.ranked_names) + "\n"
-        csv_string.write(header)
-        writer = csv.writer(csv_string, lineterminator="\n")
-        for irep in range(self.nrepetitions):
-            data = [self.normalised_scores[rank][irep]
-                    for rank in self.ranking]
-            writer.writerow(list(map(str, data)))
-        return csv_string.getvalue()
-
-
 class ResultSetFromFile(ResultSet):
     """A class to hold the results of a tournament. Reads in a CSV file produced
     by the tournament class.

--- a/axelrod/tests/unit/test_resultset.py
+++ b/axelrod/tests/unit/test_resultset.py
@@ -157,9 +157,6 @@ class TestResultSet(unittest.TestCase):
                 0.5057828909101213
             ]
 
-        cls.expected_csv = (
-            'Defector,Tit For Tat,Alternator\n2.6,1.7,1.5\n2.6,1.7,1.5\n2.6,1.7,1.5\n')
-
     def test_init(self):
         rs = axelrod.ResultSet(self.players, self.interactions,
                                progress_bar=False)
@@ -354,11 +351,6 @@ class TestResultSet(unittest.TestCase):
         self.assertEqual(len(rs.eigenmoses_rating), rs.nplayers)
         for j, rate in enumerate(rs.eigenmoses_rating):
             self.assertAlmostEqual(rate, self.expected_eigenmoses_rating[j])
-
-    def test_csv(self):
-        rs = axelrod.ResultSet(self.players, self.interactions,
-                               progress_bar=False)
-        self.assertEqual(rs.csv(), self.expected_csv)
 
 
 class TestResultSetFromFile(unittest.TestCase):


### PR DESCRIPTION
As suggested in #645 the csv method from the result set was removed. 

The tests that concerned csv method in `test_resultset.py` were also removed. 