### PR TITLE
651 - Tests for random seeding and a random seeding function

### DIFF
--- a/axelrod/__init__.py
+++ b/axelrod/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 # The order of imports matters!
 from .actions import Actions, flip_action
-from .random_ import random_choice, set_seed
+from .random_ import random_choice, seed
 from .plot import Plot
 from .game import DefaultGame, Game
 from .player import init_args, is_basic, obey_axelrod, update_history, Player

--- a/axelrod/__init__.py
+++ b/axelrod/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 # The order of imports matters!
 from .actions import Actions, flip_action
-from .random_ import random_choice
+from .random_ import random_choice, set_seed
 from .plot import Plot
 from .game import DefaultGame, Game
 from .player import init_args, is_basic, obey_axelrod, update_history, Player

--- a/axelrod/random_.py
+++ b/axelrod/random_.py
@@ -1,4 +1,5 @@
 import random
+import numpy
 from axelrod import Actions
 
 
@@ -21,3 +22,9 @@ def randrange(a, b):
     c = b - a
     r = c * random.random()
     return a + int(r)
+
+
+def set_seed(seed):
+    """Sets a seed"""
+    random.seed(seed)
+    numpy.random.seed(seed)

--- a/axelrod/random_.py
+++ b/axelrod/random_.py
@@ -24,7 +24,7 @@ def randrange(a, b):
     return a + int(r)
 
 
-def set_seed(seed):
+def seed(seed):
     """Sets a seed"""
     random.seed(seed)
     numpy.random.seed(seed)

--- a/axelrod/tests/integration/test_matches.py
+++ b/axelrod/tests/integration/test_matches.py
@@ -39,8 +39,7 @@ class TestMatchOutcomes(unittest.TestCase):
         same result"""
         results = []
         for _ in range(3):
-            random.seed(seed)
-            numpy.random.seed(seed)
+            axelrod.set_seed(seed)
             players = [s() for s in strategies]
             results.append(axelrod.Match(players, turns).play())
 

--- a/axelrod/tests/integration/test_matches.py
+++ b/axelrod/tests/integration/test_matches.py
@@ -2,6 +2,9 @@
 import unittest
 import axelrod
 
+import random
+import numpy
+
 from hypothesis import given
 from hypothesis.strategies import integers
 from axelrod.tests.property import strategy_lists
@@ -10,6 +13,9 @@ C, D = axelrod.Actions.C, axelrod.Actions.D
 
 deterministic_strategies = [s for s in axelrod.ordinary_strategies
                             if not s().classifier['stochastic']]  # Well behaved strategies
+
+stochastic_strategies = [s for s in axelrod.ordinary_strategies
+                            if s().classifier['stochastic']]
 
 class TestMatchOutcomes(unittest.TestCase):
 
@@ -23,3 +29,20 @@ class TestMatchOutcomes(unittest.TestCase):
         matches = [axelrod.Match(players, turns) for _ in range(3)]
         self.assertEqual(matches[0].play(), matches[1].play())
         self.assertEqual(matches[1].play(), matches[2].play())
+
+    @given(strategies=strategy_lists(strategies=stochastic_strategies,
+                                     min_size=2, max_size=2),
+           turns=integers(min_value=1, max_value=20),
+           seed=integers(min_value=0, max_value=4294967295))
+    def test_outcome_repeats_stochastic(self, strategies, turns, seed):
+        """a test to check that if a seed is set stochastic strategies give the
+        same result"""
+        results = []
+        for _ in range(3):
+            random.seed(seed)
+            numpy.random.seed(seed)
+            players = [s() for s in strategies]
+            results.append(axelrod.Match(players, turns).play())
+
+        self.assertEqual(results[0], results[1])
+        self.assertEqual(results[1], results[2])

--- a/axelrod/tests/integration/test_matches.py
+++ b/axelrod/tests/integration/test_matches.py
@@ -37,7 +37,7 @@ class TestMatchOutcomes(unittest.TestCase):
         same result"""
         results = []
         for _ in range(3):
-            axelrod.set_seed(seed)
+            axelrod.seed(seed)
             players = [s() for s in strategies]
             results.append(axelrod.Match(players, turns).play())
 

--- a/axelrod/tests/integration/test_matches.py
+++ b/axelrod/tests/integration/test_matches.py
@@ -2,9 +2,6 @@
 import unittest
 import axelrod
 
-import random
-import numpy
-
 from hypothesis import given
 from hypothesis.strategies import integers
 from axelrod.tests.property import strategy_lists
@@ -15,7 +12,8 @@ deterministic_strategies = [s for s in axelrod.ordinary_strategies
                             if not s().classifier['stochastic']]  # Well behaved strategies
 
 stochastic_strategies = [s for s in axelrod.ordinary_strategies
-                            if s().classifier['stochastic']]
+                         if s().classifier['stochastic']]
+
 
 class TestMatchOutcomes(unittest.TestCase):
 

