### PR TITLE
Add summary method to result set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ Axelrod.egg-info
 basic_strategies.csv
 cache.txt
 test.csv
+summary.csv
 basic_tournament.csv

--- a/docs/tutorials/getting_started/tournament_results.rst
+++ b/docs/tutorials/getting_started/tournament_results.rst
@@ -233,3 +233,29 @@ of the cooperation rating::
     [0.57..., 0.0, 0.57..., 0.57...]
 
 For more information about these see :ref:`morality-metrics`.
+
+Summarising a tournament
+------------------------
+
+The results set can also return a list of named tuples, ordered by strategy rank
+that summarises the results of the tournament::
+
+    >>> summary = results.summarise()
+    >>> pprint.pprint(summary)
+    [Player(Rank=0, Name='Defector', Median_score=2.6..., Cooperation_rating=0.0, Wins=3.0),
+     Player(Rank=1, Name='Tit For Tat', Median_score=2.3..., Cooperation_rating=0.7, Wins=0.0),
+     Player(Rank=2, Name='Grudger', Median_score=2.3..., Cooperation_rating=0.7, Wins=0.0),
+     Player(Rank=3, Name='Cooperator', Median_score=2.0..., Cooperation_rating=1.0, Wins=0.0)]
+
+It is also possible to write this data directly to a csv file using the
+`write_summary` method::
+
+    >>> results.write_summary('summary.csv')
+    >>> with open('summary.csv', 'r') as outfile:
+    ...     out = outfile.read()
+    >>> pprint.pprint(out)
+    ('Rank,Name,Median_score,Cooperation_rating,Wins\n'
+     '0,Defector,2.6,0.0,3.0\n'
+     '1,Tit For Tat,2.3,0.7,0.0\n'
+     '2,Grudger,2.3,0.7,0.0\n'
+     '3,Cooperator,2.0,1.0,0.0\n')

--- a/docs/tutorials/getting_started/tournament_results.rst
+++ b/docs/tutorials/getting_started/tournament_results.rst
@@ -251,11 +251,13 @@ It is also possible to write this data directly to a csv file using the
 `write_summary` method::
 
     >>> results.write_summary('summary.csv')
+    >>> import csv
     >>> with open('summary.csv', 'r') as outfile:
-    ...     out = outfile.read()
-    >>> pprint.pprint(out)
-    ('Rank,Name,Median_score,Cooperation_rating,Wins\n'
-     '0,Defector,2.6,0.0,3.0\n'
-     '1,Tit For Tat,2.3,0.7,0.0\n'
-     '2,Grudger,2.3,0.7,0.0\n'
-     '3,Cooperator,2.0,1.0,0.0\n')
+    ...     csvreader = csv.reader(outfile)
+    ...     for row in csvreader:
+    ...         print(row)
+    ['Rank', 'Name', 'Median_score', 'Cooperation_rating', 'Wins']
+    ['0', 'Defector', '2.6...', '0.0', '3.0']
+    ['1', 'Tit For Tat', '2.3...', '0.7', '0.0']
+    ['2', 'Grudger', '2.3...', '0.7', '0.0']
+    ['3', 'Cooperator', '2.0...', '1.0', '0.0']


### PR DESCRIPTION
Addresses one part of #701

Have not added the part to write to file, thought that could be left outside of the library (users could choose to write it to csv, json etc...: once we've got the list of named tuples it's easy enough to do)? Not terribly sure though so happy enough to add it in.

At the moment I've just included the following tournament results:

- Rank
- Name
- Score
- Cooperation rating
- Wins

Easy enough to add more.