### PR TITLE
Track CC, CD, DC, DD in Player class

### DIFF
--- a/axelrod/__init__.py
+++ b/axelrod/__init__.py
@@ -9,7 +9,8 @@ from .actions import Actions, flip_action
 from .random_ import random_choice, seed
 from .plot import Plot
 from .game import DefaultGame, Game
-from .player import init_args, is_basic, obey_axelrod, update_history, Player
+from .player import get_state_distribution_from_history, init_args, is_basic, \
+    obey_axelrod, update_history, update_state_distribution, Player
 from .mock_player import MockPlayer, simulate_play
 from .match import Match
 from .moran import MoranProcess

--- a/axelrod/mock_player.py
+++ b/axelrod/mock_player.py
@@ -1,5 +1,6 @@
 import copy
-from axelrod import Player, update_history, Actions
+from axelrod import get_state_distribution_from_history, Player, \
+    update_history, update_state_distribution,  Actions
 
 C, D = Actions.C, Actions.D
 
@@ -37,6 +38,9 @@ def simulate_play(P1, P2, h1=None, h2=None):
         # Update Cooperation / Defection counts
         update_history(P1, h1)
         update_history(P2, h2)
+        get_state_distribution_from_history(P1, h1, h2)
+        get_state_distribution_from_history(P2, h2, h1)
+
         return (h1, h2)
     else:
         s1 = P1.strategy(P2)
@@ -44,4 +48,6 @@ def simulate_play(P1, P2, h1=None, h2=None):
         # Record history
         update_history(P1, s1)
         update_history(P2, s2)
+        update_state_distribution(P1, s1, s2)
+        update_state_distribution(P2, s2, s1)
         return (s1, s2)

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -53,10 +53,10 @@ def update_history(player, move):
         player.defections += 1
 
 
-def update_play_counts(player, move, reply):
-    """Updates play_counts following play. """
-    last_round = (move, reply)
-    player.play_counts[last_round] += 1
+def update_state_distribution(player, action, reply):
+    """Updates state_distribution following play. """
+    last_turn = (action, reply)
+    player.state_distribution[last_turn] += 1
 
 
 def init_args(func):
@@ -104,7 +104,7 @@ class Player(object):
                 self.classifier[dimension] = self.default_classifier[dimension]
         self.cooperations = 0
         self.defections = 0
-        self.play_counts = defaultdict(int)
+        self.state_distribution = defaultdict(int)
         self.init_args = ()
         self.set_match_attributes()
 
@@ -149,8 +149,8 @@ class Player(object):
             s1, s2 = self._add_noise(noise, s1, s2)
         update_history(self, s1)
         update_history(opponent, s2)
-        update_play_counts(self, s1, s2)
-        update_play_counts(opponent, s2, s1)
+        update_state_distribution(self, s1, s2)
+        update_state_distribution(opponent, s2, s1)
 
     def clone(self):
         """Clones the player without history, reapplying configuration
@@ -174,4 +174,4 @@ class Player(object):
         self.history = []
         self.cooperations = 0
         self.defections = 0
-        self.play_counts = defaultdict(int)
+        self.state_distribution = defaultdict(int)

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from functools import wraps
 import random
 import copy
@@ -52,6 +53,12 @@ def update_history(player, move):
         player.defections += 1
 
 
+def update_play_counts(player, move, reply):
+    """Updates play_counts following play. """
+    last_round = (move, reply)
+    player.play_counts[last_round] += 1
+
+
 def init_args(func):
     """Decorator to simplify the handling of init_args. Use whenever overriding
     Player.__init__ in subclasses of Player that require arguments as follows:
@@ -97,6 +104,7 @@ class Player(object):
                 self.classifier[dimension] = self.default_classifier[dimension]
         self.cooperations = 0
         self.defections = 0
+        self.play_counts = defaultdict(int)
         self.init_args = ()
         self.set_match_attributes()
 
@@ -141,6 +149,8 @@ class Player(object):
             s1, s2 = self._add_noise(noise, s1, s2)
         update_history(self, s1)
         update_history(opponent, s2)
