### PR TITLE
Run CI tests on Windows with Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,5 +5,6 @@ environment:
     - PYTHON: "C:\\Python35"
 install:
   - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
+build: off
 test_script:
   - "%PYTHON%\\python.exe -m unittest discover"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,9 @@
+environment:
+  matrix:
+    - PYTHON: "C:\\Python27"
+    - PYTHON: "C:\\Python34"
+    - PYTHON: "C:\\Python35"
+install:
+  - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
+test_script:
+  - "%PYTHON%\\python.exe -m unittest discover"


### PR DESCRIPTION
You'll need to set up an account at appveyor.com.  See [these instructions](https://packaging.python.org/appveyor/#setting-up).