### PR TITLE
Add a read the docs config file.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,3 @@
+python:
+  version: 3
+requirements_file: requirements.txt


### PR DESCRIPTION
This sets the python version to python 3.

You can see the docs have built properly here: http://axelrod.readthedocs.io/en/py3rtd/tutorials/further_topics/fingerprinting.html

Whereas the current master is not pointing at the new fingerprint plots: http://axelrod.readthedocs.io/en/latest/tutorials/further_topics/fingerprinting.html