### PR TITLE
Add build directory to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *pyc
 *.DS_Store
 site/
+build/
 _build/
 *.log
 dist/


### PR DESCRIPTION
This has caught people out on a couple of recent PRs (#697 and #693). I don't actually
know what this directory is for and/or where it comes from (never seen
it on my machine).