### PR TITLE
Implement name_prefix as opt arg for transformer

### DIFF
--- a/axelrod/strategies/backstabber.py
+++ b/axelrod/strategies/backstabber.py
@@ -4,7 +4,7 @@ from axelrod.strategy_transformers import FinalTransformer
 C, D = Actions.C, Actions.D
 
 
-@FinalTransformer((D, D)) # End with two defections
+@FinalTransformer((D, D), name_prefix=None) # End with two defections
 class BackStabber(Player):
     """
     Forgives the first 3 defections but on the fourth
@@ -29,7 +29,7 @@ class BackStabber(Player):
             return D
         return C
 
-@FinalTransformer((D, D)) # End with two defections
+@FinalTransformer((D, D), name_prefix=None) # End with two defections
 class DoubleCrosser(Player):
     """
     Forgives the first 3 defections but on the fourth

--- a/axelrod/strategies/gambler.py
+++ b/axelrod/strategies/gambler.py
@@ -8,7 +8,7 @@ from .lookerup import LookerUp, create_lookup_table_keys
 C, D = Actions.C, Actions.D
 
 
-@FinalTransformer((D, D)) # End with two defections if tournament length is known
+@FinalTransformer((D, D), name_prefix=None)  # End with two defections if tournament length is known
 class Gambler(LookerUp):
     """
     A LookerUp class player which will select randomly an action in some cases.

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -1,6 +1,5 @@
-from axelrod import Actions, Player, init_args, flip_action
-from axelrod.strategy_transformers import (StrategyTransformerFactory,
-                                           history_track_wrapper)
+from axelrod import Actions, Player, init_args
+from axelrod.strategy_transformers import TrackHistoryTransformer
 
 C, D = Actions.C, Actions.D
 
@@ -335,11 +334,7 @@ class Gradual(Player):
         self.punishment_limit = 0
 
 
-Transformer = StrategyTransformerFactory(
-    history_track_wrapper, name_prefix=None)()
-
-
-@Transformer
+@TrackHistoryTransformer(name_prefix=None)
 class ContriteTitForTat(Player):
     """
     A player that corresponds to Tit For Tat if there is no noise. In the case

--- a/axelrod/strategy_transformers.py
+++ b/axelrod/strategy_transformers.py
@@ -71,6 +71,11 @@ def StrategyTransformerFactory(strategy_wrapper, name_prefix=None):
 
             args = self.args
             kwargs = self.kwargs
+            try:
+            #if "name_prefix" in kwargs remove as only want dec arguments
+                del kwargs["name_prefix"]
+            except KeyError:
+                pass
 
             # Define the new strategy method, wrapping the existing method
             # with `strategy_wrapper`
@@ -144,7 +149,7 @@ def generic_strategy_wrapper(player, opponent, proposed_action, *args, **kwargs)
     # This example just passes through the proposed_action
     return proposed_action
 
-IdentityTransformer = StrategyTransformerFactory(generic_strategy_wrapper)()
+IdentityTransformer = StrategyTransformerFactory(generic_strategy_wrapper)
 
 
 def flip_wrapper(player, opponent, action):
@@ -152,7 +157,7 @@ def flip_wrapper(player, opponent, action):
     return flip_action(action)
 
 FlipTransformer = StrategyTransformerFactory(
-    flip_wrapper, name_prefix="Flipped")()
+    flip_wrapper, name_prefix="Flipped")
 
 
 def noisy_wrapper(player, opponent, action, noise=0.05):
@@ -186,7 +191,8 @@ def initial_sequence(player, opponent, action, initial_seq):
         return initial_seq[index]
     return action
 
-InitialTransformer = StrategyTransformerFactory(initial_sequence)
+InitialTransformer = StrategyTransformerFactory(initial_sequence,
+                                                name_prefix="Initial")
 
 
 def final_sequence(player, opponent, action, seq):
@@ -210,7 +216,8 @@ def final_sequence(player, opponent, action, seq):
         return seq[-index]
     return action
 
