### PR TITLE
Changing strategy lists

### DIFF
--- a/axelrod/strategies/__init__.py
+++ b/axelrod/strategies/__init__.py
@@ -12,11 +12,11 @@ from .meta import (
     MetaMixer
     )
 
-recursive_strategies = [MetaHunter, MetaMajority, MetaMinority, MetaWinner,
+long_run_time_strategies = [MetaHunter, MetaMajority, MetaMinority, MetaWinner,
                    MetaMajorityMemoryOne, MetaWinnerMemoryOne,
                    MetaMajorityFiniteMemory, MetaWinnerFiniteMemory,
                    MetaMajorityLongMemory, MetaWinnerLongMemory, MetaMixer]
-all_strategies.extend(recursive_strategies)
+all_strategies.extend(long_run_time_strategies)
 
 # Distinguished strategy collections in addition to
 # `all_strategies` from _strategies.py

--- a/axelrod/strategies/__init__.py
+++ b/axelrod/strategies/__init__.py
@@ -12,15 +12,18 @@ from .meta import (
     MetaMixer
     )
 
-strategies.extend((MetaHunter, MetaMajority, MetaMinority, MetaWinner,
+recursive_strategies = [MetaHunter, MetaMajority, MetaMinority, MetaWinner,
                    MetaMajorityMemoryOne, MetaWinnerMemoryOne,
                    MetaMajorityFiniteMemory, MetaWinnerFiniteMemory,
-                   MetaMajorityLongMemory, MetaWinnerLongMemory, MetaMixer))
+                   MetaMajorityLongMemory, MetaWinnerLongMemory, MetaMixer]
+all_strategies.extend(recursive_strategies)
 
 # Distinguished strategy collections in addition to
-# `strategies` from _strategies.py
+# `all_strategies` from _strategies.py
 
 demo_strategies = [Cooperator, Defector, TitForTat, Grudger, Random]
-basic_strategies = [s for s in strategies if is_basic(s())]
-ordinary_strategies = [s for s in strategies if obey_axelrod(s())]
-cheating_strategies = [s for s in strategies if not obey_axelrod(s())]
+basic_strategies = [s for s in all_strategies if is_basic(s())]
+strategies = [s for s in all_strategies if obey_axelrod(s())]
+cheating_strategies = [s for s in all_strategies if not obey_axelrod(s())]
+
+ordinary_strategies = strategies  # This is a legacy and will be removed

--- a/axelrod/strategies/__init__.py
+++ b/axelrod/strategies/__init__.py
@@ -12,10 +12,13 @@ from .meta import (
     MetaMixer
     )
 
-long_run_time_strategies = [MetaHunter, MetaMajority, MetaMinority, MetaWinner,
+all_strategies.append(MetaHunter)
+
+long_run_time_strategies = [MetaMajority, MetaMinority, MetaWinner,
                    MetaMajorityMemoryOne, MetaWinnerMemoryOne,
                    MetaMajorityFiniteMemory, MetaWinnerFiniteMemory,
                    MetaMajorityLongMemory, MetaWinnerLongMemory, MetaMixer]
+
 all_strategies.extend(long_run_time_strategies)
 
 # Distinguished strategy collections in addition to

--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -61,7 +61,7 @@ from .titfortat import (
 
 # Note: Meta* strategies are handled in .__init__.py
 
-strategies = [
+all_strategies = [
     Adaptive,
     Aggravater,
     ALLCorALLD,

--- a/axelrod/strategies/meta.py
+++ b/axelrod/strategies/meta.py
@@ -1,11 +1,11 @@
 from axelrod import Actions, Player, obey_axelrod
-from ._strategies import strategies
+from ._strategies import all_strategies
 from .hunter import DefectorHunter, AlternatorHunter, RandomHunter, MathConstantHunter, CycleHunter, EventualCycleHunter
 from .cooperator import Cooperator
 from numpy.random import choice
 
 # Needs to be computed manually to prevent circular dependency
-ordinary_strategies = [s for s in strategies if obey_axelrod(s)]
+ordinary_strategies = [s for s in all_strategies if obey_axelrod(s)]
 C, D = Actions.C, Actions.D
 
 class MetaPlayer(Player):

--- a/axelrod/tests/integration/test_matches.py
+++ b/axelrod/tests/integration/test_matches.py
@@ -8,10 +8,10 @@ from axelrod.tests.property import strategy_lists
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
 
-deterministic_strategies = [s for s in axelrod.ordinary_strategies
+deterministic_strategies = [s for s in axelrod.strategies
                             if not s().classifier['stochastic']]  # Well behaved strategies
 
-stochastic_strategies = [s for s in axelrod.ordinary_strategies
+stochastic_strategies = [s for s in axelrod.strategies
                          if s().classifier['stochastic']]
 
 

--- a/axelrod/tests/integration/test_tournament.py
+++ b/axelrod/tests/integration/test_tournament.py
@@ -30,7 +30,7 @@ class TestTournament(unittest.TestCase):
 
     def test_full_tournament(self):
         """A test to check that tournament runs with all non cheating strategies."""
-        strategies = [strategy() for strategy in axelrod.ordinary_strategies]
+        strategies = [strategy() for strategy in axelrod.strategies]
         tournament = axelrod.Tournament(name='test', players=strategies,
                                         game=self.game, turns=2,
                                         repetitions=2)
@@ -63,7 +63,7 @@ class TestTournament(unittest.TestCase):
 
     def test_repeat_tournament_deterministic(self):
         """A test to check that tournament gives same results."""
-        deterministic_players = [s() for s in axelrod.ordinary_strategies
+        deterministic_players = [s() for s in axelrod.strategies
                                  if not s().classifier['stochastic']]
         files = []
         for _ in range(2):
@@ -83,7 +83,7 @@ class TestTournament(unittest.TestCase):
         files = []
         for _ in range(2):
             axelrod.seed(0)
-            stochastic_players = [s() for s in axelrod.ordinary_strategies
+            stochastic_players = [s() for s in axelrod.strategies
                                   if s().classifier['stochastic']]
             tournament = axelrod.Tournament(name='test',
                                             players=stochastic_players,

--- a/axelrod/tests/unit/test_classification.py
+++ b/axelrod/tests/unit/test_classification.py
@@ -165,8 +165,25 @@ class TestStrategies(unittest.TestCase):
                               axelrod.long_run_time_strategies]:
             self.assertTrue(set(strategy_list).issubset(strategies_set))
 
+    def test_long_run_strategies(self):
+        long_run_time_strategies = [axelrod.MetaMajority,
+                                    axelrod.MetaMinority,
+                                    axelrod.MetaWinner,
+                                    axelrod.MetaMajorityMemoryOne,
+                                    axelrod.MetaWinnerMemoryOne,
+                                    axelrod.MetaMajorityFiniteMemory,
+                                    axelrod.MetaWinnerFiniteMemory,
+                                    axelrod.MetaMajorityLongMemory,
+                                    axelrod.MetaWinnerLongMemory,
+                                    axelrod.MetaMixer]
+        self.assertTrue(long_run_time_strategies,
+                        axelrod.long_run_time_strategies)
+
     def test_meta_inclusion(self):
         self.assertTrue(axelrod.MetaMajority in axelrod.strategies)
+
+        self.assertTrue(axelrod.MetaHunter in axelrod.strategies)
+        self.assertFalse(axelrod.MetaHunter in axelrod.long_run_time_strategies)
 
     def test_demo_strategies(self):
         demo_strategies = [axelrod.Cooperator,

--- a/axelrod/tests/unit/test_classification.py
+++ b/axelrod/tests/unit/test_classification.py
@@ -133,7 +133,7 @@ class TestStrategies(unittest.TestCase):
         for strategy_list in ["all_strategies",
                               "demo_strategies",
                               "basic_strategies",
-                              "recursive_strategies",
+                              "long_run_time_strategies",
                               "strategies",
                               "ordinary_strategies",
                               "cheating_strategies"]:
@@ -143,7 +143,7 @@ class TestStrategies(unittest.TestCase):
         for strategy_list in [axelrod.all_strategies,
                               axelrod.demo_strategies,
                               axelrod.basic_strategies,
-                              axelrod.recursive_strategies,
+                              axelrod.long_run_time_strategies,
                               axelrod.strategies,
                               axelrod.ordinary_strategies,
                               axelrod.cheating_strategies]:
@@ -153,7 +153,7 @@ class TestStrategies(unittest.TestCase):
         all_strategies_set = set(axelrod.all_strategies)
         for strategy_list in [axelrod.demo_strategies,
                               axelrod.basic_strategies,
-                              axelrod.recursive_strategies,
+                              axelrod.long_run_time_strategies,
                               axelrod.strategies,
                               axelrod.ordinary_strategies,
                               axelrod.cheating_strategies]:
@@ -162,7 +162,7 @@ class TestStrategies(unittest.TestCase):
         strategies_set = set(axelrod.strategies)
         for strategy_list in [axelrod.demo_strategies,
                               axelrod.basic_strategies,
-                              axelrod.recursive_strategies]:
+                              axelrod.long_run_time_strategies]:
             self.assertTrue(set(strategy_list).issubset(strategies_set))
 
     def test_meta_inclusion(self):

--- a/axelrod/tests/unit/test_classification.py
+++ b/axelrod/tests/unit/test_classification.py
@@ -14,7 +14,7 @@ class TestClassification(unittest.TestCase):
                       'manipulates_source',
                       'manipulates_state']
 
-        for s in axelrod.strategies:
+        for s in axelrod.all_strategies:
             s = s()
             self.assertTrue(None not in [s.classifier[key] for key in known_keys])
 
@@ -130,20 +130,40 @@ class TestClassification(unittest.TestCase):
 class TestStrategies(unittest.TestCase):
 
     def test_strategy_list(self):
-        for strategy_list in ["strategies",
+        for strategy_list in ["all_strategies",
                               "demo_strategies",
                               "basic_strategies",
+                              "recursive_strategies",
+                              "strategies",
                               "ordinary_strategies",
                               "cheating_strategies"]:
             self.assertTrue(hasattr(axelrod, strategy_list))
 
     def test_lists_not_empty(self):
-        for strategy_list in [axelrod.strategies,
+        for strategy_list in [axelrod.all_strategies,
                               axelrod.demo_strategies,
                               axelrod.basic_strategies,
+                              axelrod.recursive_strategies,
+                              axelrod.strategies,
                               axelrod.ordinary_strategies,
                               axelrod.cheating_strategies]:
             self.assertTrue(len(strategy_list) > 0)
+
+    def test_inclusion_of_strategy_lists(self):
+        all_strategies_set = set(axelrod.all_strategies)
+        for strategy_list in [axelrod.demo_strategies,
+                              axelrod.basic_strategies,
+                              axelrod.recursive_strategies,
+                              axelrod.strategies,
+                              axelrod.ordinary_strategies,
+                              axelrod.cheating_strategies]:
+            self.assertTrue(set(strategy_list).issubset(all_strategies_set))
+
+        strategies_set = set(axelrod.strategies)
+        for strategy_list in [axelrod.demo_strategies,
+                              axelrod.basic_strategies,
+                              axelrod.recursive_strategies]:
+            self.assertTrue(set(strategy_list).issubset(strategies_set))
 
     def test_meta_inclusion(self):
         self.assertTrue(axelrod.MetaMajority in axelrod.strategies)

--- a/axelrod/tests/unit/test_strategy_transformers.py
+++ b/axelrod/tests/unit/test_strategy_transformers.py
@@ -19,7 +19,7 @@ class TestTransformers(unittest.TestCase):
     def test_all_strategies(self):
         # Attempt to transform each strategy to ensure that implementation
         # choices (like use of super) do not cause issues
-        for s in axelrod.ordinary_strategies:
+        for s in axelrod.strategies:
             opponent = axelrod.Cooperator()
             player = IdentityTransformer()(s)()
             player.play(opponent)

--- a/axelrod/tests/unit/test_titfortat.py
+++ b/axelrod/tests/unit/test_titfortat.py
@@ -383,7 +383,7 @@ class TestContriteTitForTat(TestPlayer):
         'manipulates_state': False
     }
 
-    deterministic_strategies = [s for s in axelrod.ordinary_strategies
+    deterministic_strategies = [s for s in axelrod.strategies
                                 if not s().classifier['stochastic']]
 
     @given(strategies=strategy_lists(strategies=deterministic_strategies,
@@ -432,7 +432,7 @@ class TestContriteTitForTat(TestPlayer):
         self.assertEqual(opponent.history, [C, D, D, D])
         self.assertFalse(ctft.contrite)
 
-             
+
     def test_reset_cleans_all(self):
         p = self.player()
         p.contrite = True
@@ -462,5 +462,5 @@ class TestSlowTitForTwoTats(TestPlayer):
         self.responses_test([C]*3, [C, D, C], [C])
         self.responses_test([C]*3, [C, D, D], [D])
 
-       
-  
+
+

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -35,8 +35,8 @@ test_prob_end = .5
 
 test_edges = [(0, 1), (1, 2), (3, 4)]
 
-deterministic_strategies = [s for s in axelrod.ordinary_strategies
-                            if not s().classifier['stochastic']] 
+deterministic_strategies = [s for s in axelrod.strategies
+                            if not s().classifier['stochastic']]
 
 class TestTournament(unittest.TestCase):
 

--- a/docs/tutorials/advanced/classification_of_strategies.rst
+++ b/docs/tutorials/advanced/classification_of_strategies.rst
@@ -24,7 +24,7 @@ This allows us to, for example, quickly identify all the stochastic
 strategies::
 
     >>> len([s for s in axl.strategies if s().classifier['stochastic']])
-    41
+    40
 
 Or indeed find out how many strategy only use 1 turn worth of memory to
 make a decision::

--- a/docs/tutorials/advanced/index.rst
+++ b/docs/tutorials/advanced/index.rst
@@ -8,6 +8,7 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
+   strategies.rst
    classification_of_strategies.rst
    strategy_transformers.rst
    making_tournaments.rst

--- a/docs/tutorials/advanced/strategies.rst
+++ b/docs/tutorials/advanced/strategies.rst
@@ -13,26 +13,39 @@ For example::
     Cooperator
 
 The **main strategies** which obey the rules of Axelrod's original tournament
-can be found in a list: `axelrod.strategies`. This makes creating a full
-tournament very straightforward:
+can be found in a list: `axelrod.strategies`::
+
+    >>> axelrod.strategies
+    [...
+
+This makes creating a full
+tournament very straightforward::
 
     >>> players = [s() for s in axelrod.strategies]
     >>> tournament = axelrod.Tournament(players)
 
 There are a list of various other strategies in the library to make it
-easier to create a variety of tournaments:
+easier to create a variety of tournaments::
 
-- :code:`axelrod.demo_strategies`: 5 simple strategies useful for demonstration.
-- :code:`axelrod.basic_strategies`: A set of basic strategies.
-- :code:`axelrod.recursive_strategies`: These have a high computational cost so
-  might want to be removed for some analysis.
+    >>> axelrod.demo_strategies  # 5 simple strategies useful for demonstration.
+    [...
+    >>> axelrod.basic_strategies  # A set of basic strategies.
+    [...
+    >>> axelrod.long_run_time_strategies  # These have a high computational cost
+    [...
 
 Furthermore there are some strategies that 'cheat' (for example by modifying
 their opponents source code). These can be found in
-:code:`axelrod.cheating_strategies`.
+:code:`axelrod.cheating_strategies`::
+
+    >>> axelrod.cheating_strategies
+    [...
 
 All of the strategies in the library are contained in:
-:code:`axelrod.all_strategies`.
+:code:`axelrod.all_strategies`::
+
+    >>> axelrod.all_strategies
+    [...
 
 All strategies are also classified, you can read more about that in
 :ref:`classification-of-strategies`.

--- a/docs/tutorials/advanced/strategies.rst
+++ b/docs/tutorials/advanced/strategies.rst
@@ -1,0 +1,38 @@
+.. _strategies:
+
+Accessing strategies
+====================
+
+All of the strategies are accessible from the main name space of the library.
+For example::
+
+    >>> import axelrod
+    >>> axelrod.TitForTat()
+    Tit For Tat
+    >>> axelrod.Cooperator()
+    Cooperator
+
+The **main strategies** which obey the rules of Axelrod's original tournament
+can be found in a list: `axelrod.strategies`. This makes creating a full
+tournament very straightforward:
+
+    >>> players = [s() for s in axelrod.strategies]
+    >>> tournament = axelrod.Tournament(players)
+
+There are a list of various other strategies in the library to make it
+easier to create a variety of tournaments:
+
+- :code:`axelrod.demo_strategies`: 5 simple strategies useful for demonstration.
+- :code:`axelrod.basic_strategies`: A set of basic strategies.
+- :code:`axelrod.recursive_strategies`: These have a high computational cost so
+  might want to be removed for some analysis.
+
+Furthermore there are some strategies that 'cheat' (for example by modifying
+their opponents source code). These can be found in
+:code:`axelrod.cheating_strategies`.
+
+All of the strategies in the library are contained in:
+:code:`axelrod.all_strategies`.
+
+All strategies are also classified, you can read more about that in
+:ref:`classification-of-strategies`.

--- a/docs/tutorials/contributing/strategy/adding_the_new_strategy.rst
+++ b/docs/tutorials/contributing/strategy/adding_the_new_strategy.rst
@@ -16,7 +16,7 @@ If you have added your strategy to a new file then simply add a line similar to
 above with your new strategy.
 
 Once you have done that, you need to add the class itself to the
-:code:`strategies` list (in `axelrod/strategies/_strategies.py`).
+:code:`all_strategies` list (in `axelrod/strategies/_strategies.py`).
 
 Finally, if you have created a new module (a new :code:`<strategy.py>` file)
 please add it to the `docs/references/all_strategies.rst` file so that it will

--- a/doctests.py
+++ b/doctests.py
@@ -7,7 +7,8 @@ def load_tests(loader, tests, ignore):
     for root, dirs, files in os.walk("./docs"):
         for f in files:
             if f.endswith(".rst"):
-                 tests.addTests(doctest.DocFileSuite(os.path.join(root, f)))
+                 tests.addTests(doctest.DocFileSuite(os.path.join(root, f),
+                                                  optionflags=doctest.ELLIPSIS))
 
     return tests
 


### PR DESCRIPTION
Closes #664.

This renames `strategies` to `all_strategies`, and `ordinary_strategies` to `strategies`. I've kept `ordinary_strategies` in there tough just to not break anyones code. It it worth not doing that and just 'ripping off' the bandaid?

Also, @marcharper mentioned having the meta strategies in a separate list. Here I've got them **still** in the one unique list (`strategies`) but have also created another list `recursive_strategies`. We could call that `expensive_strategies` to be more generic perhaps?

Have included a tutorial also, just listing these. I ended up putting that in further capabilities. 