### PR TITLE
Noise in Spatial Tournament

### DIFF
--- a/axelrod/match_generator.py
+++ b/axelrod/match_generator.py
@@ -189,7 +189,7 @@ class SpatialMatches(RoundRobinMatches):
         A list of tuples containing the existing edges
     """
 
-    def __init__(self, players, turns, game, repetitions, edges):
+    def __init__(self, players, turns, game, repetitions, noise, edges):
 
         player_indices = list(range(len(players)))
         node_indices = sorted(set([node for edge in edges for node in edge]))
@@ -197,13 +197,14 @@ class SpatialMatches(RoundRobinMatches):
             raise ValueError("The graph edges do not include all players.")
 
         self.edges = edges
-        super(SpatialMatches, self).__init__(players, turns, game, repetitions)
+        super(SpatialMatches, self).__init__(players, turns, game,
+                                                             repetitions, noise)
 
     def build_match_chunks(self):
         for edge in self.edges:
             match_params = self.build_single_match_params()
             index_pair = edge
-            yield (index_pair, match_params, self.repetitions)
+            yield (index_pair, match_params, self.repetitions, self.noise)
 
     def __len__(self):
         return len(self.edges)

--- a/axelrod/tests/unit/test_match_generator.py
+++ b/axelrod/tests/unit/test_match_generator.py
@@ -225,7 +225,8 @@ class TestSpatialMatches(unittest.TestCase):
             self.players, turns, test_game, repetitions, noise, edges)
         chunks = list(sp.build_match_chunks())
         match_definitions = [tuple(list(index_pair) + [repetitions])
-                             for (index_pair, match_params, repetitions) in chunks]
+                             for (index_pair, match_params, repetitions, noise)
+                                                                      in chunks]
         expected_match_definitions = [(edge[0], edge[1], repetitions)
                                       for edge in edges]
 

--- a/axelrod/tests/unit/test_match_generator.py
+++ b/axelrod/tests/unit/test_match_generator.py
@@ -44,7 +44,7 @@ class TestTournamentType(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             len(tt)
 
-    def _params(self):
+    def test_build__params(self):
         tt = axelrod.MatchGenerator(
             self.players, test_turns, test_game, test_repetitions)
         with self.assertRaises(NotImplementedError):

--- a/axelrod/tests/unit/test_match_generator.py
+++ b/axelrod/tests/unit/test_match_generator.py
@@ -44,7 +44,7 @@ class TestTournamentType(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             len(tt)
 
-    def test_build_match_params(self):
+    def _params(self):
         tt = axelrod.MatchGenerator(
             self.players, test_turns, test_game, test_repetitions)
         with self.assertRaises(NotImplementedError):
@@ -99,7 +99,7 @@ class TestRoundRobin(unittest.TestCase):
 
     @given(repetitions=integers(min_value=1, max_value=test_repetitions))
     @example(repetitions=test_repetitions)
-    def test_build_match_chunks(self, repetitions):
+    def _chunks(self, repetitions):
         rr = axelrod.RoundRobinMatches(self.players, test_turns, test_game, repetitions)
         chunks = list(rr.build_match_chunks())
         match_definitions = [tuple(list(index_pair) + [repetitions]) for (index_pair, match_params, repetitions) in chunks]
@@ -125,7 +125,7 @@ class TestProbEndRoundRobin(unittest.TestCase):
     @given(repetitions=integers(min_value=1, max_value=test_repetitions),
            prob_end=floats(min_value=0, max_value=1))
     @example(repetitions=test_repetitions, prob_end=.5)
-    def test_build_match_chunks(self, repetitions, prob_end):
+    def _chunks(self, repetitions, prob_end):
         rr = axelrod.ProbEndRoundRobinMatches(
             self.players, prob_end, test_game, repetitions)
         chunks = list(rr.build_match_chunks())
@@ -135,7 +135,7 @@ class TestProbEndRoundRobin(unittest.TestCase):
         self.assertEqual(sorted(match_definitions), sorted(expected_match_definitions))
 
     @given(prob_end=floats(min_value=0.1, max_value=0.5))
-    def test_build_matches_different_length(self, prob_end):
+    def es_different_length(self, prob_end):
         """
         If prob end is not 0 or 1 then the matches should all have different
         length
@@ -218,10 +218,11 @@ class TestSpatialMatches(unittest.TestCase):
     @given(repetitions=integers(min_value=1, max_value=test_repetitions),
            turns=integers(min_value=1, max_value=test_turns))
     @example(repetitions=test_repetitions, turns=test_turns)
-    def test_build_match_chunks(self, repetitions, turns):
+    def _chunks(self, repetitions, turns):
         edges = [(0, 1), (1, 2), (3, 4)]
+        noise = 0
         sp = axelrod.SpatialMatches(
-            self.players, turns, test_game, repetitions, edges)
+            self.players, turns, test_game, repetitions, noise, edges)
         chunks = list(sp.build_match_chunks())
         match_definitions = [tuple(list(index_pair) + [repetitions])
                              for (index_pair, match_params, repetitions) in chunks]
@@ -232,7 +233,20 @@ class TestSpatialMatches(unittest.TestCase):
 
     def test_len(self):
         edges = [(0, 1), (1, 2), (3, 4)]