-FinalTransformer = StrategyTransformerFactory(final_sequence)
+FinalTransformer = StrategyTransformerFactory(final_sequence,
+                                              name_prefix="Final")
 
 
 def history_track_wrapper(player, opponent, action):
@@ -222,7 +229,7 @@ def history_track_wrapper(player, opponent, action):
     return action
 
 TrackHistoryTransformer = StrategyTransformerFactory(
-    history_track_wrapper, name_prefix="HistoryTracking")()
+    history_track_wrapper, name_prefix="HistoryTracking")
 
 
 def deadlock_break_wrapper(player, opponent, action):
@@ -238,7 +245,7 @@ def deadlock_break_wrapper(player, opponent, action):
     return action
 
 DeadlockBreakingTransformer = StrategyTransformerFactory(
-    deadlock_break_wrapper, name_prefix="DeadlockBreaking")()
+    deadlock_break_wrapper, name_prefix="DeadlockBreaking")
 
 
 def grudge_wrapper(player, opponent, action, grudges):
@@ -345,4 +352,4 @@ class RetaliationUntilApologyWrapper(object):
         return action
 
 RetaliateUntilApologyTransformer = StrategyTransformerFactory(
-    RetaliationUntilApologyWrapper(), name_prefix="RUA")()
+    RetaliationUntilApologyWrapper(), name_prefix="RUA")

--- a/axelrod/tests/unit/test_strategy_transformers.py
+++ b/axelrod/tests/unit/test_strategy_transformers.py
@@ -21,12 +21,12 @@ class TestTransformers(unittest.TestCase):
         # choices (like use of super) do not cause issues
         for s in axelrod.ordinary_strategies:
             opponent = axelrod.Cooperator()
-            player = IdentityTransformer(s)()
+            player = IdentityTransformer()(s)()
             player.play(opponent)
 
     def test_naming(self):
         """Tests that the player and class names are properly modified."""
-        cls = FlipTransformer(axelrod.Cooperator)
+        cls = FlipTransformer()(axelrod.Cooperator)
         p1 = cls()
         self.assertEqual(cls.__name__, "FlippedCooperator")
         self.assertEqual(p1.name, "Flipped Cooperator")
@@ -45,7 +45,7 @@ class TestTransformers(unittest.TestCase):
         """Tests that Player.clone preserves the application of transformations.
         """
         p1 = axelrod.Cooperator()
-        p2 = FlipTransformer(axelrod.Cooperator)() # Defector
+        p2 = FlipTransformer()(axelrod.Cooperator)() # Defector
         p3 = p2.clone()
         self.assertEqual(simulate_play(p1, p3), (C, D))
         self.assertEqual(simulate_play(p1, p3), (C, D))
@@ -63,7 +63,7 @@ class TestTransformers(unittest.TestCase):
     def test_flip_transformer(self):
         """Tests that FlipTransformer(Cooperator) == Defector."""
         p1 = axelrod.Cooperator()
-        p2 = FlipTransformer(axelrod.Cooperator)() # Defector
+        p2 = FlipTransformer()(axelrod.Cooperator)() # Defector
         self.assertEqual(simulate_play(p1, p2), (C, D))
         self.assertEqual(simulate_play(p1, p2), (C, D))
         self.assertEqual(simulate_play(p1, p2), (C, D))
@@ -122,7 +122,7 @@ class TestTransformers(unittest.TestCase):
     def test_history_track(self):
         """Tests the history tracking transformer."""
         p1 = axelrod.Cooperator()
-        p2 = TrackHistoryTransformer(axelrod.Random)()
+        p2 = TrackHistoryTransformer()(axelrod.Random)()
         for _ in range(6):
             p1.play(p2)
         self.assertEqual(p2.history, p2._recorded_history)
@@ -181,7 +181,7 @@ class TestTransformers(unittest.TestCase):
 
     def test_retaliation_until_apology(self):
         """Tests the RetaliateUntilApologyTransformer."""
-        TFT = RetaliateUntilApologyTransformer(axelrod.Cooperator)
+        TFT = RetaliateUntilApologyTransformer()(axelrod.Cooperator)
         p1 = TFT()
         p2 = axelrod.Cooperator()
         p1.play(p2)