+        update_play_counts(self, s1, s2)
+        update_play_counts(opponent, s2, s1)
 
     def clone(self):
         """Clones the player without history, reapplying configuration
@@ -164,3 +174,4 @@ class Player(object):
         self.history = []
         self.cooperations = 0
         self.defections = 0
+        self.play_counts = defaultdict(int)

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -53,6 +53,12 @@ def update_history(player, move):
         player.defections += 1
 
 
+def get_state_distribution_from_history(player, history1, history2):
+    """Gets state_distribution from player's and opponent's histories"""
+    for action, reply in zip(history1, history2):
+        update_state_distribution(player, action, reply)
+
+
 def update_state_distribution(player, action, reply):
     """Updates state_distribution following play. """
     last_turn = (action, reply)

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -53,9 +53,9 @@ def update_history(player, move):
         player.defections += 1
 
 
-def get_state_distribution_from_history(player, history1, history2):
-    """Gets state_distribution from player's and opponent's histories"""
-    for action, reply in zip(history1, history2):
+def get_state_distribution_from_history(player, history_1, history_2):
+    """Gets state_distribution from player's and opponent's histories."""
+    for action, reply in zip(history_1, history_2):
         update_state_distribution(player, action, reply)
 
 

--- a/axelrod/tests/unit/test_player.py
+++ b/axelrod/tests/unit/test_player.py
@@ -74,15 +74,15 @@ class TestPlayerClass(unittest.TestCase):
 
     def test_state_distribution(self):
         p1, p2 = self.player(), self.player()
-        history_1 = [C, C, D, D, C, D]
-        history_2 = [C, D, C, D, D, C]
+        history_1 = [C, C, D, D, C]
+        history_2 = [C, D, C, D, D]
         p1.strategy = randomize
         p2.strategy = randomize
         simulate_play(p1, p2, history_1, history_2)
         self.assertEqual(p1.state_distribution,
-                         {(C, C): 1, (C, D): 2, (D, C): 2, (D, D): 1})
+                         {(C, C): 1, (C, D): 2, (D, C): 1, (D, D): 1})
         self.assertEqual(p2.state_distribution,
-                         {(C, C): 1, (C, D): 2, (D, C): 2, (D, D): 1})
+                         {(C, C): 1, (C, D): 1, (D, C): 2, (D, D): 1})
 
     def test_noisy_play(self):
         random.seed(1)

--- a/axelrod/tests/unit/test_player.py
+++ b/axelrod/tests/unit/test_player.py
@@ -52,6 +52,10 @@ class TestPlayerClass(unittest.TestCase):
         self.assertEqual(p1.defections, 0)
         self.assertEqual(p2.cooperations, 0)
         self.assertEqual(p2.defections, 1)
+        # Test play counts
+        self.assertEqual(p1.play_counts, {(C, D): 1})
+        self.assertEqual(p2.play_counts, {(D, C): 1})
+
         p1.play(p2)
         self.assertEqual(p1.history[-1], C)
         self.assertEqual(p2.history[-1], D)
@@ -60,6 +64,9 @@ class TestPlayerClass(unittest.TestCase):
         self.assertEqual(p1.defections, 0)
         self.assertEqual(p2.cooperations, 0)
         self.assertEqual(p2.defections, 2)
+        # Test play counts
+        self.assertEqual(p1.play_counts, {(C, D): 2})
+        self.assertEqual(p2.play_counts, {(D, C): 2})
 
     def test_noisy_play(self):
         random.seed(1)
@@ -172,6 +179,7 @@ class TestPlayer(unittest.TestCase):
         self.assertEqual(p.history, [])
         self.assertEqual(self.player().cooperations, 0)
         self.assertEqual(self.player().defections, 0)
+        self.assertEqual(self.player().play_counts, {})
 
     def test_clone(self):
         # Make sure that self.init_args has the right number of arguments
@@ -190,6 +198,7 @@ class TestPlayer(unittest.TestCase):
         self.assertEqual(len(p2.history), 0)
         self.assertEqual(p2.cooperations, 0)
         self.assertEqual(p2.defections, 0)
+        self.assertEqual(p2.play_counts, {})
         self.assertEqual(p2.classifier, p1.classifier)
         self.assertEqual(p2.match_attributes, p1.match_attributes)
 

--- a/axelrod/tests/unit/test_player.py
+++ b/axelrod/tests/unit/test_player.py
@@ -53,8 +53,8 @@ class TestPlayerClass(unittest.TestCase):
         self.assertEqual(p2.cooperations, 0)
         self.assertEqual(p2.defections, 1)
         # Test play counts
-        self.assertEqual(p1.play_counts, {(C, D): 1})
-        self.assertEqual(p2.play_counts, {(D, C): 1})
+        self.assertEqual(p1.state_distribution, {(C, D): 1})
+        self.assertEqual(p2.state_distribution, {(D, C): 1})
 
         p1.play(p2)
         self.assertEqual(p1.history[-1], C)
@@ -65,8 +65,8 @@ class TestPlayerClass(unittest.TestCase):
         self.assertEqual(p2.cooperations, 0)
         self.assertEqual(p2.defections, 2)
         # Test play counts
-        self.assertEqual(p1.play_counts, {(C, D): 2})
-        self.assertEqual(p2.play_counts, {(D, C): 2})
+        self.assertEqual(p1.state_distribution, {(C, D): 2})
+        self.assertEqual(p2.state_distribution, {(D, C): 2})
 
     def test_noisy_play(self):
         random.seed(1)
@@ -179,7 +179,7 @@ class TestPlayer(unittest.TestCase):
         self.assertEqual(p.history, [])
         self.assertEqual(self.player().cooperations, 0)
         self.assertEqual(self.player().defections, 0)
-        self.assertEqual(self.player().play_counts, {})
+        self.assertEqual(self.player().state_distribution, {})
 
     def test_clone(self):
         # Make sure that self.init_args has the right number of arguments
@@ -198,7 +198,7 @@ class TestPlayer(unittest.TestCase):
         self.assertEqual(len(p2.history), 0)
         self.assertEqual(p2.cooperations, 0)
         self.assertEqual(p2.defections, 0)
-        self.assertEqual(p2.play_counts, {})
+        self.assertEqual(p2.state_distribution, {})
         self.assertEqual(p2.classifier, p1.classifier)
         self.assertEqual(p2.match_attributes, p1.match_attributes)
 

--- a/axelrod/tests/unit/test_player.py
+++ b/axelrod/tests/unit/test_player.py
@@ -18,6 +18,10 @@ def defect(self):
     return D
 
 
+def randomize(self):
+    return random.choice([C, D])
+
+
 class TestPlayerClass(unittest.TestCase):
 
     name = "Player"
@@ -52,7 +56,7 @@ class TestPlayerClass(unittest.TestCase):
         self.assertEqual(p1.defections, 0)
         self.assertEqual(p2.cooperations, 0)
         self.assertEqual(p2.defections, 1)
-        # Test play counts
+        # Test state distribution
         self.assertEqual(p1.state_distribution, {(C, D): 1})
         self.assertEqual(p2.state_distribution, {(D, C): 1})
 
@@ -64,9 +68,21 @@ class TestPlayerClass(unittest.TestCase):
         self.assertEqual(p1.defections, 0)
         self.assertEqual(p2.cooperations, 0)
         self.assertEqual(p2.defections, 2)
-        # Test play counts
+        # Test state distribution
         self.assertEqual(p1.state_distribution, {(C, D): 2})
         self.assertEqual(p2.state_distribution, {(D, C): 2})
+
+    def test_state_distribution(self):
+        p1, p2 = self.player(), self.player()
+        history_1 = [C, C, D, D, C, D]
+        history_2 = [C, D, C, D, D, C]
+        p1.strategy = randomize
+        p2.strategy = randomize
+        simulate_play(p1, p2, history_1, history_2)
+        self.assertEqual(p1.state_distribution,
+                         {(C, C): 1, (C, D): 2, (D, C): 2, (D, D): 1})
+        self.assertEqual(p2.state_distribution,
+                         {(C, C): 1, (C, D): 2, (D, C): 2, (D, D): 1})
 
     def test_noisy_play(self):
         random.seed(1)


### PR DESCRIPTION
Related to https://github.com/Axelrod-Python/Axelrod/issues/744

Add play_counts property to Player class (a dictionary counting occurrences of CC, CD, DC, DD).
Update the dictionary after each play.
Add tests for the property.

TODO:
Use play_counts property in existing strategies (e.g. Prober4, Retaliate)