+        noise = 0
         sp = axelrod.SpatialMatches(
-            self.players, test_turns, test_game, test_repetitions, edges)
+            self.players, test_turns, test_game, test_repetitions, noise, edges)
         self.assertEqual(len(sp), len(list(sp.build_match_chunks())))
         self.assertEqual(len(sp), len(edges))
+
+    @given(noise=floats(min_value=0, max_value=1))
+    def test_noise(self, noise):
+        edges = [(0, 1), (1, 2), (3, 4)]
+        sp = axelrod.SpatialMatches(
+            self.players, test_turns, test_game, test_repetitions, noise, edges)
+        self.assertEqual(sp.noise, noise)
+        chunks = sp.build_match_chunks()
+        noise_values = [match_params[3]
+                        for (index_pair, match_params, turns, repetitions) in chunks]
+        for value in noise_values:
+            self.assertEqual(noise, value)

--- a/axelrod/tests/unit/test_match_generator.py
+++ b/axelrod/tests/unit/test_match_generator.py
@@ -44,7 +44,7 @@ class TestTournamentType(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             len(tt)
 
-    def test_build__params(self):
+    def test_build_match_params(self):
         tt = axelrod.MatchGenerator(
             self.players, test_turns, test_game, test_repetitions)
         with self.assertRaises(NotImplementedError):
@@ -99,7 +99,7 @@ class TestRoundRobin(unittest.TestCase):
 
     @given(repetitions=integers(min_value=1, max_value=test_repetitions))
     @example(repetitions=test_repetitions)
-    def _chunks(self, repetitions):
+    def test_build_match_chunks(self, repetitions):
         rr = axelrod.RoundRobinMatches(self.players, test_turns, test_game, repetitions)
         chunks = list(rr.build_match_chunks())
         match_definitions = [tuple(list(index_pair) + [repetitions]) for (index_pair, match_params, repetitions) in chunks]
@@ -125,7 +125,7 @@ class TestProbEndRoundRobin(unittest.TestCase):
     @given(repetitions=integers(min_value=1, max_value=test_repetitions),
            prob_end=floats(min_value=0, max_value=1))
     @example(repetitions=test_repetitions, prob_end=.5)
-    def _chunks(self, repetitions, prob_end):
+    def test_build_match_chunks(self, repetitions, prob_end):
         rr = axelrod.ProbEndRoundRobinMatches(
             self.players, prob_end, test_game, repetitions)
         chunks = list(rr.build_match_chunks())
@@ -135,7 +135,7 @@ class TestProbEndRoundRobin(unittest.TestCase):
         self.assertEqual(sorted(match_definitions), sorted(expected_match_definitions))
 
     @given(prob_end=floats(min_value=0.1, max_value=0.5))
-    def es_different_length(self, prob_end):
+    def test_build_matches_different_length(self, prob_end):
         """
         If prob end is not 0 or 1 then the matches should all have different
         length
@@ -218,7 +218,7 @@ class TestSpatialMatches(unittest.TestCase):
     @given(repetitions=integers(min_value=1, max_value=test_repetitions),
            turns=integers(min_value=1, max_value=test_turns))
     @example(repetitions=test_repetitions, turns=test_turns)
-    def _chunks(self, repetitions, turns):
+    def test_build_match_chunks(self, repetitions, turns):
         edges = [(0, 1), (1, 2), (3, 4)]
         noise = 0
         sp = axelrod.SpatialMatches(

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -35,6 +35,7 @@ test_prob_end = .5
 
 test_edges = [(0, 1), (1, 2), (3, 4)]
 
+
 deterministic_strategies = [s for s in axelrod.strategies
                             if not s().classifier['stochastic']]
 

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -35,7 +35,10 @@ test_prob_end = .5
 
 test_edges = [(0, 1), (1, 2), (3, 4)]
 
+<<<<<<< HEAD
 
+=======
+>>>>>>> Ordinary_strategies to strategies.
 deterministic_strategies = [s for s in axelrod.strategies
                             if not s().classifier['stochastic']]
 

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -35,10 +35,7 @@ test_prob_end = .5
 
 test_edges = [(0, 1), (1, 2), (3, 4)]
 
-<<<<<<< HEAD
 
-=======
->>>>>>> Ordinary_strategies to strategies.
 deterministic_strategies = [s for s in axelrod.strategies
                             if not s().classifier['stochastic']]
 

--- a/axelrod/tournament.py
+++ b/axelrod/tournament.py
@@ -381,4 +381,4 @@ class SpatialTournament(Tournament):
 
         self.edges = edges
         self.match_generator = SpatialMatches(
-            players, turns, self.game, repetitions, edges)
+            players, turns, self.game, repetitions, self.noise, edges)


### PR DESCRIPTION
Closes #673 

The bug seems to have been my fault as I was not passing the argument noise to either
the `SpatialMatches` generator or the `SpatialTournament` class. 

It has been corrected and also I added a test for the noise in the `test_match_generator` arcooding to @drvinceknight work in the `TestProbEndSpatialTournament`. 

Locally all 1595 tests seems to be running fine. Let's see what Travis has to say. 