### PR TITLE
Allow fingerprinting of instances.

### DIFF
--- a/axelrod/fingerprint.py
+++ b/axelrod/fingerprint.py
@@ -56,10 +56,12 @@ class AshlockFingerprint():
         """
         Parameters
         ----------
-        strategy : class
-            A class that must be descended from axelrod.Player
-        probe : class
-            A class that must be descended from axelrod.Player
+        strategy : class or instance
+            A class that must be descended from axelrod.Player or an instance of
+            axelrod.Player.
+        probe : class or instance
+            A class that must be descended from axelrod.Player or an instance of
+            axelrod.Player.
             Default: Tit For Tat
         """
         self.strategy = strategy
@@ -85,10 +87,17 @@ class AshlockFingerprint():
             `JossAnnTransformer` with parameters that correspond to `point`.
         """
         x, y = point
-        if x + y >= 1:
-            joss_ann = DualTransformer()(JossAnnTransformer((1 - x, 1 - y))(probe))()
+
+        if isinstance(probe, axl.Player):
+            init_args = probe.init_args
+            probe = probe.__class__
         else:
-            joss_ann = JossAnnTransformer((x, y))(probe)()
+            init_args = ()
+
+        if x + y >= 1:
+            joss_ann = DualTransformer()(JossAnnTransformer((1 - x, 1 - y))(probe))(*init_args)
+        else:
+            joss_ann = JossAnnTransformer((x, y))(probe)(*init_args)
         return joss_ann
 
     @staticmethod
@@ -173,10 +182,10 @@ class AshlockFingerprint():
         probe_players = self.create_probes(self.probe, self.points,
                                            progress_bar=progress_bar)
 
-        try:
-            tournament_players = [self.strategy()] + probe_players
-        except TypeError:  # If strategy is an instance
+        if isinstance(self.strategy, axl.Player):
             tournament_players = [self.strategy] + probe_players
+        else:
+            tournament_players = [self.strategy()] + probe_players
 
         return edges, tournament_players
 

--- a/axelrod/fingerprint.py
+++ b/axelrod/fingerprint.py
@@ -52,7 +52,7 @@ def create_points(step, progress_bar=True):
 
 
 class AshlockFingerprint():
-    def __init__(self, strategy, probe):
+    def __init__(self, strategy, probe=axl.TitForTat):
         """
         Parameters
         ----------
@@ -60,6 +60,7 @@ class AshlockFingerprint():
             A class that must be descended from axelrod.Player
         probe : class
             A class that must be descended from axelrod.Player
+            Default: Tit For Tat
         """
         self.strategy = strategy
         self.probe = probe
@@ -172,7 +173,10 @@ class AshlockFingerprint():
         probe_players = self.create_probes(self.probe, self.points,
                                            progress_bar=progress_bar)
 
-        tournament_players = [self.strategy()] + probe_players
+        try:
+            tournament_players = [self.strategy()] + probe_players
+        except TypeError:  # If strategy is an instance
+            tournament_players = [self.strategy] + probe_players
 
         return edges, tournament_players
 

--- a/axelrod/tests/unit/test_fingerprint.py
+++ b/axelrod/tests/unit/test_fingerprint.py
@@ -25,12 +25,21 @@ class TestFingerprint(unittest.TestCase):
                               (0, 4), (0, 5), (0, 6),
                               (0, 7), (0, 8), (0, 9)]
 
+    def test_default_init(self):
+        fingerprint = AshlockFingerprint(self.strategy)
+        self.assertEqual(fingerprint.strategy, self.strategy)
+        self.assertEqual(fingerprint.probe, self.probe)
+
     def test_init(self):
-        strategy = axl.Cooperator()
-        probe = axl.TitForTat()
-        fingerprint = AshlockFingerprint(strategy, probe)
-        self.assertEqual(fingerprint.strategy, strategy)
-        self.assertEqual(fingerprint.probe, probe)
+        fingerprint = AshlockFingerprint(self.strategy, self.probe)
+        self.assertEqual(fingerprint.strategy, self.strategy)
+        self.assertEqual(fingerprint.probe, self.probe)
+
+    def test_init_with_instance(self):
+        player = self.strategy()
+        fingerprint = AshlockFingerprint(player)
+        self.assertEqual(fingerprint.strategy, player)
+        self.assertEqual(fingerprint.probe, self.probe)
 
     def test_create_points(self):
         test_points = create_points(0.5, progress_bar=False)
@@ -226,10 +235,15 @@ class TestFingerprint(unittest.TestCase):
     def test_pair_fingerprints(self, strategy_pair):
         """
         A test to check that we can fingerprint
