### PR TITLE
Meta Winner Ensemble

### DIFF
--- a/axelrod/strategies/__init__.py
+++ b/axelrod/strategies/__init__.py
@@ -10,13 +10,14 @@ from .meta import (
     MetaPlayer, MetaMajority, MetaMinority, MetaWinner, MetaHunter,
     MetaMajorityMemoryOne, MetaWinnerMemoryOne, MetaMajorityFiniteMemory,
     MetaWinnerFiniteMemory, MetaMajorityLongMemory, MetaWinnerLongMemory,
-    MetaMixer
+    MetaMixer, MetaWinnerEnsemble
     )
 
 all_strategies.extend([MetaHunter, MetaMajority, MetaMinority, MetaWinner,
                        MetaMajorityMemoryOne, MetaWinnerMemoryOne,
                        MetaMajorityFiniteMemory, MetaWinnerFiniteMemory,
-                       MetaMajorityLongMemory, MetaWinnerLongMemory, MetaMixer])
+                       MetaMajorityLongMemory, MetaWinnerLongMemory, MetaMixer,
+                       MetaWinnerEnsemble])
 
 
 # Distinguished strategy collections in addition to

--- a/axelrod/strategies/meta.py
+++ b/axelrod/strategies/meta.py
@@ -54,7 +54,8 @@ class MetaPlayer(Player):
         # Get the results of all our players.
         results = [player.strategy(opponent) for player in self.team]
 
-        # A subclass should just define a way to choose the result based on team results.
+        # A subclass should just define a way to choose the result based on
+        # team results.
         return self.meta_strategy(results, opponent)
 
     def meta_strategy(self, results, opponent):
@@ -137,7 +138,8 @@ class MetaWinner(MetaPlayer):
             t.score = 0
 
     def strategy(self, opponent):
-        # Update the running score for each player, before determining the next move.
+        # Update the running score for each player, before determining the
+        # next move.
         if len(self.history):
             for player in self.team:
                 game = self.match_attributes["game"]
@@ -149,7 +151,8 @@ class MetaWinner(MetaPlayer):
     def meta_strategy(self, results, opponent):
         scores = [pl.score for pl in self.team]
         bestscore = max(scores)
-        beststrategies = [i for i, pl in enumerate(self.team) if pl.score == bestscore]
+        beststrategies = [i for (i, pl) in enumerate(self.team)
+                          if pl.score == bestscore]
         bestproposals = [results[i] for i in beststrategies]
         bestresult = C if C in bestproposals else D
 
@@ -166,7 +169,13 @@ class MetaWinner(MetaPlayer):
         return bestresult
 
 class MetaWinnerEnsemble(MetaWinner):
-    """A variant of MetaWinner that chooses one of the top scoring strategies at random against each opponent."""
+    """A variant of MetaWinner that chooses one of the top scoring strategies
+    at random against each opponent.
+
+    Names:
+
+    Meta Winner Ensemble: Original name by Marc Harper
+    """
 
     name = "Meta Winner Ensemble"
 

--- a/axelrod/tests/unit/test_classification.py
+++ b/axelrod/tests/unit/test_classification.py
@@ -129,6 +129,11 @@ class TestClassification(unittest.TestCase):
             self.assertFalse(axelrod.is_basic(strategy()), msg=strategy)
 
 
+def str_reps(xs):
+    """Maps a collection of player classes to their string representations."""
+    return set(map(str, [x() for x in xs]))
+
+
 class TestStrategies(unittest.TestCase):
 
     def test_strategy_list(self):
@@ -159,18 +164,21 @@ class TestStrategies(unittest.TestCase):
                               axelrod.strategies,
                               axelrod.ordinary_strategies,
                               axelrod.cheating_strategies]:
-            self.assertTrue(set(strategy_list).issubset(all_strategies_set))
+            self.assertTrue(str_reps(strategy_list).issubset(
+                str_reps(all_strategies_set)))
 
         strategies_set = set(axelrod.strategies)
         for strategy_list in [axelrod.demo_strategies,
                               axelrod.basic_strategies,
                               axelrod.long_run_time_strategies]:
-            self.assertTrue(set(strategy_list).issubset(strategies_set))
+            self.assertTrue(str_reps(strategy_list).issubset(
+                str_reps(strategies_set)))
 
     def test_long_run_strategies(self):
         long_run_time_strategies = [axelrod.MetaMajority,
                                     axelrod.MetaMinority,
                                     axelrod.MetaWinner,
+                                    axelrod.MetaWinnerEnsemble,
                                     axelrod.MetaMajorityMemoryOne,
                                     axelrod.MetaWinnerMemoryOne,
                                     axelrod.MetaMajorityFiniteMemory,
@@ -178,15 +186,18 @@ class TestStrategies(unittest.TestCase):
                                     axelrod.MetaMajorityLongMemory,
                                     axelrod.MetaWinnerLongMemory,
                                     axelrod.MetaMixer]
