### PR TITLE
Moran processes are always stochastic

### DIFF
--- a/axelrod/moran.py
+++ b/axelrod/moran.py
@@ -1,11 +1,10 @@
-# -*- coding: utf-8 -*-
 from collections import Counter
 import random
 
 import numpy as np
 
 from .deterministic_cache import DeterministicCache
-from .match import Match, is_stochastic
+from .match import Match
 from .random_ import randrange
 
 
@@ -93,14 +92,6 @@ class MoranProcess(object):
             self.players.append(player)
         self.populations = [self.population_distribution()]
         self.num_players = len(self.players)
-
-    @property
-    def _stochastic(self):
-        """
-        A boolean to show whether a match between two players would be
-        stochastic
-        """
-        return is_stochastic(self.players, self.noise) or (self.mutation_rate > 0)
 
     def mutate(self, index):
         # If mutate, choose another strategy at random from the initial population

--- a/axelrod/tests/unit/test_moran.py
+++ b/axelrod/tests/unit/test_moran.py
@@ -1,15 +1,13 @@
-# -*- coding: utf-8 -*-
 from collections import Counter
 import itertools
 import random
 import unittest
 
+from hypothesis import given, example, settings
+
 import axelrod
 from axelrod import MoranProcess
 from axelrod.moran import fitness_proportionate_selection
-
-from hypothesis import given, example, settings
-
 from axelrod.tests.property import strategy_lists
 
 
@@ -20,17 +18,6 @@ class TestMoranProcess(unittest.TestCase):
         random.seed(1)
         self.assertEqual(fitness_proportionate_selection([1, 1, 1]), 0)
         self.assertEqual(fitness_proportionate_selection([1, 1, 1]), 2)
-
-    def test_stochastic(self):
-        p1, p2 = axelrod.Cooperator(), axelrod.Cooperator()
-        mp = MoranProcess((p1, p2))
-        self.assertFalse(mp._stochastic)
-        p1, p2 = axelrod.Cooperator(), axelrod.Cooperator()
-        mp = MoranProcess((p1, p2), noise=0.05)
-        self.assertTrue(mp._stochastic)
-        p1, p2 = axelrod.Cooperator(), axelrod.Random()
-        mp = MoranProcess((p1, p2))
-        self.assertTrue(mp._stochastic)
 
     def test_exit_condition(self):
         p1, p2 = axelrod.Cooperator(), axelrod.Cooperator()
@@ -62,7 +49,6 @@ class TestMoranProcess(unittest.TestCase):
         p1, p2 = axelrod.Cooperator(), axelrod.Defector()
         random.seed(5)
         mp = MoranProcess((p1, p2), mutation_rate=0.2)
-        self.assertEqual(mp._stochastic, True)
         self.assertDictEqual(mp.mutation_targets, {str(p1): [p2], str(p2): [p1]})
         # Test that mutation causes the population to alternate between fixations
         counters = [
@@ -99,7 +85,6 @@ class TestMoranProcess(unittest.TestCase):
         p3 = axelrod.Defector()
         players = [p1, p2, p3]
         mp = MoranProcess(players, mutation_rate=0.2)
-        self.assertEqual(mp._stochastic, True)
         self.assertDictEqual(mp.mutation_targets, {str(p1): [p3, p2], str(p2): [p1, p3], str(p3): [p1, p2]})
         # Test that mutation causes the population to alternate between fixations
         counters = [


### PR DESCRIPTION
The Matches in the process may still be deterministic but the process itself still uses random values for the fitness proportionate selection stages.