--- a/axelrod/tests/integration/test_tournament.py
+++ b/axelrod/tests/integration/test_tournament.py
@@ -82,7 +82,7 @@ class TestTournament(unittest.TestCase):
         """
         files = []
         for _ in range(2):
-            axelrod.set_seed(0)
+            axelrod.seed(0)
             stochastic_players = [s() for s in axelrod.ordinary_strategies
                                   if s().classifier['stochastic']]
             tournament = axelrod.Tournament(name='test',

--- a/axelrod/tests/unit/test_random_.py
+++ b/axelrod/tests/unit/test_random_.py
@@ -1,9 +1,10 @@
 """Test for the random strategy."""
 
+import numpy
 import random
 import unittest
 
-from axelrod import random_choice, Actions
+from axelrod import random_choice, set_seed, Actions
 
 C, D = Actions.C, Actions.D
 
@@ -16,3 +17,18 @@ class TestRandom_(unittest.TestCase):
         self.assertEqual(random_choice(), C)
         random.seed(2)
         self.assertEqual(random_choice(), D)
+
+    def test_set_seed(self):
+        """Test that numpy and stdlib random seed is set by set seed helper
+        function"""
+
+        numpy_random_numbers = []
+        stdlib_random_numbers = []
+        for _ in range(2):
+            set_seed(0)
+            numpy_random_numbers.append(numpy.random.random())
+            stdlib_random_numbers.append(random.random())
+
+        self.assertEqual(numpy_random_numbers[0], numpy_random_numbers[1])
+        self.assertEqual(stdlib_random_numbers[0], stdlib_random_numbers[1])
+

--- a/axelrod/tests/unit/test_random_.py
+++ b/axelrod/tests/unit/test_random_.py
@@ -4,7 +4,7 @@ import numpy
 import random
 import unittest
 
-from axelrod import random_choice, set_seed, Actions
+from axelrod import random_choice, seed, Actions
 
 C, D = Actions.C, Actions.D
 
@@ -19,13 +19,12 @@ class TestRandom_(unittest.TestCase):
         self.assertEqual(random_choice(), D)
 
     def test_set_seed(self):
-        """Test that numpy and stdlib random seed is set by set seed helper
-        function"""
+        """Test that numpy and stdlib random seed is set by axelrod seed"""
 
         numpy_random_numbers = []
         stdlib_random_numbers = []
         for _ in range(2):
-            set_seed(0)
+            seed(0)
             numpy_random_numbers.append(numpy.random.random())
             stdlib_random_numbers.append(random.random())
 

--- a/docs/tutorials/advanced/index.rst
+++ b/docs/tutorials/advanced/index.rst
@@ -13,3 +13,4 @@ Contents:
    making_tournaments.rst
    reading_and_writing_interactions.rst
    using_the_cache.rst
+   setting_a_seed.rst

--- a/docs/tutorials/advanced/setting_a_seed.rst
+++ b/docs/tutorials/advanced/setting_a_seed.rst
@@ -1,7 +1,7 @@
 .. _setting_a_seed:
 
-Setting a seed
-==============
+Setting a random seed
+=====================
 
 The library has a variety of strategies whose behaviour is stochastic. To ensure
 reproducible results a random seed should be set. As both Numpy and the standard

--- a/docs/tutorials/advanced/setting_a_seed.rst
+++ b/docs/tutorials/advanced/setting_a_seed.rst
@@ -6,17 +6,17 @@ Setting a random seed
 The library has a variety of strategies whose behaviour is stochastic. To ensure
 reproducible results a random seed should be set. As both Numpy and the standard
 library are used for random number generation, both seeds need to be
-set. To do this we can use the `set_seed` function::
+set. To do this we can use the `seed` function::
 
     >>> import axelrod as axl
     >>> players = (axl.Random(), axl.MetaMixer())  # Two stochastic strategies
-    >>> axl.set_seed(0)
+    >>> axl.seed(0)
     >>> axl.Match(players, turns=3).play()
     [('D', 'C'), ('D', 'D'), ('C', 'D')]
 
 We obtain the same results is it is played with the same seed::
 
-    >>> axl.set_seed(0)
+    >>> axl.seed(0)
     >>> axl.Match(players, turns=3).play()
     [('D', 'C'), ('D', 'D'), ('C', 'D')]
 

--- a/docs/tutorials/advanced/setting_a_seed.rst
+++ b/docs/tutorials/advanced/setting_a_seed.rst
@@ -1,0 +1,35 @@
+.. _setting_a_seed:
+
+Setting a seed
+==============
+
+The library has a variety of strategies whose behaviour is stochastic. To ensure
+reproducible results a random seed should be set. As both Numpy and the standard
+library are used for random number generation, both seeds need to be
+set. To do this we can use the `set_seed` function::
+
+    >>> import axelrod as axl
+    >>> players = (axl.Random(), axl.MetaMixer())  # Two stochastic strategies
+    >>> axl.set_seed(0)
+    >>> axl.Match(players, turns=3).play()
+    [('D', 'C'), ('D', 'D'), ('C', 'D')]
+
+We obtain the same results is it is played with the same seed::
+
+    >>> axl.set_seed(0)
+    >>> axl.Match(players, turns=3).play()
+    [('D', 'C'), ('D', 'D'), ('C', 'D')]
+
+Note that this is equivalent to::
+
+    >>> import numpy
+    >>> import random
+    >>> players = (axl.Random(), axl.MetaMixer())
+    >>> random.seed(0)
+    >>> numpy.random.seed(0)
+    >>> axl.Match(players, turns=3).play()
+    [('D', 'C'), ('D', 'D'), ('C', 'D')]
+    >>> numpy.random.seed(0)
+    >>> random.seed(0)
+    >>> axl.Match(players, turns=3).play()
+    [('D', 'C'), ('D', 'D'), ('C', 'D')]


### PR DESCRIPTION
Closes #651 

Firstly this adds a test to `integration/test_matches`. Simply checks that if two stochastic matches are played with the same seed they give the same result. 

Note that both the numpy and stdlib seed need to be set.

Have also added a function that sets both of those: `axelrod.set_seed` just to make it 'less easy' to only set one of the seeds...