@@ -276,7 +276,7 @@ class TestTransformers(unittest.TestCase):
         # Now let's use the transformer to break the deadlock to achieve
         # Mutual cooperation
         p1 = axelrod.TitForTat()
-        p2 = DeadlockBreakingTransformer(InitialTransformer([D])(axelrod.TitForTat))()
+        p2 = DeadlockBreakingTransformer()(InitialTransformer([D])(axelrod.TitForTat))()
         for _ in range(4):
             p1.play(p2)
         self.assertEqual(p1.history, [C, D, C, C])
@@ -301,9 +301,9 @@ class TestTransformers(unittest.TestCase):
     def test_nilpotency(self):
         """Show that some of the transformers are (sometimes) nilpotent, i.e.
         that transfomer(transformer(PlayerClass)) == PlayerClass"""
-        for transformer in [IdentityTransformer,
-                            FlipTransformer,
-                            TrackHistoryTransformer]:
+        for transformer in [IdentityTransformer(),
+                            FlipTransformer(),
+                            TrackHistoryTransformer()]:
             for PlayerClass in [axelrod.Cooperator, axelrod.Defector]:
                 for third_player in [axelrod.Cooperator(), axelrod.Defector()]:
                     player = PlayerClass()
@@ -320,13 +320,13 @@ class TestTransformers(unittest.TestCase):
         transfomer(transformer(PlayerClass)) == transformer(PlayerClass).
         That means that the transformer is a projection on the set of
         strategies."""
-        for transformer in [IdentityTransformer, GrudgeTransformer(1),
+        for transformer in [IdentityTransformer(), GrudgeTransformer(1),
                             FinalTransformer([C]), FinalTransformer([D]),
                             InitialTransformer([C]), InitialTransformer([D]),
-                            DeadlockBreakingTransformer,
+                            DeadlockBreakingTransformer(),
                             RetaliationTransformer(1),
-                            RetaliateUntilApologyTransformer,
-                            TrackHistoryTransformer,
+                            RetaliateUntilApologyTransformer(),
+                            TrackHistoryTransformer(),
                             ApologyTransformer([D], [C])]:
             for PlayerClass in [axelrod.Cooperator, axelrod.Defector]:
                 for third_player in [axelrod.Cooperator(), axelrod.Defector()]:
@@ -345,24 +345,18 @@ class TestTransformers(unittest.TestCase):
         the implementation matters, not just the outcomes."""
         # Difference between Alternator and CyclerCD
         p1 = axelrod.Cycler(cycle="CD")
-        p2 = FlipTransformer(axelrod.Cycler)(cycle="CD")
+        p2 = FlipTransformer()(axelrod.Cycler)(cycle="CD")
         for _ in range(5):
             p1.play(p2)
         self.assertEqual(p1.history, [C, D, C, D, C])
         self.assertEqual(p2.history, [D, C, D, C, D])
 
         p1 = axelrod.Alternator()
-        p2 = FlipTransformer(axelrod.Alternator)()
+        p2 = FlipTransformer()(axelrod.Alternator)()
         for _ in range(5):
             p1.play(p2)
         self.assertEqual(p1.history, [C, D, C, D, C])
         self.assertEqual(p2.history, [D, D, D, D, D])
-
-    def test_namespace(self):
-        test_object = TestClass()
-        self.assertEqual(
-            test_object.__class__,
-            axelrod.tests.unit.test_strategy_transformers.TestClass)
 
 
 # Test that RUA(Cooperator) is the same as TitForTat
@@ -372,7 +366,7 @@ class TestTransformers(unittest.TestCase):
 # this alters Cooperator's class variable, and causes its test to fail
 # So for now this is commented out.
 
-TFT = RetaliateUntilApologyTransformer(axelrod.Cooperator)
+TFT = RetaliateUntilApologyTransformer()(axelrod.Cooperator)
 
 class TestRUAisTFT(TestTitForTat):
     # This runs the 7 TFT tests when unittest is invoked