-        self.assertTrue(long_run_time_strategies,
-                        axelrod.long_run_time_strategies)
+
+        self.assertEqual(str_reps(long_run_time_strategies),
+                         str_reps(axelrod.long_run_time_strategies))
 
     def test_meta_inclusion(self):
-        self.assertTrue(axelrod.MetaMajority in axelrod.strategies)
+        self.assertTrue(str(axelrod.MetaMajority()) in
+                        str_reps(axelrod.strategies))
 
-        self.assertTrue(axelrod.MetaHunter in axelrod.strategies)
-        self.assertFalse(
-            axelrod.MetaHunter in axelrod.long_run_time_strategies)
+        self.assertTrue(str(axelrod.MetaHunter()) in
+                        str_reps(axelrod.strategies))
+        self.assertFalse(str(axelrod.MetaHunter()) in
+            str_reps(axelrod.long_run_time_strategies))
 
     def test_demo_strategies(self):
         demo_strategies = [axelrod.Cooperator,
@@ -194,4 +205,5 @@ class TestStrategies(unittest.TestCase):
                            axelrod.TitForTat,
                            axelrod.Grudger,
                            axelrod.Random]
-        self.assertTrue(demo_strategies, axelrod.demo_strategies)
+        self.assertTrue(str_reps(demo_strategies),
+                        str_reps(axelrod.demo_strategies))

--- a/axelrod/tests/unit/test_meta.py
+++ b/axelrod/tests/unit/test_meta.py
@@ -5,7 +5,7 @@ import random
 import axelrod
 import copy
 
-from .test_player import TestPlayer
+from .test_player import TestPlayer, test_responses
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
 
@@ -153,7 +153,8 @@ class TestMetaWinner(TestMetaPlayer):
         P1 = axelrod.MetaWinner(team=[axelrod.Cooperator, axelrod.Defector])
         P2 = axelrod.Player()
 
-        # This meta player will simply choose the strategy with the highest current score.
+        # This meta player will simply choose the strategy with the highest
+        # current score.
         P1.team[0].score = 0
         P1.team[1].score = 1
         self.assertEqual(P1.strategy(P2), C)
@@ -205,6 +206,14 @@ class TestMetaWinnerEnsemble(TestMetaPlayer):
     def test_strategy(self):
         self.first_play_test(C)
 
+        P1 = axelrod.MetaWinner(team=[axelrod.Cooperator, axelrod.Defector])
+        P2 = axelrod.Cooperator()
+        test_responses(self, P1, P2, [C] * 4, [C] * 4, [C] * 4)
+
+        P1 = axelrod.MetaWinner(team=[axelrod.Cooperator, axelrod.Defector])
+        P2 = axelrod.Defector()
+        test_responses(self, P1, P2, [C] * 4, [D] * 4, [D] * 4)
+
 
 class TestMetaHunter(TestMetaPlayer):
 
@@ -222,7 +231,8 @@ class TestMetaHunter(TestMetaPlayer):
     def test_strategy(self):
         self.first_play_test(C)
 
-        # We are not using the Cooperator Hunter here, so this should lead to cooperation.
+        # We are not using the Cooperator Hunter here, so this should lead to
+        #  cooperation.
         self.responses_test([C, C, C, C], [C, C, C, C], [C])
 
         # After long histories tit-for-tat should come into play.

--- a/axelrod/tests/unit/test_meta.py
+++ b/axelrod/tests/unit/test_meta.py
@@ -185,6 +185,27 @@ class TestMetaWinner(TestMetaPlayer):
         self.assertEqual(player.history[-1], D)
 
 
+class TestMetaWinnerEnsemble(TestMetaPlayer):
+    name = "Meta Winner Ensemble"
+    player = axelrod.MetaWinnerEnsemble
+    expected_classifier = {
+        'memory_depth': float('inf'),  # Long memory
+        'stochastic': True,
+        'makes_use_of': set(['game']),
+        'long_run_time': True,
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+
+    expected_class_classifier = copy.copy(expected_classifier)
+    expected_class_classifier['stochastic'] = False
+    expected_class_classifier['makes_use_of'] = set([])
+
+    def test_strategy(self):
+        self.first_play_test(C)
+
+
 class TestMetaHunter(TestMetaPlayer):
 
     name = "Meta Hunter"

--- a/docs/tutorials/advanced/classification_of_strategies.rst
+++ b/docs/tutorials/advanced/classification_of_strategies.rst
@@ -101,7 +101,7 @@ Some strategies have been classified as having a particularly long run time::
     ... }
     >>> strategies = axl.filtered_strategies(filterset)
     >>> len(strategies)
-    10
+    11
 
 Strategies that :code:`manipulate_source`, :code:`manipulate_state`
 and/or :code:`inspect_source` return :code:`False` for the :code:`obey_axelrod`


### PR DESCRIPTION
New strategy: Meta Winner Ensemble

Rather than take the "best" strategy, this MetaWinner variant chooses randomly from some of the top strategies computed each round against each opponent. In the full tournament it comes in 7th and is now the current best meta strategy.

I spent a little time tuning the parameter of how many strategies to pick from but not a lot, so it's possible that there's room for improvement.