### PR TITLE
Caching the hypothesis db.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ python:
   - 2.7
   - 3.4
   - 3.5
+
+cache:
+  directories:
+    - $TRAVIS_BUILD_DIR/.hypothesis
+
 before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
(I believe) this closes #595.

It caches the hypothesis failure database. It just means that travis will keep track of parts of the test space for which tests previously failed.