@@ -388,7 +382,7 @@ class TestRUAisTFT(TestTitForTat):
     }
 
 # Test that FlipTransformer(Defector) == Cooperator
-Cooperator2 = FlipTransformer(axelrod.Defector)
+Cooperator2 = FlipTransformer()(axelrod.Defector)
 
 class TestFlipDefector(TestCooperator):
     # This runs the 7 TFT tests when unittest is invoked

--- a/docs/tutorials/advanced/strategy_transformers.rst
+++ b/docs/tutorials/advanced/strategy_transformers.rst
@@ -12,7 +12,7 @@ C to D and D to C::
 
     >>> import axelrod
     >>> from axelrod.strategy_transformers import *
-    >>> FlippedCooperator = FlipTransformer(axelrod.Cooperator)
+    >>> FlippedCooperator = FlipTransformer()(axelrod.Cooperator)
     >>> player = FlippedCooperator()
     >>> opponent = axelrod.Cooperator()
     >>> player.strategy(opponent)
@@ -29,15 +29,17 @@ class and player::
     >>> FlippedCooperator.name
     'Flipped Cooperator'
 
-This behavor can be supressed by setting the :code:`name_prefix` argument::
+This behavior can be suppressed by setting the :code:`name_prefix` argument::
 
-    FlipTransformer = StrategyTransformerFactory(flip_wrapper, name_prefix="")()
+    >>> FlippedCooperator = FlipTransformer(name_prefix=None)(axelrod.Cooperator)
+    >>> player = FlippedCooperator()
+    >>> player.name
+    'Cooperator'
 
 Note carefully that the transformer returns a class, not an instance of a class.
 This means that you need to use the Transformed class as you would normally to
 create a new instance::
 
-    >>> import axelrod
     >>> from axelrod.strategy_transformers import NoisyTransformer
     >>> player = NoisyTransformer(0.5)(axelrod.Cooperator)()
 
@@ -52,7 +54,7 @@ The library includes the following transformers:
 
     >>> import axelrod
     >>> from axelrod.strategy_transformers import FlipTransformer
-    >>> FlippedCooperator = FlipTransformer(axelrod.Cooperator)
+    >>> FlippedCooperator = FlipTransformer()(axelrod.Cooperator)
     >>> player = FlippedCooperator()
 
 * :code:`NoisyTransformer(noise)`: Flips actions with probability :code:`noise`::
@@ -94,7 +96,7 @@ The library includes the following transformers:
 
     >>> import axelrod
     >>> from axelrod.strategy_transformers import RetaliateUntilApologyTransformer
-    >>> TFT = RetaliateUntilApologyTransformer(axelrod.Cooperator)
+    >>> TFT = RetaliateUntilApologyTransformer()(axelrod.Cooperator)
     >>> player = TFT()
 
 * :code:`ApologizingTransformer`: Apologizes after a round of :code:`(D, C)`::
@@ -116,7 +118,7 @@ The library includes the following transformers:
 
     >>> import axelrod
     >>> from axelrod.strategy_transformers import DeadlockBreakingTransformer
-    >>> DeadlockBreakingTFT = DeadlockBreakingTransformer(axelrod.TitForTat)
+    >>> DeadlockBreakingTFT = DeadlockBreakingTransformer()(axelrod.TitForTat)
     >>> player = DeadlockBreakingTFT()
 
 * :code:`GrudgeTransformer(N)`: Defections unconditionally after more than N defections::
@@ -130,7 +132,7 @@ The library includes the following transformers:
 
     >>> import axelrod
     >>> from axelrod.strategy_transformers import TrackHistoryTransformer
-    >>> player = TrackHistoryTransformer(axelrod.Random)()
+    >>> player = TrackHistoryTransformer()(axelrod.Random)()
 
 * :code:`MixedTransformer`: Randomly plays a mutation to another strategy (or
   set of strategies. Here is the syntax to do this with a set of strategies::


### PR DESCRIPTION
Closes #642

This makes all transformers have the same behaviour. They need to be
called to work: previous to this, only transformers with arguments
needed to be called.