### PR TITLE
Moran Process with Mutation

### DIFF
--- a/axelrod/moran.py
+++ b/axelrod/moran.py
@@ -82,7 +82,7 @@ class MoranProcess(object):
             d[str(p)] = p
         mt = dict()
         for key in sorted(keys):
-            mt[key] = [v for (k, v) in d.items() if k != key]
+            mt[key] = [v for (k, v) in sorted(d.items()) if k != key]
         self.mutation_targets = mt
 
     def set_players(self):

--- a/axelrod/moran.py
+++ b/axelrod/moran.py
@@ -81,7 +81,7 @@ class MoranProcess(object):
         for p in players:
             d[str(p)] = p
         mt = dict()
-        for key in keys:
+        for key in sorted(keys):
             mt[key] = [v for (k, v) in d.items() if k != key]
         self.mutation_targets = mt
 

--- a/axelrod/moran.py
+++ b/axelrod/moran.py
@@ -43,7 +43,7 @@ class MoranProcess(object):
         the process will iterate indefinitely, so mp.play() will never exit, and you should use the class as an
         iterator instead.
 
-        When a player mutates, it chooses a random player type from the initial population. This is not the only
+        When a player mutates it chooses a random player type from the initial population. This is not the only
         method yet emulates the common method in the literature.
 
         Parameters
@@ -123,7 +123,6 @@ class MoranProcess(object):
         - update the population
         """
         # Check the exit condition, that all players are of the same type.
-#        classes = set(p.__class__ for p in self.players)
         classes = set(str(p) for p in self.players)
         if (self.mutation_rate == 0) and (len(classes) == 1):
             self.winning_strategy_name = str(self.players[0])

--- a/axelrod/moran.py
+++ b/axelrod/moran.py
@@ -107,7 +107,8 @@ class MoranProcess(object):
         r = random.random()
         if r < self.mutation_rate:
             s = str(self.players[index])
-            p = random.choice(self.mutation_targets[s])
+            j = randrange(0, len(self.mutation_targets[s]))
+            p = self.mutation_targets[s][j]
             new_player = p.clone()
         else:
             # Just clone the player

--- a/axelrod/moran.py
+++ b/axelrod/moran.py
@@ -80,10 +80,10 @@ class MoranProcess(object):
         d = dict()
         for p in players:
             d[str(p)] = p
-        mt = dict()
+        mutation_targets = dict()
         for key in sorted(keys):
-            mt[key] = [v for (k, v) in sorted(d.items()) if k != key]
-        self.mutation_targets = mt
+            mutation_targets[key] = [v for (k, v) in sorted(d.items()) if k != key]
+        self.mutation_targets = mutation_targets
 
     def set_players(self):
         """Copy the initial players into the first population."""
@@ -182,6 +182,8 @@ class MoranProcess(object):
 
     def play(self):
         """Play the process out to completion."""
+        if self.mutation_rate != 0:
+            raise ValueError("MoranProcess.play() will never exit if mutation_rate is nonzero")
         while True:
             try:
                 self.__next__()

--- a/axelrod/tests/unit/test_moran.py
+++ b/axelrod/tests/unit/test_moran.py
@@ -48,12 +48,22 @@ class TestMoranProcess(unittest.TestCase):
         self.assertEqual(populations, mp.populations)
         self.assertEqual(mp.winning_strategy_name, str(p2))
 
+    def test_two_random_players(self):
+        p1, p2 = axelrod.Random(0.5), axelrod.Random(0.25)
+        random.seed(5)
+        mp = MoranProcess((p1, p2))
+        populations = mp.play()
+        self.assertEqual(len(mp), 2)
+        self.assertEqual(len(populations), 2)
+        self.assertEqual(populations, mp.populations)
+        self.assertEqual(mp.winning_strategy_name, str(p1))
+
     def test_two_players_with_mutation(self):
         p1, p2 = axelrod.Cooperator(), axelrod.Defector()
         random.seed(5)
         mp = MoranProcess((p1, p2), mutation_rate=0.2)
         self.assertEqual(mp._stochastic, True)
-        self.assertEqual(mp.mutation_targets, {str(p1): [p2], str(p2): [p1]})
+        self.assertDictEqual(mp.mutation_targets, {str(p1): [p2], str(p2): [p1]})
         # Test that mutation causes the population to alternate between fixations
         counters = [
             Counter({'Cooperator': 2}),
@@ -84,7 +94,7 @@ class TestMoranProcess(unittest.TestCase):
         players = [p1, p2, p3]
         mp = MoranProcess(players, mutation_rate=0.2)
         self.assertEqual(mp._stochastic, True)
-        self.assertEqual(mp.mutation_targets, {str(p1): [p2, p3], str(p2): [p1, p3], str(p3): [p1, p2]})
+        self.assertDictEqual(mp.mutation_targets, {str(p1): [p3, p2], str(p2): [p1, p3], str(p3): [p1, p2]})
         # Test that mutation causes the population to alternate between fixations
         counters = [
             Counter({'Cooperator': 3}),

--- a/axelrod/tests/unit/test_moran.py
+++ b/axelrod/tests/unit/test_moran.py
@@ -76,6 +76,12 @@ class TestMoranProcess(unittest.TestCase):
                 pass
             self.assertEqual(mp.population_distribution(), counter)
 
+    def test_play_exception(self):
+        p1, p2 = axelrod.Cooperator(), axelrod.Defector()
+        mp = MoranProcess((p1, p2), mutation_rate=0.2)
+        with self.assertRaises(ValueError):
+            mp.play()
+
     def test_three_players(self):
         players = [axelrod.Cooperator(), axelrod.Cooperator(),
                    axelrod.Defector()]

--- a/docs/tutorials/getting_started/moran.rst
+++ b/docs/tutorials/getting_started/moran.rst
@@ -54,3 +54,21 @@ The scores in each round::
     [3.0, 7.04, 7.04, 4.98],
     [3.04, 3.04, 3.04, 2.97],
     [3.04, 3.04, 3.04, 2.97]]
+
+
+The `MoranProcess` class also accepts an argument for a mutation rate. Nonzero mutation changes the Markov process so
+that it no longer has absorbing states, and will iterate forever. To prevent this, iterate with a loop (or function
+like `takewhile` from `itertools`):
+
+    >>> import axelrod as axl
+    >>> axl.seed(4) # for reproducible example
+    >>> players = [axl.Cooperator(), axl.Defector(),
+    ...               axl.TitForTat(), axl.Grudger()]
+    >>> mp = axl.MoranProcess(players, mutation_rate=0.1)
+    >>> for _ in mp:
+    ...     if len(mp.population_distribution()) == 1:
+    ...         break
+    >>> mp.population_distribution()
+    Counter({'Grudger': 4})
+
+

--- a/docs/tutorials/getting_started/moran.rst
+++ b/docs/tutorials/getting_started/moran.rst
@@ -69,6 +69,6 @@ like `takewhile` from `itertools`):
     ...     if len(mp.population_distribution()) == 1:
     ...         break
     >>> mp.population_distribution()
-    Counter({'Grudger': 4})
+    Counter({'Tit For Tat': 4})
 
 


### PR DESCRIPTION
I also made some improvements to the Moran process implementation -- it better handles unique player types now by using the string representations of the players. In the previous implementation the process would not have distinguished between `Random(0.5)` and `Random(0.25)`, for example.

Re #754 