-        with any two given strategies
+        with any two given strategies or instances
         """
         strategy, probe = strategy_pair
         af = AshlockFingerprint(strategy, probe)
+        data = af.fingerprint(turns=2, repetitions=2, step=0.5,
+                              progress_bar=False)
+        self.assertIsInstance(data, dict)
+
+        af = AshlockFingerprint(strategy(), probe)
         data = af.fingerprint(turns=2, repetitions=2, step=0.5,
                               progress_bar=False)
         self.assertIsInstance(data, dict)

--- a/axelrod/tests/unit/test_fingerprint.py
+++ b/axelrod/tests/unit/test_fingerprint.py
@@ -41,6 +41,47 @@ class TestFingerprint(unittest.TestCase):
         self.assertEqual(fingerprint.strategy, player)
         self.assertEqual(fingerprint.probe, self.probe)
 
+        probe_player = self.probe()
+        fingerprint = AshlockFingerprint(self.strategy, probe_player)
+        self.assertEqual(fingerprint.strategy, self.strategy)
+        self.assertEqual(fingerprint.probe, probe_player)
+
+        fingerprint = AshlockFingerprint(player, probe_player)
+        self.assertEqual(fingerprint.strategy, player)
+        self.assertEqual(fingerprint.probe, probe_player)
+
+    def test_create_jossann(self):
+        fingerprint = AshlockFingerprint(self.strategy)
+
+        # x + y < 1
+        ja = fingerprint.create_jossann((.5, .4), self.probe)
+        self.assertEqual(str(ja), "Joss-Ann Tit For Tat")
+
+        # x + y = 1
+        ja = fingerprint.create_jossann((.4, .6), self.probe)
+        self.assertEqual(str(ja), "Dual Joss-Ann Tit For Tat")
+
+        # x + y > 1
+        ja = fingerprint.create_jossann((.5, .6), self.probe)
+        self.assertEqual(str(ja), "Dual Joss-Ann Tit For Tat")
+
+    def test_create_jossann_parametrised_player(self):
+        fingerprint = AshlockFingerprint(self.strategy)
+
+        probe = axl.Random(0.1)
+
+        # x + y < 1
+        ja = fingerprint.create_jossann((.5, .4), probe)
+        self.assertEqual(str(ja), "Joss-Ann Random: 0.1")
+
+        # x + y = 1
+        ja = fingerprint.create_jossann((.4, .6), probe)
+        self.assertEqual(str(ja), "Dual Joss-Ann Random: 0.1")
+
+        # x + y > 1
+        ja = fingerprint.create_jossann((.5, .6), probe)
+        self.assertEqual(str(ja), "Dual Joss-Ann Random: 0.1")
+
     def test_create_points(self):
         test_points = create_points(0.5, progress_bar=False)
         self.assertEqual(test_points, self.expected_points)
@@ -244,6 +285,16 @@ class TestFingerprint(unittest.TestCase):
         self.assertIsInstance(data, dict)
 
         af = AshlockFingerprint(strategy(), probe)
+        data = af.fingerprint(turns=2, repetitions=2, step=0.5,
+                              progress_bar=False)
+        self.assertIsInstance(data, dict)
+
+        af = AshlockFingerprint(strategy, probe())
+        data = af.fingerprint(turns=2, repetitions=2, step=0.5,
+                              progress_bar=False)
+        self.assertIsInstance(data, dict)
+
+        af = AshlockFingerprint(strategy(), probe())
         data = af.fingerprint(turns=2, repetitions=2, step=0.5,
                               progress_bar=False)
         self.assertIsInstance(data, dict)

--- a/docs/reference/bibliography.rst
+++ b/docs/reference/bibliography.rst
@@ -6,6 +6,7 @@ Bibliography
 This is a collection of various bibliographic items referenced in the
 documentation.
 
+.. [Ashlock2009] Ashlock, D., Kim, E. Y., & Ashlock, W. (2009) Fingerprint analysis of the noisy prisoner’s dilemma using a finite-state representation. IEEE Transactions on Computational Intelligence and AI in Games. 1(2), 154-167  http://doi.org/10.1109/TCIAIG.2009.2018704
 .. [Ashlock2010] Ashlock, D., Kim, E. Y., & Ashlock, W. (2010). A fingerprint comparison of different Prisoner’s Dilemma payoff matrices. Proceedings of the 2010 IEEE Conference on Computational Intelligence and Games, CIG2010, (2009), 219–226. http://doi.org/10.1109/ITW.2010.5593352
 .. [Axelrod1980] Axelrod, R. (1980). Effective Choice in the Prisoner’s Dilemma. Journal of Conflict Resolution, 24(1), 3–25.
 .. [Axelrod1980b] Axelrod, R. (1980). More Effective Choice in the Prisoner’s Dilemma. Journal of Conflict Resolution, 24(3), 379-403.

--- a/docs/reference/bibliography.rst
+++ b/docs/reference/bibliography.rst
@@ -6,8 +6,8 @@ Bibliography
 This is a collection of various bibliographic items referenced in the
 documentation.
 
+.. [Ashlock2008] Ashlock, D., & Kim, E. Y. (2008). Fingerprinting: Visualization and automatic analysis of prisoner’s dilemma strategies. IEEE Transactions on Evolutionary Computation, 12(5), 647–659. http://doi.org/10.1109/TEVC.2008.920675
 .. [Ashlock2009] Ashlock, D., Kim, E. Y., & Ashlock, W. (2009) Fingerprint analysis of the noisy prisoner’s dilemma using a finite-state representation. IEEE Transactions on Computational Intelligence and AI in Games. 1(2), 154-167  http://doi.org/10.1109/TCIAIG.2009.2018704
-.. [Ashlock2010] Ashlock, D., Kim, E. Y., & Ashlock, W. (2010). A fingerprint comparison of different Prisoner’s Dilemma payoff matrices. Proceedings of the 2010 IEEE Conference on Computational Intelligence and Games, CIG2010, (2009), 219–226. http://doi.org/10.1109/ITW.2010.5593352
 .. [Axelrod1980] Axelrod, R. (1980). Effective Choice in the Prisoner’s Dilemma. Journal of Conflict Resolution, 24(1), 3–25.
 .. [Axelrod1980b] Axelrod, R. (1980). More Effective Choice in the Prisoner’s Dilemma. Journal of Conflict Resolution, 24(3), 379-403.
 .. [Axelrod1984]  The Evolution of Cooperation. Basic Books. ISBN 0-465-02121-2.

--- a/docs/tutorials/advanced/strategy_transformers.rst
+++ b/docs/tutorials/advanced/strategy_transformers.rst
@@ -60,12 +60,12 @@ The library includes the following transformers:
     >>> NoisyCooperator = NoisyTransformer(0.5)(axl.Cooperator)
     >>> player = NoisyCooperator()
 
-* :code:`DualTransformer`: The Dual of a strategy will return the exact opposite set of moves to the original strategy when both are faced with the same history. [Ashlock2010]_::
+* :code:`DualTransformer`: The Dual of a strategy will return the exact opposite set of moves to the original strategy when both are faced with the same history. [Ashlock2008]_::
 
     >>> DualWSLS = DualTransformer()(axl.WinStayLoseShift)
     >>> player = DualWSLS()
 
-* :code:`JossAnnTransformer(probability)`: Where :code:`probability = (x, y)`, the Joss-Ann of a strategy is a new strategy which has a probability :code:`x` of choosing the move C, a probability :code:`y` of choosing the move D, and otherwise uses the response appropriate to the original strategy. [Ashlock2010]_::
+* :code:`JossAnnTransformer(probability)`: Where :code:`probability = (x, y)`, the Joss-Ann of a strategy is a new strategy which has a probability :code:`x` of choosing the move C, a probability :code:`y` of choosing the move D, and otherwise uses the response appropriate to the original strategy. [Ashlock2008]_::
 
     >>> JossAnnTFT = JossAnnTransformer((0.2, 0.3))(axl.TitForTat)
     >>> player = JossAnnTFT()

--- a/docs/tutorials/further_topics/fingerprinting.rst
+++ b/docs/tutorials/further_topics/fingerprinting.rst
@@ -3,17 +3,18 @@
 Fingerprinting
 ==============
 
-In [Ashlock2010]_ a methodology for obtaining visual representation of a
-strategy's behaviour is given.  The basic method is to play the strategy against
-a probe strategy with varying noise parameters.  These noise parameters are
-implemented through the :code:`JossAnnTransformer`.  The Joss-Ann of a strategy
-is a new strategy which has a probability :code:`x` of cooperating, a
-probability :code:`y` of defecting, and otherwise uses the response appropriate
-to the original strategy.  We can then plot the expected score of the strategy
-against :code:`x` and :code:`y` and obtain a heat plot over the unit square.
-When :code:`x + y >= 1` the :code:`JossAnn` is created with parameters
-:code:`(1-y, 1-x)` and plays against the Dual of the probe instead.  A full
-definition and explanation is given in [Ashlock2010]_.
+In [Ashlock2009]_, [Ashlock2010]_ a methodology for obtaining visual
+representation of a strategy's behaviour is described.  The basic method is to
+play the strategy against a probe strategy with varying noise parameters.
+These noise parameters are implemented through the :code:`JossAnnTransformer`.
+The Joss-Ann of a strategy is a new strategy which has a probability :code:`x`
+of cooperating, a probability :code:`y` of defecting, and otherwise uses the
+response appropriate to the original strategy.  We can then plot the expected
+score of the strategy against :code:`x` and :code:`y` and obtain a heat plot
+over the unit square.  When :code:`x + y >= 1` the :code:`JossAnn` is created
+with parameters :code:`(1-y, 1-x)` and plays against the Dual of the probe
+instead. A full definition and explanation is given in
+[Ashlock2009]_, [Ashlock2010]_.
 
 Here is how to create a fingerprint of :code:`WinStayLoseShift` using
 :code:`TitForTat` as a probe::

--- a/docs/tutorials/further_topics/fingerprinting.rst
+++ b/docs/tutorials/further_topics/fingerprinting.rst
@@ -4,17 +4,16 @@ Fingerprinting
 ==============
 
 In [Ashlock2010]_ a methodology for obtaining visual representation of a
-strategy's behaviour is given.
-The basic method is to play the strategy against a probe strategy with varying
-noise parameters.
-These noise parameters are implemented through the :code:`JossAnnTransformer`.
-The Joss-Ann of a strategy is a new strategy which has a probability :code:`x` of
-cooperating, a probability :code:`y` of defecting, and otherwise
-uses the response appropriate to the original strategy.
-We can then plot the expected score of the strategy against :code:`x` and :code:`y` and
-obtain a heat plot over the unit square.
-When :code:`x + y >= 1` the :code:`JossAnn` is created with parameters :code:`(1-y, 1-x)` and plays against the Dual of the probe instead.
-A full definition and explanation is given in [Ashlock2010]_.
+strategy's behaviour is given.  The basic method is to play the strategy against
+a probe strategy with varying noise parameters.  These noise parameters are
+implemented through the :code:`JossAnnTransformer`.  The Joss-Ann of a strategy
+is a new strategy which has a probability :code:`x` of cooperating, a
+probability :code:`y` of defecting, and otherwise uses the response appropriate
+to the original strategy.  We can then plot the expected score of the strategy
+against :code:`x` and :code:`y` and obtain a heat plot over the unit square.
+When :code:`x + y >= 1` the :code:`JossAnn` is created with parameters
+:code:`(1-y, 1-x)` and plays against the Dual of the probe instead.  A full
+definition and explanation is given in [Ashlock2010]_.
 
 Here is how to create a fingerprint of :code:`WinStayLoseShift` using
 :code:`TitForTat` as a probe::
@@ -42,19 +41,37 @@ We can then plot the above to get::
      :align: center
 
 In reality we would need much more detail to make this plot useful.
-Using pararemeters :code:`turns=50, repetitions=2, step=0.01` we get the plot:
+
+Running the above with the following parameters::
+
+    >>> af.fingerprint(turns=50, repetitions=2, step=0.01)  # doctest: +SKIP
+
+We get the plot:
 
 .. image:: _static/fingerprinting/WSLS_large.png
      :width: 100%
      :align: center
 
-We are also able to specify a matplotlib colour map and interpolation. Passing
-parameters :code:`col_map='PuOr', interpolation='bicubic'` to the :code:`plot()`
-function gives us this plot instead:
+We are also able to specify a matplotlib colour map and interpolation::
+
+    >>> af.plot(col_map='PuOr', interpolation='bicubic')  # doctest: +SKIP
 
 .. image:: _static/fingerprinting/WSLS_large_alt.png
      :width: 100%
      :align: center
+
+Note that it is also possible to pass a player instance to be fingerprinted.
+This allows for the fingerprinting of parametrized strategies::
+
+    >>> axl.seed(0)
+    >>> player = axl.Random(.1)
+    >>> probe = axl.TitForTat
+    >>> af = axl.AshlockFingerprint(player, probe)
+    >>> data = af.fingerprint(turns=10, repetitions=2, step=0.2)
+    >>> data
+    {...
+    >>> data[(0, 0)]
+    1.39...
 
 Ashlock's fingerprint is currently the only fingerprint implemented in the
 library.

--- a/docs/tutorials/further_topics/fingerprinting.rst
+++ b/docs/tutorials/further_topics/fingerprinting.rst
@@ -3,7 +3,7 @@
 Fingerprinting
 ==============
 
-In [Ashlock2009]_, [Ashlock2010]_ a methodology for obtaining visual
+In [Ashlock2008]_, [Ashlock2009]_ a methodology for obtaining visual
 representation of a strategy's behaviour is described.  The basic method is to
 play the strategy against a probe strategy with varying noise parameters.
 These noise parameters are implemented through the :code:`JossAnnTransformer`.
@@ -14,7 +14,7 @@ score of the strategy against :code:`x` and :code:`y` and obtain a heat plot
 over the unit square.  When :code:`x + y >= 1` the :code:`JossAnn` is created
 with parameters :code:`(1-y, 1-x)` and plays against the Dual of the probe
 instead. A full definition and explanation is given in
-[Ashlock2009]_, [Ashlock2010]_.
+[Ashlock2008]_, [Ashlock2009]_.
 
 Here is how to create a fingerprint of :code:`WinStayLoseShift` using
 :code:`TitForTat` as a probe::

--- a/docs/tutorials/further_topics/fingerprinting.rst
+++ b/docs/tutorials/further_topics/fingerprinting.rst
@@ -61,18 +61,19 @@ We are also able to specify a matplotlib colour map and interpolation::
      :width: 100%
      :align: center
 
-Note that it is also possible to pass a player instance to be fingerprinted.
+Note that it is also possible to pass a player instance to be fingerprinted
+and/or as a probe.
 This allows for the fingerprinting of parametrized strategies::
 
     >>> axl.seed(0)
     >>> player = axl.Random(.1)
-    >>> probe = axl.TitForTat
+    >>> probe = axl.GTFT(.9)
     >>> af = axl.AshlockFingerprint(player, probe)
     >>> data = af.fingerprint(turns=10, repetitions=2, step=0.2)
     >>> data
     {...
     >>> data[(0, 0)]
-    1.39...
+    4.4...
 
 Ashlock's fingerprint is currently the only fingerprint implemented in the
 library.


### PR DESCRIPTION
Currently fingerprinting takes classes as the target for the
fingerprint.

This was an oversight as it doesn't allow for the fingerprinting of
parametrized strategies. This allows for both.