### PR TITLE
Remove memoized for py3 caching

### DIFF
--- a/axelrod/_strategy_utils.py
+++ b/axelrod/_strategy_utils.py
@@ -1,5 +1,6 @@
 """Utilities used by various strategies"""
 import itertools
+from functools import lru_cache
 
 from axelrod import update_history
 from axelrod import Actions
@@ -82,34 +83,7 @@ def look_ahead(player_1, player_2, game, rounds=10):
     return strategies[results.index(max(results))]
 
 
-class Memoized(object):
-    """Decorator that caches a function's return value each time it is called.
-    If called later with the same arguments, the cached value is returned
-    (not reevaluated). From:
-    https://wiki.python.org/moin/PythonDecoratorLibrary#Memoize
-    """
-
-    def __init__(self, func):
-        self.func = func
-        self.cache = {}
-
-    def __call__(self, *args):
-        try:
-            try:
-                return self.cache[args]
-            except KeyError:
-                value = self.func(*args)
-                self.cache[args] = value
-                return value
-        except TypeError:
-            return self.func(*args)
-
-    def __repr__(self):
-        """Return the function's docstring."""
-        return self.func.__doc__
-
-
-@Memoized
+@lru_cache()
 def recursive_thue_morse(n):
     """The recursive definition of the Thue-Morse sequence. The first few terms
     of the Thue-Morse sequence are: 0 1 1 0 1 0 0 1 1 0 0 1 0 1 1 0 . . ."""

--- a/axelrod/tests/unit/test_strategy_utils.py
+++ b/axelrod/tests/unit/test_strategy_utils.py
@@ -7,7 +7,6 @@ from hypothesis.strategies import sampled_from, lists, integers
 
 from axelrod import Actions
 from axelrod._strategy_utils import detect_cycle
-from axelrod._strategy_utils import Memoized
 
 C, D = Actions.C, Actions.D
 
@@ -26,40 +25,3 @@ class TestDetectCycle(unittest.TestCase):
 
         history = [D, D, C, C, C]
         self.assertIsNone(detect_cycle(history))
-
-
-class TestMemoized(unittest.TestCase):
-    """Test the Memoized class"""
-
-    def test_init(self):
-        func = lambda x: x + x
-        memoized = Memoized(func)
-        self.assertEqual(memoized.func, func)
-        self.assertEqual(memoized.cache, {})
-
-    def test_call_with_unhashable_type(self):
-        func = lambda x: x + x
-        memoized = Memoized(func)
-        self.assertEqual(memoized([2]), [2, 2])
-        self.assertEqual(memoized.cache, {})
-
-    def test_call(self):
-        func = lambda x: x + x
-        memoized = Memoized(func)
-        self.assertEqual(memoized.cache, {})
-        self.assertEqual(memoized(2), 4)
-        self.assertEqual(memoized.cache, {(2,): 4})
-        self.assertEqual(memoized(2), 4)
-        self.assertEqual(memoized.cache, {(2,): 4})
-
-    def test_repr(self):
-        func = lambda x: x + x
-        memoized = Memoized(func)
-        self.assertEqual(memoized.__repr__(), None)
-
-        def func_with_docstring(x):
-            """A docstring"""
-            return x + x
-
-        memoized = Memoized(func_with_docstring)
-        self.assertEqual(memoized.__repr__(), "A docstring")


### PR DESCRIPTION
This is possible thanks to us dropping py2 :)