### PR TITLE
History class

### DIFF
--- a/axelrod/__init__.py
+++ b/axelrod/__init__.py
@@ -11,6 +11,7 @@ from .actions import Actions, flip_action
 from .random_ import random_choice, seed
 from .plot import Plot
 from .game import DefaultGame, Game
+from .history import History
 from .player import (
     get_state_distribution_from_history, init_args, is_basic, obey_axelrod,
     update_history, update_state_distribution, Player)

--- a/axelrod/_strategy_utils.py
+++ b/axelrod/_strategy_utils.py
@@ -10,7 +10,7 @@ from axelrod.strategies.cycler import Cycler
 C, D = Actions.C, Actions.D
 
 
-def detect_cycle(history, min_size=1, offset=0):
+def detect_cycle(history, min_size=1, max_size=12, offset=0):
     """Detects cycles in the sequence history.
 
     Mainly used by hunter strategies.
@@ -21,18 +21,22 @@ def detect_cycle(history, min_size=1, offset=0):
         The sequence to look for cycles within
     min_size: int, 1
         The minimum length of the cycle
+    max_size: int, 12
     offset: int, 0
         The amount of history to skip initially
     """
-    history_tail = history[-offset:]
-    for i in range(min_size, len(history_tail) // 2):
+    history_tail = history[offset:]
+    max_ = min(len(history_tail) // 2, max_size)
+    for i in range(min_size, max_):
+        has_cycle = True
         cycle = tuple(history_tail[:i])
         for j, elem in enumerate(history_tail):
             if elem != cycle[j % len(cycle)]:
+                has_cycle = False
                 break
-        if j == len(history_tail) - 1:
+        if has_cycle and (j == len(history_tail) - 1):
             # We made it to the end, is the cycle itself a cycle?
-            # I.E. CCC is not ok as cycle if min_size is really 2
+            # E.G. CCC is not ok as cycle if min_size is really 2
             # Since this is the same as C
             return cycle
     return None

--- a/axelrod/deterministic_cache.py
+++ b/axelrod/deterministic_cache.py
@@ -1,9 +1,4 @@
-try:
-    # Python 2.x
-    from UserDict import UserDict
-except ImportError:
-    # Python 3.x
-    from collections import UserDict
+from collections import UserDict
 import pickle
 
 from axelrod import Player

--- a/axelrod/fingerprint.py
+++ b/axelrod/fingerprint.py
@@ -1,12 +1,14 @@
-import axelrod as axl
-import numpy as np
-import matplotlib.pyplot as plt
-import tqdm
-from axelrod.strategy_transformers import JossAnnTransformer, DualTransformer
-from axelrod.interaction_utils import compute_final_score_per_turn, read_interactions_from_file
-from axelrod import on_windows
 from collections import namedtuple
 from tempfile import NamedTemporaryFile
+
+import matplotlib.pyplot as plt
+import numpy as np
+import tqdm
+
+import axelrod as axl
+from axelrod import on_windows
+from axelrod.interaction_utils import compute_final_score_per_turn, read_interactions_from_file
+from axelrod.strategy_transformers import JossAnnTransformer, DualTransformer
 
 
 Point = namedtuple('Point', 'x y')
@@ -308,7 +310,8 @@ class AshlockFingerprint():
         plotting_data = np.flipud(shaped_data)
         return plotting_data
 
-    def plot(self, col_map='seismic', interpolation='none', title=None, colorbar=True, labels=True):
+    def plot(self, col_map='seismic', interpolation='none', title=None,
+             colorbar=True, labels=True):
         """Plot the results of the spatial tournament.
 
         Parameters

--- a/axelrod/history.py
+++ b/axelrod/history.py
@@ -50,9 +50,10 @@ class HistoryList(object):
         elif isinstance(other, list):
             # other_history = "".join(other)
             other_history = other
-        elif isinstance(other, History):
+        elif isinstance(other, HistoryList):
             other_history = other._history
         else:
+            print(other)
             raise ValueError("Cannot compare types.")
 
         return (self._history == other_history)
@@ -63,9 +64,9 @@ class HistoryList(object):
             temp = self._history + other
         if isinstance(other, str):
             temp = self._history + list(other)
-        elif isinstance(other, History):
+        elif isinstance(other, HistoryList):
             temp = self._history + other._history
-        return History(temp)
+        return HistoryList(temp)
 
     def __getitem__(self, key):
         # Passthrough keys and slice objects
@@ -125,7 +126,7 @@ class HistoryString(object):
             other_history = other
         elif isinstance(other, list):
             other_history = "".join(other)
-        elif isinstance(other, History):
+        elif isinstance(other, HistoryString):
             other_history = other._history
         else:
             raise ValueError("Cannot compare types.")
@@ -137,9 +138,9 @@ class HistoryString(object):
             temp = self._history + ''.join(other)
         if isinstance(other, str):
             temp = self._history + other
-        elif isinstance(other, History):
+        elif isinstance(other, HistoryString):
             temp = self._history + other._history
-        return History(temp)
+        return HistoryString(temp)
 
     def __getitem__(self, key):
         # Passthrough keys and slice objects

--- a/axelrod/history.py
+++ b/axelrod/history.py
@@ -1,3 +1,5 @@
+from collections import Counter, defaultdict
+
 
 def copy_history(history):
     """Copies a history object efficiently."""
@@ -9,13 +11,18 @@ def copy_history(history):
 class History(object):
     def __init__(self, history=None):
         self._history = []
-        self._counter = collections.Counter()
+        self._counter = Counter()
         if history:
             self.extend(history)
 
+    def copy(self):
+        new_history = History()
+        new_history.extend(self._history)
+        return new_history
+
     def reset(self):
         self._history = []
-        self._counter = collections.Counter()
+        self._counter = Counter()
 
     def append(self, play):
         self._history.append(play)
@@ -53,4 +60,4 @@ class History(object):
         return (self._history == other_history)
 
     def __repr__(self):
-        return "History: " + self._history.__repr__()
+        return "History: " + ''.join(self._history)

--- a/axelrod/history.py
+++ b/axelrod/history.py
@@ -1,0 +1,56 @@
+
+def copy_history(history):
+    """Copies a history object efficiently."""
+    new_history = History()
+    new_history.extend(history)
+    return new_history
+
+
+class History(object):
+    def __init__(self, history=None):
+        self._history = []
+        self._counter = collections.Counter()
+        if history:
+            self.extend(history)
+
+    def reset(self):
+        self._history = []
+        self._counter = collections.Counter()
+
+    def append(self, play):
+        self._history.append(play)
+        self._counter[play] += 1
+
+    def extend(self, list_):
+        self._history.extend(list_)
+        self._counter.update(list_)
+
+    def pop(self, index):
+        play = self._history.pop(index)
+        self._counter[play] -= 1
+        return play
+
+    def __len__(self):
+        return len(self._history)
+
+    def cooperations(self):
+        return self._counter['C']
+
+    def defections(self):
+        return self._counter['D']
+
+    def __getitem__(self, key):
+        # Passthrough keys and slice objects
+        return self._history[key]
+
+    def __eq__(self, other):
+        # Allow comparison to lists
+        if isinstance(other, list):
+            other_history = other
+        else:
+            other_history = other._history
+
+        return (self._history == other_history)
+
+    def __repr__(self):
+        return "History: " + self._history.__repr__()

--- a/axelrod/history.py
+++ b/axelrod/history.py
@@ -38,6 +38,8 @@ class HistoryList(object):
 
     def pop(self, index):
         play = self._history.pop(index)
+        self._counter[play] -= 1
+        self._len -= 1
         return play
 
     def reset(self):

--- a/axelrod/history.py
+++ b/axelrod/history.py
@@ -7,6 +7,7 @@ C, D = Actions.C, Actions.D
 
 class HistoryList(object):
     def __init__(self, history=None):
+        self._len = 0
         self._history = []
         self._counter = Counter()
         if isinstance(history, History):
@@ -15,6 +16,7 @@ class HistoryList(object):
             self.extend(history)
 
     def append(self, play):
+        self._len += 1
         self._history.append(play)
         self._counter[play] += 1
 
@@ -39,7 +41,9 @@ class HistoryList(object):
         return play
 
     def reset(self):
+        del self._history
         self._history = []
+        self._len = 0
         self._counter = Counter()
 
     def __eq__(self, other):
@@ -62,7 +66,7 @@ class HistoryList(object):
         if isinstance(other, list):
             # temp = self._history + ''.join(other)
             temp = self._history + other
-        if isinstance(other, str):
+        elif isinstance(other, str):
             temp = self._history + list(other)
         elif isinstance(other, HistoryList):
             temp = self._history + other._history
@@ -72,8 +76,15 @@ class HistoryList(object):
         # Passthrough keys and slice objects
         return "".join(self._history[key])
 
+    def __str__(self):
+        return "".join(self._history)
+
+    def __list__(self):
+        return self._history
+
     def __len__(self):
-        return len(self._history)
+        return self._len
+        # return len(self._history)
 
     def __repr__(self):
         return "History: " + ''.join(self._history)
@@ -82,6 +93,7 @@ class HistoryList(object):
 class HistoryString(object):
     def __init__(self, history=None):
         self._history = ""
+        self._len = 0
         self._counter = Counter()
         if isinstance(history, History):
             history = history._history
@@ -91,6 +103,7 @@ class HistoryString(object):
     def append(self, play):
         self._history += play
         self._counter[play] += 1
+        self._len += 1
 
     @property
     def cooperations(self):
@@ -114,45 +127,54 @@ class HistoryString(object):
         play = self._history[index]
         self._history = self._history[:index] + self._history[index+1:]
         self._counter[play] -= 1
+        self._len -= 1
         return play
 
     def reset(self):
         self._history = ""
         self._counter = Counter()
+        self._len = 0
+
+    def __add__(self, other):
+        if isinstance(other, HistoryString):
+            temp = self._history + other._history
+        elif isinstance(other, str):
+            temp = self._history + other
+        elif isinstance(other, list):
+            temp = self._history + ''.join(other)
+        return HistoryString(temp)
 
     def __eq__(self, other):
         # Allow comparison to lists and strings
-        if isinstance(other, str):
+        if isinstance(other, HistoryString):
+            other_history = other._history
+        elif isinstance(other, str):
             other_history = other
         elif isinstance(other, list):
             other_history = "".join(other)
-        elif isinstance(other, HistoryString):
-            other_history = other._history
         else:
             raise ValueError("Cannot compare types.")
 
         return (self._history == other_history)
 
-    def __add__(self, other):
-        if isinstance(other, list):
-            temp = self._history + ''.join(other)
-        if isinstance(other, str):
-            temp = self._history + other
-        elif isinstance(other, HistoryString):
-            temp = self._history + other._history
-        return HistoryString(temp)
-
     def __getitem__(self, key):
         # Passthrough keys and slice objects
-        return "".join(self._history[key])
+        return self._history[key]
+
+    def __str__(self):
+        return self._history
+
+    def __list__(self):
+        return list(self._history)
 
     def __len__(self):
-        return len(self._history)
+        return self._len
+        # return len(self._history)
 
     def __repr__(self):
         return "History: " + ''.join(self._history)
 
-History = HistoryList
+History = HistoryString
 
 
 class JointHistory(object):

--- a/axelrod/history.py
+++ b/axelrod/history.py
@@ -1,52 +1,72 @@
 from collections import Counter, defaultdict
 
+from .actions import Actions
+
+C, D = Actions.C, Actions.D
+
 
 class History(object):
     def __init__(self, history=None):
+        self._history = ""
+        self._counter = Counter()
         if isinstance(history, History):
             history = history._history
-        self._history = []
-        self._counter = Counter()
         if history:
-            self.extend(list(history))
+            self.extend(history)
 
     def append(self, play):
-        self._history.append(play)
+        # self._history.append(play)
+        self._history += play
         self._counter[play] += 1
 
+    @property
     def cooperations(self):
-        return self._counter['C']
+        return self._counter[C]
 
     def copy(self):
         new_history = History(self._history)
         return new_history
 
+    @property
     def defections(self):
-        return self._counter['D']
+        return self._counter[D]
 
-    def extend(self, list_):
-        self._history.extend(list_)
-        self._counter.update(list_)
+    def extend(self, plays):
+        for play in plays:
+            self.append(play)
 
     def pop(self, index):
-        play = self._history.pop(index)
+        # play = self._history.pop(index)
+        play = self._history[index]
+        self._history = self._history[0:index] + self._history[index+1:]
         self._counter[play] -= 1
         return play
 
     def reset(self):
-        self._history = []
+        self._history = ""
         self._counter = Counter()
 
     def __eq__(self, other):
         # Allow comparison to lists and strings
         if isinstance(other, str):
-            other = list(str)
-        if isinstance(other, list):
             other_history = other
-        else:
+        elif isinstance(other, list):
+            other_history = "".join(other)
+        elif isinstance(other, History):
             other_history = other._history
+        else:
+            raise ValueError("Cannot compare types.")
 
         return (self._history == other_history)
+
+    def __add__(self, other):
+        if isinstance(other, list):
+            temp = self._history + ''.join(other)
+        if isinstance(other, str):
+            temp = self._history + other
+        elif isinstance(other, History):
+            temp = self._history + other._history
+        return History(temp)
 
     def __getitem__(self, key):
         # Passthrough keys and slice objects

--- a/axelrod/history.py
+++ b/axelrod/history.py
@@ -5,7 +5,80 @@ from .actions import Actions
 C, D = Actions.C, Actions.D
 
 
-class History(object):
+class HistoryList(object):
+    def __init__(self, history=None):
+        self._history = []
+        self._counter = Counter()
+        if isinstance(history, History):
+            history = history._history
+        if history:
+            self.extend(history)
+
+    def append(self, play):
+        self._history.append(play)
+        self._counter[play] += 1
+
+    @property
+    def cooperations(self):
+        return self._counter[C]
+
+    def copy(self):
+        new_history = History(self._history)
+        return new_history
+
+    @property
+    def defections(self):
+        return self._counter[D]
+
+    def extend(self, plays):
+        for play in plays:
+            self.append(play)
+
+    def pop(self, index):
+        play = self._history.pop(index)
+        return play
+
+    def reset(self):
+        self._history = []
+        self._counter = Counter()
+
+    def __eq__(self, other):
+        # Allow comparison to lists and strings
+        if isinstance(other, str):
+            # other_history = other
+            other_history = list(other)
+        elif isinstance(other, list):
+            # other_history = "".join(other)
+            other_history = other
+        elif isinstance(other, History):
+            other_history = other._history
+        else:
+            raise ValueError("Cannot compare types.")
+
+        return (self._history == other_history)
+
+    def __add__(self, other):
+        if isinstance(other, list):
+            # temp = self._history + ''.join(other)
+            temp = self._history + other
+        if isinstance(other, str):
+            temp = self._history + list(other)
+        elif isinstance(other, History):
+            temp = self._history + other._history
+        return History(temp)
+
+    def __getitem__(self, key):
+        # Passthrough keys and slice objects
+        return "".join(self._history[key])
+
+    def __len__(self):
+        return len(self._history)
+
+    def __repr__(self):
+        return "History: " + ''.join(self._history)
+
+
+class HistoryString(object):
     def __init__(self, history=None):
         self._history = ""
         self._counter = Counter()
@@ -15,7 +88,6 @@ class History(object):
             self.extend(history)
 
     def append(self, play):
-        # self._history.append(play)
         self._history += play
         self._counter[play] += 1
 
@@ -36,9 +108,10 @@ class History(object):
             self.append(play)
 
     def pop(self, index):
-        # play = self._history.pop(index)
+        if index == -1:
+            index = len(self._history) - 1
         play = self._history[index]
-        self._history = self._history[0:index] + self._history[index+1:]
+        self._history = self._history[:index] + self._history[index+1:]
         self._counter[play] -= 1
         return play
 
@@ -70,13 +143,15 @@ class History(object):
 
     def __getitem__(self, key):
         # Passthrough keys and slice objects
-        return self._history[key]
+        return "".join(self._history[key])
 
     def __len__(self):
         return len(self._history)
 
     def __repr__(self):
         return "History: " + ''.join(self._history)
+
+History = HistoryList
 
 
 class JointHistory(object):

--- a/axelrod/history.py
+++ b/axelrod/history.py
@@ -1,11 +1,4 @@
-from collections import Counter, defaultdict
-
-
-def copy_history(history):
-    """Copies a history object efficiently."""
-    new_history = History()
-    new_history.extend(history)
-    return new_history
+from collections import Counter
 
 
 class History(object):
@@ -16,8 +9,7 @@ class History(object):
             self.extend(history)
 
     def copy(self):
-        new_history = History()
-        new_history.extend(self._history)
+        new_history = History(self._history)
         return new_history
 
     def reset(self):
@@ -51,7 +43,9 @@ class History(object):
         return self._history[key]
 
     def __eq__(self, other):
-        # Allow comparison to lists
+        # Allow comparison to lists and strings
+        if isinstance(other, str):
+            other = list(str)
         if isinstance(other, list):
             other_history = other
         else:

--- a/axelrod/history.py
+++ b/axelrod/history.py
@@ -1,24 +1,28 @@
-from collections import Counter
+from collections import Counter, defaultdict
 
 
 class History(object):
     def __init__(self, history=None):
+        if isinstance(history, History):
+            history = history._history
         self._history = []
         self._counter = Counter()
         if history:
-            self.extend(history)
+            self.extend(list(history))
+
+    def append(self, play):
+        self._history.append(play)
+        self._counter[play] += 1
+
+    def cooperations(self):
+        return self._counter['C']
 
     def copy(self):
         new_history = History(self._history)
         return new_history
 
-    def reset(self):
-        self._history = []
-        self._counter = Counter()
-
-    def append(self, play):
-        self._history.append(play)
-        self._counter[play] += 1
+    def defections(self):
+        return self._counter['D']
 
     def extend(self, list_):
         self._history.extend(list_)
@@ -29,18 +33,9 @@ class History(object):
         self._counter[play] -= 1
         return play
 
-    def __len__(self):
-        return len(self._history)
-
-    def cooperations(self):
-        return self._counter['C']
-
-    def defections(self):
-        return self._counter['D']
-
-    def __getitem__(self, key):
-        # Passthrough keys and slice objects
-        return self._history[key]
+    def reset(self):
+        self._history = []
+        self._counter = Counter()
 
     def __eq__(self, other):
         # Allow comparison to lists and strings
@@ -53,5 +48,61 @@ class History(object):
 
         return (self._history == other_history)
 
+    def __getitem__(self, key):
+        # Passthrough keys and slice objects
+        return self._history[key]
+
+    def __len__(self):
+        return len(self._history)
+
     def __repr__(self):
         return "History: " + ''.join(self._history)
+
+
+class JointHistory(object):
+    def __init__(self, my_history, op_history):
+        self._my_history = History(my_history)
+        self._op_history = History(op_history)
+        self._joint = defaultdict(int)
+        for (h1, h2) in zip(my_history, op_history):
+            self._joint[(h1, h2)] += 1
+
+    def append(self, my_play, op_play):
+        self._my_history.append(my_play)
+        self._op_history.append(op_play)
+        self._joint[(my_play, op_play)] += 1
+
+    # def cooperations(self):
+    #     return self._my_history.cooperations()
+
+    def copy(self):
+        new = JointHistory(self._my_history, self._op_history)
+        return new
+
+    # def defections(self):
+    #     return self._my_history.defections()
+
+    def pop(self, index):
+        my_play = self._my_history.pop(index)
+        op_play = self._my_history.pop(index)
+        self._joint[(my_play, op_play)] -= 1
+        return (my_play, op_play)
+
+
+    def reset(self):
+        self._my_history.reset()
+        self._op_history.reset()
+        self._joint = Counter()
+
+    def __eq__(self, other):
+        return (self._my_history == other._my_history) and \
+               (self._op_history == other._op_history)
+
+    def __getitem__(self, key):
+        # Passthrough keys and slice objects
+        return (self._my_history[key], self._op_history[key])
+
+    def __len__(self):
+        return len(self._my_history)
+
+

--- a/axelrod/match.py
+++ b/axelrod/match.py
@@ -85,7 +85,7 @@ class Match(object):
     @property
     def _cache_update_required(self):
         """
-        A boolean to show whether the deterministic cache should be updated
+        A boolean to show whether the deterministic cache should be updated.
         """
         return (
             not self.noise and
@@ -152,11 +152,11 @@ class Match(object):
         return self.players[winner_index]
 
     def cooperation(self):
-        """Returns the count of cooperations by each player"""
+        """Returns the count of cooperations by each player."""
         return iu.compute_cooperations(self.result)
 
     def normalised_cooperation(self):
-        """Returns the count of cooperations by each player per turn"""
+        """Returns the count of cooperations by each player per turn."""
         return iu.compute_normalised_cooperation(self.result)
 
     def state_distribution(self):

--- a/axelrod/match_generator.py
+++ b/axelrod/match_generator.py
@@ -1,4 +1,3 @@
-from __future__ import division
 from math import ceil, log
 import random
 
@@ -78,9 +77,8 @@ class RoundRobinMatches(MatchGenerator):
 
     def __len__(self):
         """
-        The size of the generator.
-        This corresponds to the number of match chunks as it
-        ignores repetitions.
+        The size of the generator. This corresponds to the number of match
+        chunks as it ignores repetitions.
         """
         n = len(self.players)
         num_matches = int(n * (n - 1) // 2 + n)
@@ -171,7 +169,10 @@ class ProbEndRoundRobinMatches(RoundRobinMatches):
 
 def graph_is_connected(edges, players):
     """
-    Test if a set of edges defines a complete graph on a set of players.
+    Test if the set of edges defines a graph in which each player is connected
+    to at least one other player. This function does not test if the graph
+    is fully connected in the sense that each node is reachable from every
+    other node.
 
     This is used by the spatial tournaments.
 
@@ -182,7 +183,8 @@ def graph_is_connected(edges, players):
 
     Returns:
     --------
-    boolean : True if the graph is connected
+    boolean : True if the graph is connected as specified in the function
+    definition.
     """
     # Check if all players are connected.
     player_indices = set(range(len(players)))
@@ -192,7 +194,6 @@ def graph_is_connected(edges, players):
             node_indices.add(node)
 
     return player_indices == node_indices
-
 
 
 class SpatialMatches(RoundRobinMatches):

--- a/axelrod/mock_player.py
+++ b/axelrod/mock_player.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 
-from axelrod import get_state_distribution_from_history, Player, \
-    update_history, update_state_distribution,  Actions
+from axelrod import Actions, Player, update_history, update_state_distribution
+from .history import History
 
 C, D = Actions.C, Actions.D
 
@@ -13,7 +13,7 @@ class MockPlayer(Player):
     def __init__(self, player, move):
         # Need to retain history for opponents that examine opponents history
         Player.__init__(self)
-        self.history = player.history.copy()
+        self.history = History(player.history)
         self.move = move
 
     def strategy(self, opponent):

--- a/axelrod/moran.py
+++ b/axelrod/moran.py
@@ -301,7 +301,7 @@ class MoranProcessGraph(MoranProcess):
             probability `mutation_rate`
         mode: string, bd
             Birth-Death (bd) or Death-Birth (db)
-        match_class: subclass of Match
+        match_class: subclass of axelrod.Match
             The match type to use for scoring
         """
         MoranProcess.__init__(self, players, turns=turns, noise=noise,

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
+import copy
 from functools import wraps
 import random
-import copy
 
 from axelrod import Actions, flip_action
 from .game import DefaultGame
@@ -71,6 +71,7 @@ def init_args(func):
     def wrapper(self, *args, **kwargs):
         r = func(self, *args, **kwargs)
         self.init_args = args
+        self.init_kwargs = kwargs
         return r
     return wrapper
 
@@ -104,6 +105,7 @@ class Player(object):
                 self.classifier[dimension] = self.default_classifier[dimension]
         self.state_distribution = defaultdict(int)
         self.init_args = ()
+        self.init_kwargs = dict()
         self.set_match_attributes()
 
     def receive_match_attributes(self):
@@ -159,7 +161,7 @@ class Player(object):
         # be significant changes required throughout the library.
         # Consider overriding in special cases only if necessary
         cls = self.__class__
-        new_player = cls(*self.init_args)
+        new_player = cls(*self.init_args, **self.init_kwargs)
         new_player.match_attributes = dict(self.match_attributes)
         return new_player
 
@@ -178,16 +180,13 @@ class Player(object):
 
     @history.setter
     def history(self, obj):
-        if isinstance(obj, list):
-            self._history = History(history=obj)
-        elif isinstance(obj, History):
-            self._history = obj.copy()
+        self._history = History(history=obj)
 
     @property
     def cooperations(self):
-        return self.history.cooperations()
+        return self.history.cooperations
 
     @property
     def defections(self):
-        return self.history.defections()
+        return self.history.defections
 

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -160,7 +160,7 @@ class Player(object):
         # Consider overriding in special cases only if necessary
         cls = self.__class__
         new_player = cls(*self.init_args)
-        new_player.match_attributes = copy.copy(self.match_attributes)
+        new_player.match_attributes = dict(self.match_attributes)
         return new_player
 
     def reset(self):

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -5,7 +5,7 @@ import copy
 
 from axelrod import Actions, flip_action
 from .game import DefaultGame
-
+from .history import History
 
 C, D = Actions.C, Actions.D
 
@@ -46,11 +46,11 @@ def update_history(player, move):
     """Updates histories and cooperation / defections counts following play."""
     # Update histories
     player.history.append(move)
-    # Update player counts of cooperation and defection
-    if move == C:
-        player.cooperations += 1
-    elif move == D:
-        player.defections += 1
+    # # Update player counts of cooperation and defection
+    # if move == C:
+    #     player.cooperations += 1
+    # elif move == D:
+    #     player.defections += 1
 
 
 def get_state_distribution_from_history(player, history_1, history_2):
@@ -101,15 +101,15 @@ class Player(object):
 
     def __init__(self):
         """Initiates an empty history and 0 score for a player."""
-        self.history = []
+        self.history = History()
         self.classifier = copy.deepcopy(self.classifier)
         if self.name == "Player":
             self.classifier['stochastic'] = False
         for dimension in self.default_classifier:
             if dimension not in self.classifier:
                 self.classifier[dimension] = self.default_classifier[dimension]
-        self.cooperations = 0
-        self.defections = 0
+        # self.cooperations = 0
+        # self.defections = 0
         self.state_distribution = defaultdict(int)
         self.init_args = ()
         self.set_match_attributes()
@@ -177,7 +177,27 @@ class Player(object):
         should be re-written (in the inherited class) and should not only reset
         history but also rest all other attributes.
         """
-        self.history = []
+        self._history.reset()
         self.cooperations = 0
         self.defections = 0
         self.state_distribution = defaultdict(int)
+
+    @property
+    def history(self):
+        return self._history
+
+    @history.setter
+    def history(self, obj):
+        if isinstance(obj, list):
+            self._history = History(history=obj)
+        elif isinstance(obj, History):
+            self._history = copy_history(obj)
+
+    @property
+    def cooperations(self):
+        return self.history.cooperations()
+
+    @property
+    def defections(self):
+        return self.history.defections()
+

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -44,13 +44,7 @@ def obey_axelrod(s):
 
 def update_history(player, move):
     """Updates histories and cooperation / defections counts following play."""
-    # Update histories
     player.history.append(move)
-    # # Update player counts of cooperation and defection
-    # if move == C:
-    #     player.cooperations += 1
-    # elif move == D:
-    #     player.defections += 1
 
 
 def get_state_distribution_from_history(player, history_1, history_2):
@@ -101,15 +95,13 @@ class Player(object):
 
     def __init__(self):
         """Initiates an empty history and 0 score for a player."""
-        self.history = History()
+        self._history = History()
         self.classifier = copy.deepcopy(self.classifier)
         if self.name == "Player":
             self.classifier['stochastic'] = False
         for dimension in self.default_classifier:
             if dimension not in self.classifier:
                 self.classifier[dimension] = self.default_classifier[dimension]
-        # self.cooperations = 0
-        # self.defections = 0
         self.state_distribution = defaultdict(int)
         self.init_args = ()
         self.set_match_attributes()
@@ -162,7 +154,7 @@ class Player(object):
         """Clones the player without history, reapplying configuration
         parameters as necessary."""
 
-        # You may be tempted to reimplement using the `copy` module
+        # You may be tempted to re-implement using the `copy` module
         # Note that this would require a deepcopy in some cases and there may
         # be significant changes required throughout the library.
         # Consider overriding in special cases only if necessary
@@ -178,8 +170,6 @@ class Player(object):
         history but also rest all other attributes.
         """
         self._history.reset()
-        self.cooperations = 0
-        self.defections = 0
         self.state_distribution = defaultdict(int)
 
     @property
@@ -191,7 +181,7 @@ class Player(object):
         if isinstance(obj, list):
             self._history = History(history=obj)
         elif isinstance(obj, History):
-            self._history = copy_history(obj)
+            self._history = obj.copy()
 
     @property
     def cooperations(self):

--- a/axelrod/random_.py
+++ b/axelrod/random_.py
@@ -2,6 +2,7 @@ import random
 import numpy
 from axelrod import Actions
 
+C, D = Actions.C, Actions.D
 
 def random_choice(p=0.5):
     """
@@ -20,16 +21,17 @@ def random_choice(p=0.5):
     -------
     axelrod.Actions.C or axelrod.Actions.D
     """
+    assert (p >= 0) and (p <= 1)
     if p == 0:
-        return Actions.D
+        return D
 
     if p == 1:
-        return Actions.C
+        return C
 
     r = random.random()
     if r < p:
-        return Actions.C
-    return Actions.D
+        return C
+    return D
 
 
 def randrange(a, b):

--- a/axelrod/result_set.py
+++ b/axelrod/result_set.py
@@ -31,7 +31,7 @@ class ResultSet(object):
     """A class to hold the results of a tournament."""
 
     def __init__(self, players, interactions, repetitions=False,
-                 progress_bar=True, game=None, num_interactions=False):
+                 progress_bar=True, game=None):
         """
         Parameters
         ----------
@@ -42,9 +42,7 @@ class ResultSet(object):
                 interactions (1 for each repetition)
             repetitions : int
                 The number of repetitions
-            num_interactions : int
-                The number of interactions
-            game : axlerod.game
+            game : axelrod.game
                 The particular game used.
             progress_bar : bool
                 Whether or not to create a progress bar which will be updated
@@ -81,7 +79,7 @@ class ResultSet(object):
 
     def _update_players(self, index_pair, players):
         """
-        During a read of the data, update the internal players dictionary
+        During a read of the data, update the internal players dictionary.
 
         Parameters
         ----------
@@ -97,7 +95,7 @@ class ResultSet(object):
 
     def _update_repetitions(self, index_pair, nbr=1):
         """
-        During a read of the data, update the internal repetitions dictionary
+        During a read of the data, update the internal repetitions dictionary.
 
         Parameters
         ----------
@@ -114,7 +112,7 @@ class ResultSet(object):
 
     def _build_repetitions(self):
         """
-        Count the number of repetitions
+        Count the number of repetitions.
 
         Returns
         -------
@@ -129,7 +127,7 @@ class ResultSet(object):
 
     def _build_players(self):
         """
-        List the players
+        List the players.
 
         Returns
         -------
@@ -150,8 +148,8 @@ class ResultSet(object):
         Returns:
         --------
 
-        The eigenmoses rating as defined in:
-        http://www.scottaaronson.com/morality.pdf
+            The eigenmoses rating as defined in:
+            http://www.scottaaronson.com/morality.pdf
         """
         eigenvector, eigenvalue = eigen.principal_eigenvector(
             self.vengeful_cooperation)
@@ -164,8 +162,8 @@ class ResultSet(object):
         Returns:
         --------
 
-        The eigenjesus rating as defined in:
-        http://www.scottaaronson.com/morality.pdf
+            The eigenjesus rating as defined in:
+            http://www.scottaaronson.com/morality.pdf
         """
         eigenvector, eigenvalue = eigen.principal_eigenvector(
             self.normalised_cooperation)
@@ -413,7 +411,7 @@ class ResultSet(object):
 
     def _update_payoffs(self, p1, p2, scores_per_turn):
         """
-        During a read of the data, update the payoffs attribute
+        During a read of the data, update the payoffs attribute.
 
         Parameters
         ----------
@@ -429,7 +427,7 @@ class ResultSet(object):
 
     def _update_score_diffs(self, repetition, p1, p2, scores_per_turn):
         """
-        During a read of the data, update the score diffs attribute
+        During a read of the data, update the score diffs attribute.
 
         Parameters
         ----------
@@ -445,7 +443,7 @@ class ResultSet(object):
 
     def _update_normalised_cooperation(self, p1, p2, interaction):
         """
-        During a read of the data, update the normalised cooperation attribute
+        During a read of the data, update the normalised cooperation attribute.
 
         Parameters
         ----------
@@ -462,7 +460,7 @@ class ResultSet(object):
 
     def _update_wins(self, repetition, p1, p2, interaction):
         """
-        During a read of the data, update the wins attribute
+        During a read of the data, update the wins attribute.
 
         Parameters
         ----------
@@ -483,7 +481,7 @@ class ResultSet(object):
 
     def _update_scores(self, repetition, p1, p2, interaction):
         """
-        During a read of the data, update the scores attribute
+        During a read of the data, update the scores attribute.
 
         Parameters
         ----------
@@ -502,7 +500,7 @@ class ResultSet(object):
 
     def _update_normalised_scores(self, repetition, p1, p2, scores_per_turn):
         """
-        During a read of the data, update the normalised scores attribute
+        During a read of the data, update the normalised scores attribute.
 
         Parameters
         ----------
@@ -520,7 +518,7 @@ class ResultSet(object):
 
     def _update_cooperation(self, p1, p2, cooperations):
         """
-        During a read of the data, update the cooperation attribute
+        During a read of the data, update the cooperation attribute.
 
         Parameters
         ----------
@@ -536,7 +534,7 @@ class ResultSet(object):
     def _update_initial_cooperation_count(self, p1, p2, initial_cooperations):
         """
         During a read of the data, update the initial cooperation count
-        attribute
+        attribute.
 
         Parameters
         ----------
@@ -553,7 +551,7 @@ class ResultSet(object):
 
     def _update_state_distribution(self, p1, p2, counter):
         """
-        During a read of the data, update the state_distribution attribute
+        During a read of the data, update the state_distribution attribute.
 
         Parameters
         ----------
@@ -570,7 +568,7 @@ class ResultSet(object):
 
     def _update_good_partner_matrix(self, p1, p2, cooperations):
         """
-        During a read of the data, update the good partner matrix attribute
+        During a read of the data, update the good partner matrix attribute.
 
         Parameters
         ----------
@@ -587,7 +585,7 @@ class ResultSet(object):
 
     def _summarise_normalised_scores(self):
         """
-        At the end of a read of the data, finalise the normalised scores
+        At the end of a read of the data, finalise the normalised scores.
         """
         for i, rep in enumerate(self.normalised_scores):
             for j, player_scores in enumerate(rep):
@@ -602,7 +600,7 @@ class ResultSet(object):
 
     def _summarise_normalised_cooperation(self):
         """
-        At the end of a read of the data, finalise the normalised cooperation
+        At the end of a read of the data, finalise the normalised cooperation.
         """
         for i, rep in enumerate(self.normalised_cooperation):
             for j, cooperation in enumerate(rep):
@@ -618,7 +616,7 @@ class ResultSet(object):
     @update_progress_bar
     def _build_good_partner_rating(self):
         """
-        At the end of a read of the data, build the good partner rating
+        At the end of a read of the data, build the good partner rating.
         attribute
         """
         return [sum(self.good_partner_matrix[player]) /
@@ -629,7 +627,7 @@ class ResultSet(object):
     def _build_initial_cooperation_rate(self):
         """
         At the end of a read of the data, build the normalised initial
-        cooperation rate attribute
+        cooperation rate attribute.
         """
         return [self.initial_cooperation_count[player] /
                 max(1, float(self.total_interactions[player]))
@@ -712,7 +710,7 @@ class ResultSet(object):
 
     def __eq__(self, other):
         """
-        Check equality of results set
+        Check equality of results set.
 
         Parameters
         ----------
@@ -742,7 +740,7 @@ class ResultSet(object):
 
     def __ne__(self, other):
         """
-        Check inequality of results set
+        Check inequality of results set.
 
         Parameters
         ----------
@@ -818,7 +816,7 @@ class ResultSet(object):
 
     def read_match_chunks(self, progress_bar=False):
         """
-        A generator to return a given repetitions of matches
+        A generator to return a given repetitions of matches.
 
         Parameters
         ----------
@@ -850,7 +848,7 @@ class ResultSet(object):
 
     def _read_players_and_repetition_numbers(self, progress_bar=False):
         """
-        Read the players and the repetitions numbers
+        Read the players and the repetitions numbers.
 
         Parameters
         ----------

--- a/axelrod/strategies/adaptive.py
+++ b/axelrod/strategies/adaptive.py
@@ -28,7 +28,7 @@ class Adaptive(Player):
     def __init__(self, initial_plays=None):
         Player.__init__(self)
         if not initial_plays:
-            initial_plays = [C] * 6 + [D] * 5
+            initial_plays = C * 6 + D * 5
         self.initial_plays = initial_plays
         self.scores = {C: 0, D: 0}
 

--- a/axelrod/strategies/alternator.py
+++ b/axelrod/strategies/alternator.py
@@ -1,6 +1,9 @@
 from axelrod import Actions, Player
 
 
+C, D = Actions.C, Actions.D
+
+
 class Alternator(Player):
     """A player who alternates between cooperating and defecting."""
 
@@ -17,7 +20,7 @@ class Alternator(Player):
 
     def strategy(self, opponent):
         if len(self.history) == 0:
-            return Actions.C
-        if self.history[-1] == Actions.C:
-            return Actions.D
-        return Actions.C
+            return C
+        if self.history[-1] == C:
+            return D
+        return C

--- a/axelrod/strategies/alternator.py
+++ b/axelrod/strategies/alternator.py
@@ -1,5 +1,7 @@
 from axelrod import Actions, Player
 
+C, D = Actions.C, Actions.D
+
 
 C, D = Actions.C, Actions.D
 

--- a/axelrod/strategies/apavlov.py
+++ b/axelrod/strategies/apavlov.py
@@ -14,7 +14,7 @@ class APavlov2006(Player):
     uncooperative opponents.
     """
 
-    name = "Adapative Pavlov 2006"
+    name = "Adaptive Pavlov 2006"
     classifier = {
         'memory_depth': float('inf'),
         'stochastic': False,
@@ -32,16 +32,16 @@ class APavlov2006(Player):
     def strategy(self, opponent):
         # TFT for six rounds
         if len(self.history) < 6:
-            return D if opponent.history[-1:] == [D] else C
+            return D if opponent.history[-1:] == D else C
         # Classify opponent
         if len(self.history) % 6 == 0:
-            if opponent.history[-6:] == [C] * 6:
+            if opponent.history[-6:] == C * 6:
                 self.opponent_class = "Cooperative"
-            if opponent.history[-6:] == [D] * 6:
+            if opponent.history[-6:] == D * 6:
                 self.opponent_class = "ALLD"
-            if opponent.history[-6:] == [D, C, D, C, D, C]:
+            if opponent.history[-6:] == D + C + D + C + D + C:
                 self.opponent_class = "STFT"
-            if opponent.history[-6:] == [D, D, C, D, D, C]:
+            if opponent.history[-6:] == D + D + C + D + D + C:
                 self.opponent_class = "PavlovD"
             if not self.opponent_class:
                 self.opponent_class = "Random"
@@ -53,7 +53,7 @@ class APavlov2006(Player):
             if len(self.history) % 6 in [0, 1]:
                 return C
             # TFT
-            if opponent.history[-1:] == [D]:
+            if opponent.history[-1:] == D:
                 return D
         if self.opponent_class == "PavlovD":
             # Return D then C for the period
@@ -61,7 +61,7 @@ class APavlov2006(Player):
                 return D
         if self.opponent_class == "Cooperative":
             # TFT
-            if opponent.history[-1:] == [D]:
+            if opponent.history[-1:] == D:
                 return D
         return C
 
@@ -81,7 +81,7 @@ class APavlov2011(Player):
     uncooperative opponents.
     """
 
-    name = "Adapative Pavlov 2011"
+    name = "Adaptive Pavlov 2011"
     classifier = {
         'memory_depth': float('inf'),
         'stochastic': False,
@@ -99,26 +99,26 @@ class APavlov2011(Player):
     def strategy(self, opponent):
         # TFT for six rounds
         if len(self.history) < 6:
-            return D if opponent.history[-1:] == [D] else C
+            return D if opponent.history[-1:] == D else C
         if len(self.history) % 6 == 0:
             # Classify opponent
-            if opponent.history[-6:] == [C] * 6:
+            if opponent.history[-6:] == C * 6:
                 self.opponent_class = "Cooperative"
-            if opponent.history[-6:].count(D) >= 4:
+            elif opponent.history[-6:].count(D) >= 4:
                 self.opponent_class = "ALLD"
-            if opponent.history[-6:].count(D) == 3:
+            elif opponent.history[-6:].count(D) == 3:
                 self.opponent_class = "STFT"
-            if not self.opponent_class:
+            elif not self.opponent_class:
                 self.opponent_class = "Random"
         # Play according to classification
         if self.opponent_class in ["Random", "ALLD"]:
             return D
         if self.opponent_class == "STFT":
             # TFTT
-            return D if opponent.history[-2:] == [D, D] else C
+            return D if opponent.history[-2:] == D + D else C
         if self.opponent_class == "Cooperative":
             # TFT
-            return D if opponent.history[-1:] == [D] else C
+            return D if opponent.history[-1:] == D else C
 
     def reset(self):
         Player.reset(self)

--- a/axelrod/strategies/appeaser.py
+++ b/axelrod/strategies/appeaser.py
@@ -2,11 +2,13 @@ from axelrod import Actions, Player
 
 C, D = Actions.C, Actions.D
 
-class Appeaser(Player):
-    """A player who tries to guess what the opponent wants.
 
-    Switch the classifier every time the opponent plays 'D'.
-    Start with 'C', switch between 'C' and 'D' when opponent plays 'D'.
+class Appeaser(Player):
+    """
+    A player who tries to guess what the opponent wants.
+
+    Switch the classifier every time the opponent plays D.
+    Start with C, switch between C and D when opponent plays D.
     """
 
     name = 'Appeaser'

--- a/axelrod/strategies/averagecopier.py
+++ b/axelrod/strategies/averagecopier.py
@@ -3,8 +3,8 @@ from axelrod import Actions, Player, random_choice
 
 class AverageCopier(Player):
     """
-    The player will cooperate with probability p if the opponent's cooperation ratio is p.
-    Starts with random decision.
+    The player will cooperate with probability p if the opponent's cooperation
+    ratio is p. Starts with a random decision.
     """
 
     name = 'Average Copier'

--- a/axelrod/strategies/axelrod_first.py
+++ b/axelrod/strategies/axelrod_first.py
@@ -56,7 +56,8 @@ class Davis(Player):
 
 class RevisedDowning(Player):
     """Revised Downing attempts to determine if players are cooperative or not.
-    If so, it cooperates with them. This strategy would have won Axelrod's first tournament.
+    If so, it cooperates with them. This strategy would have won Axelrod's first
+    tournament.
 
     Names:
 
@@ -83,8 +84,8 @@ class RevisedDowning(Player):
         self.bad = 0.0
         self.nice1 = 0
         self.nice2 = 0
-        self.total_C = 0 # not the same as self.cooperations
-        self.total_D = 0 # not the same as self.defections
+        self.total_C = 0  # not the same as self.cooperations
+        self.total_D = 0  # not the same as self.defections
 
     def strategy(self, opponent):
         round_number = len(self.history) + 1
@@ -164,11 +165,11 @@ class Feld(Player):
         """
         Parameters
         ----------
-        start_coop_prob, float
+        start_coop_prob : float
             The initial probability to cooperate
-        end_coop_prob, float
+        end_coop_prob : float
             The final probability to cooperate
-        rounds_of_decay, int
+        rounds_of_decay : int
             The number of rounds to linearly decrease from start_coop_prob
             to end_coop_prob
         """
@@ -252,7 +253,7 @@ class Joss(MemoryOnePlayer):
         """
         Parameters
         ----------
-        p, float
+        p : float
             The probability of cooperating when the previous round was (C, C)
             or (D, C), i.e. the opponent cooperated.
         """
@@ -268,9 +269,9 @@ class Nydegger(Player):
     """
     Submitted to Axelrod's first tournament by Rudy Nydegger.
 
-    The program begins with tit for tat for the first three moves, except
-    that if it was the only one to cooperate on the first move and the only one
-    to defect on the second move, it defects on the third move. After the third
+    The program begins with tit for tat for the first three moves, except that
+    if it was the only one to cooperate on the first move and the only one to
+    defect on the second move, it defects on the third move. After the third
     move, its choice is determined from the 3 preceding outcomes in the
     following manner.
 
@@ -380,7 +381,7 @@ class Shubik(Player):
             return C
         if opponent.history[-1] == D:
             # Retaliate against defections
-            if self.history[-1] == C: # it's on now!
+            if self.history[-1] == C:  # it's on now!
                 # Lengthen the retaliation period
                 self.is_retaliating = True
                 self.retaliation_length += 1

--- a/axelrod/strategies/axelrod_first.py
+++ b/axelrod/strategies/axelrod_first.py
@@ -5,8 +5,7 @@ Additional strategies from Axelrod's first tournament.
 import random
 
 from axelrod import Actions, Player, init_args, flip_action, random_choice
-
-from.memoryone import MemoryOnePlayer
+from .memoryone import MemoryOnePlayer
 
 C, D = Actions.C, Actions.D
 
@@ -84,8 +83,8 @@ class RevisedDowning(Player):
         self.bad = 0.0
         self.nice1 = 0
         self.nice2 = 0
-        self.total_C = 0 # note the same as self.cooperations
-        self.total_D = 0 # note the same as self.defections
+        self.total_C = 0 # not the same as self.cooperations
+        self.total_D = 0 # not the same as self.defections
 
     def strategy(self, opponent):
         round_number = len(self.history) + 1
@@ -132,8 +131,8 @@ class RevisedDowning(Player):
         self.bad = 0.0
         self.nice1 = 0
         self.nice2 = 0
-        self.total_C = 0 # not the same as self.cooperations
-        self.total_D = 0 # not the same as self.defections
+        self.total_C = 0  # not the same as self.cooperations
+        self.total_D = 0  # not the same as self.defections
 
 
 class Feld(Player):
@@ -150,7 +149,7 @@ class Feld(Player):
 
     name = "Feld"
     classifier = {
-        'memory_depth': 200, # Varies actually, eventually becomes depth 1
+        'memory_depth': 200,  # Varies actually, eventually becomes depth 1
         'stochastic': True,
         'makes_use_of': set(),
         'long_run_time': False,
@@ -229,7 +228,7 @@ class Grofman(Player):
             return opponent.history[-1]
         if self.history[-1] == opponent.history[-1]:
             return C
-        return random_choice(2./ 7)
+        return random_choice(2. / 7)
 
 
 
@@ -269,12 +268,22 @@ class Nydegger(Player):
     """
     Submitted to Axelrod's first tournament by Rudy Nydegger.
 
-    The program begins with tit for tat for the first three moves, except 
-    that if it was the only one to cooperate on the first move and the only one to defect on the second move, it defects on the third move. After the third move, its choice is determined from the 3 preceding outcomes in the following manner.
+    The program begins with tit for tat for the first three moves, except
+    that if it was the only one to cooperate on the first move and the only one
+    to defect on the second move, it defects on the third move. After the third
+    move, its choice is determined from the 3 preceding outcomes in the
+    following manner.
 
-    Let A be the sum formed by counting the other's defection as 2 points and one's own as 1 point, and giving weights of 16, 4, and 1 to the preceding three moves in chronological order. The choice can be described as defecting only when A equals 1, 6, 7, 17, 22, 23, 26, 29, 30, 31, 33, 38, 39, 45, 49, 54, 55, 58, or 61.
+    Let A be the sum formed by counting the other's defection as 2 points and
+    one's own as 1 point, and giving weights of 16, 4, and 1 to the preceding
+    three moves in chronological order. The choice can be described as defecting
+    only when A equals 1, 6, 7, 17, 22, 23, 26, 29, 30, 31, 33, 38, 39, 45, 49,
+    54, 55, 58, or 61.
 
-    Thus if all three preceding moves are mutual defection, A = 63 and the rule cooperates. This rule was designed for use in laboratory experiments as a stooge which had a memory and appeared to be trustworthy, potentially cooperative, but not gullible.
+    Thus if all three preceding moves are mutual defection, A = 63 and the
+    player cooperates. This rule was designed for use in laboratory experiments
+    as a stooge which had a memory and appeared to be trustworthy, potentially
+    cooperative, but not gullible.
 
     Names:
 
@@ -317,7 +326,7 @@ class Nydegger(Player):
             # TFT
             return D if opponent.history[-1] == D else C
         if len(self.history) == 2:
-            if opponent.history[0: 2] == [D, C]:
+            if opponent.history[:2] == D + C:
                 return D
             else:
                 # TFT
@@ -333,9 +342,8 @@ class Shubik(Player):
     """
     Submitted to Axelrod's first tournament by Martin Shubik.
 
-    Plays like Tit-For-Tat with the following modification. After
-    each retaliation, the number of rounds that Shubik retaliates
-    increases by 1.
+    Plays like Tit-For-Tat with the following modification. After each
+    retaliation, the number of rounds that Shubik retaliates increases by 1.
 
     Names:
 
@@ -411,7 +419,7 @@ class Tullock(Player):
 
     name = "Tullock"
     classifier = {
-        'memory_depth': 11, # long memory, modified by init
+        'memory_depth': 11,  # long memory, modified by init
         'stochastic': True,
         'makes_use_of': set(),
         'long_run_time': False,
@@ -451,14 +459,15 @@ class UnnamedStrategy(Player):
     is also adjusted.
 
     Fourteenth Place with 282.2 points is a 77-line program by a graduate
-    student of political science whose dissertation is in game theory. This rule has
-    a probability of cooperating, P, which is initially 30% and is updated every 10
-    moves. P is adjusted if the other player seems random, very cooperative, or
-    very uncooperative. P is also adjusted after move 130 if the rule has a lower
-    score than the other player. Unfortunately, the complex process of adjustment
-    frequently left the probability of cooperation in the 30% to 70% range, and
-    therefore the rule appeared random to many other players.
-    
+    student of political science whose dissertation is in game theory. This rule
+    has a probability of cooperating, P, which is initially 30% and is updated
+    every 10 moves. P is adjusted if the other player seems random, very
+    cooperative, or very uncooperative. P is also adjusted after move 130 if the
+    rule has a lower score than the other player. Unfortunately, the complex
+    process of adjustment frequently left the probability of cooperation in the
+    30% to 70% range, and therefore the rule appeared random to many other
+    players.
+
     Names:
 
     - Unnamed Strategy: [Axelrod1980]_

--- a/axelrod/strategies/axelrod_second.py
+++ b/axelrod/strategies/axelrod_second.py
@@ -13,8 +13,12 @@ class Champion(Player):
     """
     Strategy submitted to Axelrod's second tournament by Danny Champion.
 
-    This player cooperates on the first 10 moves and plays Tit for Tat for the next 15 more moves. After 25 moves, the program cooperates unless all the following are true: the other player defected on the previous move, the other player cooperated less than 60% and the random number between 0 and 1 is greater that the other player's cooperation rate.
-    
+    This player cooperates on the first 10 moves and plays Tit for Tat for the
+    next 15 more moves. After 25 moves, the program cooperates unless all the
+    following are true: the other player defected on the previous move, the
+    other player cooperated less than 60% and the random number between 0 and 1
+    is greater that the other player's cooperation rate.
+
     Names:
 
     - Champion: [Axelrod1980b]_
@@ -55,7 +59,10 @@ class Eatherley(Player):
     """
     Strategy submitted to Axelrod's second tournament by Graham Eatherley.
 
-    A player that keeps track of how many times in the game the other player defected. After the other player defects, it defects with a probability equal to the ratio of the other's total defections to the total moves to that point.
+    A player that keeps track of how many times in the game the other player
+    defected. After the other player defects, it defects with a probability
+    equal to the ratio of the other's total defections to the total moves to
+    that point.
 
     Names:
 
@@ -91,7 +98,9 @@ class Tester(Player):
     """
     Submitted to Axelrod's second tournament by David Gladstein.
 
-    Defects on the first move and plays Tit For Tat if the opponent ever defects (after one apology cooperation round). Otherwise alternate cooperation and defection.
+    Defects on the first move and plays Tit For Tat if the opponent ever defects
+    (after one apology cooperation round). Otherwise alternate cooperation and
+    defection.
 
     Names:
 
@@ -119,7 +128,7 @@ class Tester(Player):
             return D
         # Am I TFT?
         if self.is_TFT:
-            return D if opponent.history[-1:] == [D] else C
+            return D if opponent.history[-1:] == D else C
         else:
             # Did opponent defect?
             if opponent.history[-1] == D:

--- a/axelrod/strategies/backstabber.py
+++ b/axelrod/strategies/backstabber.py
@@ -30,7 +30,8 @@ class BackStabber(Player):
             return D
         return C
 
-@FinalTransformer((D, D), name_prefix=None) # End with two defections
+
+@FinalTransformer((D, D), name_prefix=None)  # End with two defections
 class DoubleCrosser(Player):
     """
     Forgives the first 3 defections but on the fourth
@@ -58,7 +59,7 @@ class DoubleCrosser(Player):
         if len(opponent.history) < 180:
             if len(opponent.history) > cutoff:
                 if D not in opponent.history[:cutoff + 1]:
-                    if opponent.history[-2:] != [D, D]:  # Fail safe
+                    if opponent.history[-2:] != D + D:  # Fail safe
                         return C
         if opponent.defections > 3:
             return D

--- a/axelrod/strategies/better_and_better.py
+++ b/axelrod/strategies/better_and_better.py
@@ -1,6 +1,5 @@
-from axelrod import Actions, Player, random_choice
+from axelrod import Player, random_choice
 
-C, D = Actions.C, Actions.D
 
 class BetterAndBetter(Player):
     """

--- a/axelrod/strategies/better_and_better.py
+++ b/axelrod/strategies/better_and_better.py
@@ -1,6 +1,7 @@
 from axelrod import Player, random_choice
 
 
+
 class BetterAndBetter(Player):
     """
     Defects with probability of '(1000 - current turn) / 1000'.
@@ -25,4 +26,5 @@ class BetterAndBetter(Player):
     def strategy(self, opponent):
         current_round = len(self.history) + 1
         probability = current_round / 1000
+        probability = min(probability, 1)
         return random_choice(probability)

--- a/axelrod/strategies/calculator.py
+++ b/axelrod/strategies/calculator.py
@@ -1,6 +1,9 @@
 from axelrod import Actions, Player
-from .axelrod_first import Joss
 from axelrod._strategy_utils import detect_cycle
+from .axelrod_first import Joss
+
+
+C, D = Actions.C, Actions.D
 
 
 class Calculator(Player):
@@ -38,10 +41,10 @@ class Calculator(Player):
 
     def extended_strategy(self, opponent):
         if self.cycle:
-            return Actions.D
+            return D
         else:
             # TFT
-            return Actions.D if opponent.history[-1:] == [Actions.D] else Actions.C
+            return D if opponent.history[-1:] == D else C
 
     def reset(self):
         Player.reset(self)

--- a/axelrod/strategies/cooperator.py
+++ b/axelrod/strategies/cooperator.py
@@ -43,6 +43,6 @@ class TrickyCooperator(Player):
         Defect once in a while in order to get a better payout, when the opponent
         has not defected in the last ten turns and only cooperated during last 3 turns.
         """
-        if D not in opponent.history[-10:] and opponent.history[-3:] == [C]*3:
+        if D not in opponent.history[-10:] and opponent.history[-3:] == C * 3:
             return D
         return C

--- a/axelrod/strategies/cycler.py
+++ b/axelrod/strategies/cycler.py
@@ -1,6 +1,9 @@
+import copy
+
 from axelrod import Actions, Player, init_args
 
-import copy
+C, D = Actions.C, Actions.D
+
 
 
 class AntiCycler(Player):
@@ -55,7 +58,7 @@ class Cycler(Player):
     }
 
     @init_args
-    def __init__(self, cycle="CCD"):
+    def __init__(self, cycle=C*2+D):
         """This strategy will repeat the parameter `cycle` endlessly,
         e.g. C C D C C D C C D ...
 
@@ -84,7 +87,7 @@ class CyclerDC(Cycler):
     classifier['memory_depth'] = 1
 
     @init_args
-    def __init__(self, cycle="DC"):
+    def __init__(self, cycle=D+C):
         Cycler.__init__(self, cycle=cycle)
 
 
@@ -95,7 +98,7 @@ class CyclerCCD(Cycler):
     classifier['memory_depth'] = 2
 
     @init_args
-    def __init__(self, cycle="CCD"):
+    def __init__(self, cycle=C*2+D):
         Cycler.__init__(self, cycle=cycle)
 
 
@@ -106,7 +109,7 @@ class CyclerDDC(Cycler):
     classifier['memory_depth'] = 2
 
     @init_args
-    def __init__(self, cycle="DDC"):
+    def __init__(self, cycle=D*2+C):
         Cycler.__init__(self, cycle=cycle)
 
 
@@ -117,7 +120,7 @@ class CyclerCCCD(Cycler):
     classifier['memory_depth'] = 3
 
     @init_args
-    def __init__(self, cycle="CCCD"):
+    def __init__(self, cycle=C*3+D):
         Cycler.__init__(self, cycle=cycle)
 
 
@@ -128,7 +131,7 @@ class CyclerCCCCCD(Cycler):
     classifier['memory_depth'] = 5
 
     @init_args
-    def __init__(self, cycle="CCCCCD"):
+    def __init__(self, cycle=C*5+D):
         Cycler.__init__(self, cycle=cycle)
 
 
@@ -139,5 +142,5 @@ class CyclerCCCDCD(Cycler):
     classifier['memory_depth'] = 5
 
     @init_args
-    def __init__(self, cycle="CCCDCD"):
+    def __init__(self, cycle=C*3+D+C+D):
         Cycler.__init__(self, cycle=cycle)

--- a/axelrod/strategies/defector.py
+++ b/axelrod/strategies/defector.py
@@ -2,6 +2,7 @@ from axelrod import Actions, Player
 
 C, D = Actions.C, Actions.D
 
+
 class Defector(Player):
     """A player who only ever defects."""
 

--- a/axelrod/strategies/defector.py
+++ b/axelrod/strategies/defector.py
@@ -41,6 +41,6 @@ class TrickyDefector(Player):
         Defect if opponent has cooperated at least once in the past and has defected
         for the last 3 turns in a row.
         """
-        if C in opponent.history and opponent.history[-3:] == [D] * 3:
+        if C in opponent.history and opponent.history[-3:] == D * 3:
             return C
         return D

--- a/axelrod/strategies/forgiver.py
+++ b/axelrod/strategies/forgiver.py
@@ -5,8 +5,8 @@ C, D = Actions.C, Actions.D
 
 class Forgiver(Player):
     """
-    A player starts by cooperating however will defect if at any point
-    the opponent has defected more than 10 percent of the time
+    A player starts by cooperating however will defect if at any point the
+    opponent has defected more than 10 percent of the time.
     """
 
     name = 'Forgiver'
@@ -23,7 +23,8 @@ class Forgiver(Player):
     @staticmethod
     def strategy(opponent):
         """
-        Begins by playing C, then plays D if the opponent has defected more than 10 percent of the time
+        Begins by playing C, then plays D if the opponent has defected more than
+        10 percent of the time
         """
         if opponent.defections > len(opponent.history) / 10.:
             return D
@@ -32,9 +33,9 @@ class Forgiver(Player):
 
 class ForgivingTitForTat(Player):
     """
-    A player starts by cooperating however will defect if at any point,
-    the opponent has defected more than 10 percent of the time,
-    and their most recent decision was defect.
+    A player starts by cooperating however will defect if at any point, the
+    opponent has defected more than 10 percent of the time, and their most
+    recent decision was defect.
     """
 
     name = 'Forgiving Tit For Tat'
@@ -51,9 +52,8 @@ class ForgivingTitForTat(Player):
     @staticmethod
     def strategy(opponent):
         """
-        Begins by playing C, then plays D if,
-        the opponent has defected more than 10 percent of the time,
-        and their most recent decision was defect.
+        Begins by playing C, then plays D if the opponent has defected more than
+        10 percent of the time and their most recent decision was defect.
         """
         if opponent.defections > len(opponent.history) / 10.:
             return opponent.history[-1]

--- a/axelrod/strategies/forgiver.py
+++ b/axelrod/strategies/forgiver.py
@@ -2,6 +2,7 @@ from axelrod import Actions, Player
 
 C, D = Actions.C, Actions.D
 
+
 class Forgiver(Player):
     """
     A player starts by cooperating however will defect if at any point

--- a/axelrod/strategies/gambler.py
+++ b/axelrod/strategies/gambler.py
@@ -5,7 +5,7 @@ For the original see:
  https://gist.github.com/GDKO/60c3d0fd423598f3c4e4
 """
 
-from axelrod import Actions, random_choice, load_pso_tables
+from axelrod import Actions, init_args, load_pso_tables, random_choice
 from .lookerup import LookerUp, create_lookup_table_from_pattern
 
 
@@ -50,6 +50,7 @@ class PSOGamblerMem1(Gambler):
 
     name = "PSO Gambler Mem1"
 
+    @init_args
     def __init__(self):
         pattern = tables[("PSO Gambler Mem1", 1, 1, 0)]
         lookup_table = create_lookup_table_from_pattern(
@@ -69,6 +70,7 @@ class PSOGambler1_1_1(Gambler):
 
     name = "PSO Gambler 1_1_1"
 
+    @init_args
     def __init__(self):
         pattern = tables[("PSO Gambler 1_1_1", 1, 1, 1)]
         lookup_table = create_lookup_table_from_pattern(
@@ -87,6 +89,7 @@ class PSOGambler2_2_2(Gambler):
 
     name = "PSO Gambler 2_2_2"
 
+    @init_args
     def __init__(self):
         pattern = tables[("PSO Gambler 2_2_2", 2, 2, 2)]
         lookup_table = create_lookup_table_from_pattern(
@@ -106,6 +109,7 @@ class PSOGambler2_2_2_Noise05(Gambler):
 
     name = "PSO Gambler 2_2_2 Noise 05"
 
+    @init_args
     def __init__(self):
         pattern = tables[("PSO Gambler 2_2_2 Noise 05", 2, 2, 2)]
         lookup_table = create_lookup_table_from_pattern(

--- a/axelrod/strategies/gobymajority.py
+++ b/axelrod/strategies/gobymajority.py
@@ -18,7 +18,7 @@ class GoByMajority(Player):
     default this is 0)
     """
 
-    name = 'Go By Marjority'
+    name = 'Go By Majority'
     classifier = {
         'stochastic': False,
         'inspects_source': False,
@@ -66,8 +66,8 @@ class GoByMajority(Player):
         """
 
         history = opponent.history[-self.memory:]
-        defections = sum([s == D for s in history])
-        cooperations = sum([s == C for s in history])
+        defections = history.count(D)
+        cooperations = history.count(C)
         if defections > cooperations:
             return D
         if defections == cooperations:

--- a/axelrod/strategies/gradualkiller.py
+++ b/axelrod/strategies/gradualkiller.py
@@ -1,9 +1,10 @@
-from axelrod import Actions, Player, init_args
+from axelrod import Actions, Player
 from axelrod.strategy_transformers import InitialTransformer
 
 C, D = Actions.C, Actions.D
 
-@InitialTransformer((D, D, D, D, D, C, C), name_prefix=None)
+
+@InitialTransformer(D * 5 + C * 2, name_prefix=None)
 class GradualKiller(Player):
     """
     It begins by defecting in the first five moves, then cooperates two times.
@@ -17,10 +18,9 @@ class GradualKiller(Player):
     - Gradual Killer: [PRISON1998]_
     """
 
-    # These are various properties for the strategy
     name = 'Gradual Killer'
     classifier = {
-        'memory_depth': float('Inf'),
+        'memory_depth': float('inf'),
         'stochastic': False,
         'makes_use_of': set(),
         'long_run_time': False,
@@ -30,6 +30,6 @@ class GradualKiller(Player):
     }
 
     def strategy(self, opponent):
-        if opponent.history[5:7] == [D, D]:
+        if opponent.history[5:7] == D + D:
             return D
         return C

--- a/axelrod/strategies/grudger.py
+++ b/axelrod/strategies/grudger.py
@@ -2,6 +2,7 @@ from axelrod import Actions, Player
 
 C, D = Actions.C, Actions.D
 
+
 class Grudger(Player):
     """
     A player starts by cooperating however will defect if at any point the

--- a/axelrod/strategies/grumpy.py
+++ b/axelrod/strategies/grumpy.py
@@ -45,7 +45,8 @@ class Grumpy(Player):
         and nicer the more they cooperate.
 
         Starts off Nice, but becomes grumpy once the grumpiness threshold is hit.
-        Won't become nice once that grumpy threshold is hit, but must reach a much lower threshold before it becomes nice again.
+        Won't become nice once that grumpy threshold is hit, but must reach a
+        much lower threshold before it becomes nice again.
         """
 
         self.grumpiness = opponent.defections - opponent.cooperations

--- a/axelrod/strategies/handshake.py
+++ b/axelrod/strategies/handshake.py
@@ -27,7 +27,7 @@ class Handshake(Player):
     def __init__(self, initial_plays=None):
         Player.__init__(self)
         if not initial_plays:
-            initial_plays = [C, D]
+            initial_plays = C + D
         self.initial_plays = initial_plays
 
     def strategy(self, opponent):

--- a/axelrod/strategies/human.py
+++ b/axelrod/strategies/human.py
@@ -22,7 +22,7 @@ class ActionValidator(Validator):
     def validate(self, document):
         text = document.text
 
-        if text and text.upper() not in ['C', 'D']:
+        if text and text.upper() not in C + D:
             raise ValidationError(
                 message='Action must be C or D',
                 cursor_position=0)
@@ -51,7 +51,7 @@ class Human(Player):
     }
 
     @init_args
-    def __init__(self, name='Human', c_symbol='C', d_symbol='D'):
+    def __init__(self, name='Human', c_symbol=C, d_symbol=D):
         """
         Parameters
         ----------

--- a/axelrod/strategies/hunter.py
+++ b/axelrod/strategies/hunter.py
@@ -44,6 +44,13 @@ class CooperatorHunter(Player):
         return C
 
 
+def is_alternator(history):
+    for i in range(len(history) - 1):
+        if history[i] == history[i+1]:
+            return False
+    return True
+
+
 class AlternatorHunter(Player):
     """A player who hunts for alternators."""
 
@@ -58,11 +65,23 @@ class AlternatorHunter(Player):
         'manipulates_state': False
     }
 
+    def __init__(self):
+        Player.__init__(self)
+        self.is_alt = False
+
     def strategy(self, opponent):
-        oh = opponent.history
-        if len(self.history) >= 6 and all([oh[i] != oh[i+1] for i in range(len(oh)-1)]):
+        if len(opponent.history) < 6:
+            return C
+        if len(self.history) == 6:
+            if is_alternator(opponent.history):
+                self.is_alt = True
+        if self.is_alt:
             return D
         return C
+
+    def reset(self):
+        Player.reset(self)
+        self.is_alt = False
 
 
 class CycleHunter(Player):
@@ -80,17 +99,27 @@ class CycleHunter(Player):
         'manipulates_state': False
     }
 
-    @staticmethod
-    def strategy(opponent):
-        cycle = detect_cycle(opponent.history, min_size=2)
+    def __init__(self):
+        Player.__init__(self)
+        self.cycle = None
+
+    def strategy(self, opponent):
+        if self.cycle:
+            return D
+        cycle = detect_cycle(opponent.history, min_size=3)
         if cycle:
             if len(set(cycle)) > 1:
+                self.cycle = cycle
                 return D
         return C
 
+    def reset(self):
+        Player.reset(self)
+        self.cycle = None
 
-class EventualCycleHunter(Player):
-    """Hunts strategies that eventually play cyclically"""
+
+class EventualCycleHunter(CycleHunter):
+    """Hunts strategies that eventually play cyclically."""
 
     name = 'Eventual Cycle Hunter'
     classifier = {
@@ -103,13 +132,16 @@ class EventualCycleHunter(Player):
         'manipulates_state': False
     }
 
-    @staticmethod
-    def strategy(opponent):
+    def strategy(self, opponent):
         if len(opponent.history) < 10:
             return C
         if len(opponent.history) == opponent.cooperations:
             return C
-        if detect_cycle(opponent.history, offset=15):
+        if self.cycle:
+            return D
+        cycle = detect_cycle(opponent.history, offset=10, min_size=3)
+        if cycle:
+            self.cycle = cycle
             return D
         else:
             return C

--- a/axelrod/strategies/inverse.py
+++ b/axelrod/strategies/inverse.py
@@ -25,7 +25,8 @@ class Inverse(Player):
         If so, player defection is inversely proportional to when this occurred.
         """
 
-        index = next((index for index, value in enumerate(opponent.history, start=1) if value == D), None)
+        index = next((index for index, value in enumerate(opponent.history, start=1)
+                      if value == D), None)
 
         if index is None:
             return C

--- a/axelrod/strategies/lookerup.py
+++ b/axelrod/strategies/lookerup.py
@@ -194,6 +194,7 @@ class Winner12(LookerUp):
     """
     name = "Winner12"
 
+    @init_args
     def __init__(self):
         lookup_table_keys = create_lookup_table_keys(
             plays=1, op_plays=2, op_start_plays=0)
@@ -214,6 +215,7 @@ class Winner21(LookerUp):
     """
     name = "Winner21"
 
+    @init_args
     def __init__(self):
         lookup_table_keys = create_lookup_table_keys(
             plays=2, op_plays=1, op_start_plays=0)

--- a/axelrod/strategies/mathematicalconstants.py
+++ b/axelrod/strategies/mathematicalconstants.py
@@ -26,7 +26,7 @@ class CotoDeRatio(Player):
         # Avoid initial division by zero
         if not opponent.defections:
             return D
-        # Otherwise compare ratio to golden mean
+        # Otherwise compare ratio to ratio
         cooperations = opponent.cooperations + self.cooperations
         defections = float(opponent.defections + self.defections)
         if cooperations / defections > self.ratio:

--- a/axelrod/strategies/mathematicalconstants.py
+++ b/axelrod/strategies/mathematicalconstants.py
@@ -2,6 +2,8 @@ from math import e, pi, sqrt
 
 from axelrod import Actions, Player
 
+C, D = Actions.C, Actions.D
+
 
 class CotoDeRatio(Player):
     """The player will always aim to bring the ratio of co-operations to
@@ -20,16 +22,16 @@ class CotoDeRatio(Player):
     def strategy(self, opponent):
         # Initially cooperate
         if len(opponent.history) == 0:
-            return Actions.C
+            return C
         # Avoid initial division by zero
         if not opponent.defections:
-            return Actions.D
+            return D
         # Otherwise compare ratio to golden mean
         cooperations = opponent.cooperations + self.cooperations
         defections = float(opponent.defections + self.defections)
         if cooperations / defections > self.ratio:
-            return Actions.D
-        return Actions.C
+            return D
+        return C
 
 
 class Golden(CotoDeRatio):

--- a/axelrod/strategies/memoryone.py
+++ b/axelrod/strategies/memoryone.py
@@ -1,7 +1,7 @@
 from axelrod import Actions, Player, init_args, random_choice
 
-
 C, D = Actions.C, Actions.D
+
 
 class MemoryOnePlayer(Player):
     """Uses a four-vector for strategies based on the last round of play,
@@ -82,7 +82,7 @@ class WinStayLoseShift(MemoryOnePlayer):
 
     name = 'Win-Stay Lose-Shift'
     classifier = {
-        'memory_depth': 1,  # Memory-one Four-Vector
+        'memory_depth': 1,
         'stochastic': False,
         'makes_use_of': set(),
         'long_run_time': False,
@@ -108,7 +108,7 @@ class WinShiftLoseStay(MemoryOnePlayer):
 
     name = 'Win-Shift Lose-Stay'
     classifier = {
-        'memory_depth': 1,  # Memory-one Four-Vector
+        'memory_depth': 1,
         'stochastic': False,
         'makes_use_of': set(),
         'long_run_time': False,
@@ -134,7 +134,7 @@ class GTFT(MemoryOnePlayer):
 
     name = 'GTFT'
     classifier = {
-        'memory_depth': 1,  # Memory-one Four-Vector
+        'memory_depth': 1,
         'stochastic': True,
         'makes_use_of': set(["game"]),
         'long_run_time': False,
@@ -237,7 +237,7 @@ class LRPlayer(MemoryOnePlayer):
 
     name = 'LinearRelation'
     classifier = {
-        'memory_depth': 1,  # Memory-one Four-Vector
+        'memory_depth': 1,
         'stochastic': True,
         'makes_use_of': set(["game"]),
         'long_run_time': False,

--- a/axelrod/strategies/memoryone.py
+++ b/axelrod/strategies/memoryone.py
@@ -55,7 +55,8 @@ class MemoryOnePlayer(Player):
         if not all(0 <= p <= 1 for p in four_vector):
             raise ValueError('An element in the probability vector, %s, is not between 0 and 1.' % str(four_vector))
 
-        self._four_vector = dict(zip([(C, C), (C, D), (D, C), (D, D)], map(float, four_vector)))
+        self._four_vector = dict(zip([(C, C), (C, D), (D, C), (D, D)],
+                                     map(float, four_vector)))
         self.classifier['stochastic'] = any(0 < x < 1 for x in set(four_vector))
 
     def strategy(self, opponent):

--- a/axelrod/strategies/memorytwo.py
+++ b/axelrod/strategies/memorytwo.py
@@ -43,7 +43,7 @@ class MEM2(Player):
     def strategy(self, opponent):
         # Update Histories
         # Note that this assumes that TFT and TFTT do not use internal counters,
-        # Rather that they examine the actual history of play
+        # rather that they examine the actual history of play.
         if len(self.history) > 0:
             for v in self.players.values():
                 v.history.append(self.history[-1])

--- a/axelrod/strategies/meta.py
+++ b/axelrod/strategies/meta.py
@@ -40,7 +40,6 @@ class MetaPlayer(Player):
 
         # Make sure we don't use any meta players to avoid infinite recursion.
         self.team = [t for t in self.team if not issubclass(t, MetaPlayer)]
-        self.nteam = len(self.team)
 
         # Initiate all the player in out team.
         self.team = [t() for t in self.team]

--- a/axelrod/strategies/meta.py
+++ b/axelrod/strategies/meta.py
@@ -195,6 +195,7 @@ class MetaHunter(MetaPlayer):
         'manipulates_state': False
     }
 
+    @init_args
     def __init__(self):
         # Notice that we don't include the cooperator hunter, because it leads
         # to excessive defection and therefore bad performance against
@@ -219,7 +220,7 @@ class MetaHunter(MetaPlayer):
         # false-positives. So go ahead and use it, but only for longer
         # histories.
         if len(opponent.history) > 100:
-            return D if opponent.history[-1:] == [D] else C
+            return D if opponent.history[-1:] == D else C
         else:
             return C
 
@@ -238,6 +239,7 @@ class MetaHunterAggressive(MetaPlayer):
         'manipulates_state': False
     }
 
+    @init_args
     def __init__(self):
         # This version uses CooperatorHunter
         team = [DefectorHunter, AlternatorHunter, RandomHunter,
@@ -257,7 +259,7 @@ class MetaHunterAggressive(MetaPlayer):
         # false-positives. So go ahead and use it, but only for longer
         # histories.
         if len(opponent.history) > 100:
-            return D if opponent.history[-1:] == [D] else C
+            return D if opponent.history[-1:] == D else C
         else:
             return C
 

--- a/axelrod/strategies/mindreader.py
+++ b/axelrod/strategies/mindreader.py
@@ -6,6 +6,7 @@ from axelrod._strategy_utils import look_ahead
 
 C, D = Actions.C, Actions.D
 
+
 class MindReader(Player):
     """A player that looks ahead at what the opponent will do and decides what to do."""
 

--- a/axelrod/strategies/negation.py
+++ b/axelrod/strategies/negation.py
@@ -1,8 +1,7 @@
-import random
-from axelrod import Actions, Player, random_choice, flip_action, init_args
-from axelrod.strategy_transformers import TrackHistoryTransformer
+from axelrod import Actions, Player, random_choice, flip_action
 
 C, D = Actions.C, Actions.D
+
 
 class Negation(Player):
     """
@@ -28,8 +27,8 @@ class Negation(Player):
     def strategy(self, opponent):
         # Random first move
         if not self.history:
-            return random_choice();
-        
+            return random_choice()
+
         # Act opposite of opponent otherwise
         return flip_action(opponent.history[-1])
-		
+

--- a/axelrod/strategies/negation.py
+++ b/axelrod/strategies/negation.py
@@ -31,4 +31,3 @@ class Negation(Player):
 
         # Act opposite of opponent otherwise
         return flip_action(opponent.history[-1])
-

--- a/axelrod/strategies/oncebitten.py
+++ b/axelrod/strategies/oncebitten.py
@@ -3,6 +3,7 @@ from axelrod import Actions, Player, init_args
 
 C, D = Actions.C, Actions.D
 
+
 class OnceBitten(Player):
     """
     Cooperates once when the opponent defects, but if they defect twice in a row defaults to forgetful grudger for 10 turns defecting

--- a/axelrod/strategies/oncebitten.py
+++ b/axelrod/strategies/oncebitten.py
@@ -6,12 +6,13 @@ C, D = Actions.C, Actions.D
 
 class OnceBitten(Player):
     """
-    Cooperates once when the opponent defects, but if they defect twice in a row defaults to forgetful grudger for 10 turns defecting
+    Cooperates once when the opponent defects, but if they defect twice in a row
+    defaults to forgetful grudger for 10 turns defecting
     """
 
     name = 'Once Bitten'
     classifier = {
-        'memory_depth': 12,  # Long memory
+        'memory_depth': 12,
         'stochastic': False,
         'makes_use_of': set(),
         'long_run_time': False,
@@ -101,7 +102,7 @@ class ForgetfulFoolMeOnce(Player):
         """
         Parameters
         ----------
-        forget_probability, float
+        forget_probability:  float
             The probability of forgetting the count of opponent defections.
         """
         Player.__init__(self)

--- a/axelrod/strategies/prober.py
+++ b/axelrod/strategies/prober.py
@@ -1,6 +1,7 @@
+from axelrod import random_choice
+
 from axelrod import Actions, Player, init_args, random_choice
 
-import random
 
 C, D = Actions.C, Actions.D
 
@@ -37,7 +38,7 @@ class CollectiveStrategy(Player):
             return D
         if opponent.defections > 1:
             return D
-        if opponent.history[0:2] == [C, D]:
+        if opponent.history[0:2] == C + D:
             return C
         return D
 
@@ -68,11 +69,11 @@ class Prober(Player):
         if turn == 2:
             return C
         if turn > 2:
-            if opponent.history[1: 3] == [C, C]:
+            if opponent.history[1: 3] == C + C:
                 return D
             else:
                 # TFT
-                return D if opponent.history[-1:] == [D] else C
+                return D if opponent.history[-1:] == D else C
 
 
 class Prober2(Player):
@@ -101,11 +102,11 @@ class Prober2(Player):
         if turn == 2:
             return C
         if turn > 2:
-            if opponent.history[1: 3] == [D, C]:
+            if opponent.history[1: 3] == D + C:
                 return C
             else:
                 # TFT
-                return D if opponent.history[-1:] == [D] else C
+                return D if opponent.history[-1:] == D else C
 
 
 class Prober3(Player):
@@ -136,7 +137,7 @@ class Prober3(Player):
                 return D
             else:
                 # TFT
-                return D if opponent.history[-1:] == [D] else C
+                return D if opponent.history[-1:] == D else C
 
 
 class Prober4(Player):
@@ -228,11 +229,11 @@ class HardProber(Player):
         if turn == 3:
             return C
         if turn > 3:
-            if opponent.history[1: 3] == [C, C]:
+            if opponent.history[1: 3] == C + C:
                 return D
             else:
                 # TFT
-                return D if opponent.history[-1:] == [D] else C
+                return D if opponent.history[-1:] == D else C
 
 
 class NaiveProber(Player):
@@ -261,7 +262,7 @@ class NaiveProber(Player):
         """
         Parameters
         ----------
-        p, float
+        p : float
             The probability to defect randomly
         """
         Player.__init__(self)
@@ -315,7 +316,7 @@ class RemorsefulProber(NaiveProber):
 
     @init_args
     def __init__(self, p=0.1):
-        NaiveProber.__init__(self, p)
+        NaiveProber.__init__(self, p=p)
         self.probing = False
 
     def strategy(self, opponent):
@@ -330,7 +331,8 @@ class RemorsefulProber(NaiveProber):
             return D
 
         # Otherwise cooperate with probability 1 - self.p
-        if random.random() < 1 - self.p:
+        # if random.random() < 1 - self.p:
+        if random_choice(1 - self.p) == C:
             self.probing = False
             return C
 
@@ -338,5 +340,5 @@ class RemorsefulProber(NaiveProber):
         return D
 
     def reset(self):
-        Player.reset(self)
+        NaiveProber.reset(self)
         self.probing = False

--- a/axelrod/strategies/punisher.py
+++ b/axelrod/strategies/punisher.py
@@ -2,6 +2,7 @@ from axelrod import Actions, Player
 
 C, D = Actions.C, Actions.D
 
+
 class Punisher(Player):
     """
     A player starts by cooperating however will defect if at any point the
@@ -88,7 +89,6 @@ class InversePunisher(Player):
 
     def __init__(self):
         super(InversePunisher, self).__init__()
-        self.history = []
         self.mem_length = 1
         self.grudged = False
         self.grudge_memory = 1

--- a/axelrod/strategies/punisher.py
+++ b/axelrod/strategies/punisher.py
@@ -67,9 +67,10 @@ class Punisher(Player):
 
 class InversePunisher(Player):
     """
-    An inverted version of Punisher. Similarly the player starts by cooperating however will defect if at any point the
-    opponent has defected, but forgets after mem_length matches, with 1 <= mem_length <= 20. This time mem_length is
-    proportional to the amount of time the opponent has played C.
+    An inverted version of Punisher. Similarly the player starts by cooperating
+    however will defect if at any point the opponent has defected, but forgets
+    after mem_length matches, with 1 <= mem_length <= 20. This time mem_length
+    is proportional to the amount of time the opponent has played C.
 
     Names:
 
@@ -95,7 +96,9 @@ class InversePunisher(Player):
 
     def strategy(self, opponent):
         """
-        Begins by playing C, then plays D for an amount of rounds proportional to the opponents historical '%' of playing C if the opponent ever plays D
+        Begins by playing C, then plays D for an amount of rounds proportional
+        to the opponents historical '%' of playing C if the opponent ever plays
+        D.
         """
 
         if self.grudge_memory >= self.mem_length:

--- a/axelrod/strategies/qlearner.py
+++ b/axelrod/strategies/qlearner.py
@@ -41,9 +41,7 @@ class RiskyQLearner(Player):
         # Set this explicitely, since the constructor of super will not pick it up
         # for any subclasses that do not override methods using random calls.
         self.classifier['stochastic'] = True
-
         self.prev_action = random_choice()
-        self.history = []
         self.score = 0
         self.Qs = OrderedDict({'':  OrderedDict(zip([C, D], [0, 0]))})
         self.Vs = OrderedDict({'': 0})

--- a/axelrod/strategies/rand.py
+++ b/axelrod/strategies/rand.py
@@ -26,7 +26,7 @@ class Random(Player):
         """
         Parameters
         ----------
-        p, float
+        p : float
             The probability to cooperate
 
         Special Cases

--- a/axelrod/strategies/sequence_player.py
+++ b/axelrod/strategies/sequence_player.py
@@ -2,6 +2,9 @@ from axelrod import Actions, Player, init_args
 from axelrod._strategy_utils import thue_morse_generator
 
 
+C, D = Actions.C, Actions.D
+
+
 class SequencePlayer(Player):
     """Abstract base class for players that use a generated sequence to
     determine their plays.
@@ -20,9 +23,9 @@ class SequencePlayer(Player):
         By default, treat values like python truth values. Override in child
         classes for alternate behaviors."""
         if value == 0:
-            return Actions.D
+            return D
         else:
-            return Actions.C
+            return C
 
     def strategy(self, opponent):
         # Iterate through the sequence and apply the meta strategy
@@ -90,6 +93,6 @@ class ThueMorseInverse(ThueMorse):
     def meta_strategy(self, value):
         # Switch the default cooperate and defect action on 0 or 1
         if value == 0:
-            return Actions.C
+            return C
         else:
-            return Actions.D
+            return D

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -64,7 +64,7 @@ class TitFor2Tats(Player):
 
     @staticmethod
     def strategy(opponent):
-        return D if opponent.history[-2:] == [D, D] else C
+        return D if opponent.history[-2:] == D + D else C
 
 
 class TwoTitsForTat(Player):
@@ -118,7 +118,7 @@ class Bully(Player):
 
     @staticmethod
     def strategy(opponent):
-        return C if opponent.history[-1:] == [D] else D
+        return C if opponent.history[-1:] == D else D
 
 
 class SneakyTitForTat(Player):
@@ -172,7 +172,7 @@ class SuspiciousTitForTat(Player):
 
     @staticmethod
     def strategy(opponent):
-        return C if opponent.history[-1:] == [C] else D
+        return C if opponent.history[-1:] == C else D
 
 
 class AntiTitForTat(Player):
@@ -197,7 +197,7 @@ class AntiTitForTat(Player):
 
     @staticmethod
     def strategy(opponent):
-        return D if opponent.history[-1:] == [C] else C
+        return D if opponent.history[-1:] == C else C
 
 
 class HardTitForTat(Player):
@@ -257,7 +257,7 @@ class HardTitFor2Tats(Player):
         if not opponent.history:
             return C
         # Defects if two consecutive D in the opponent's last three moves
-        history_string = "".join(opponent.history[-3:])
+        history_string = opponent.history[-3:]
         if 'DD' in history_string:
             return D
         # Otherwise cooperates
@@ -300,7 +300,7 @@ class OmegaTFT(Player):
             return C
         # TFT on round 2
         if len(self.history) == 1:
-            return D if opponent.history[-1:] == [D] else C
+            return D if opponent.history[-1:] == D else C
 
         # Are we deadlocked? (in a CD -> DC loop)
         if (self.deadlock_counter >= self.deadlock_threshold):
@@ -311,7 +311,7 @@ class OmegaTFT(Player):
                 self.deadlock_counter = 0
         else:
             # Update counters
-            if opponent.history[-2:] == [C, C]:
+            if opponent.history[-2:] == C + C:
                 self.randomness_counter -= 1
             # If the opponent's move changed, increase the counter
             if opponent.history[-2] != opponent.history[-1]:
@@ -326,7 +326,7 @@ class OmegaTFT(Player):
                 self.move = D
             else:
                 # TFT
-                self.move = D if opponent.history[-1:] == [D] else C
+                self.move = D if opponent.history[-1:] == D else C
                 # Check for deadlock
                 if opponent.history[-2] != opponent.history[-1]:
                     self.deadlock_counter += 1
@@ -447,7 +447,11 @@ class ContriteTitForTat(Player):
     def reset(self):
         Player.reset(self)
         self.contrite = False
-        self._recorded_history = []
+        try:
+            self._recorded_history.reset()
+        except AttributeError:
+            # The history object may not exist if no plays have occurred.
+            pass
 
 
 class SlowTitForTwoTats(Player):
@@ -589,7 +593,7 @@ class SpitefulTitForTat(Player):
         if not self.history:
             return C
 
-        if opponent.history[-2:] == [D, D]:
+        if opponent.history[-2:] == D + D:
             self.retaliating = True
 
         if self.retaliating:

--- a/axelrod/strategies/worse_and_worse.py
+++ b/axelrod/strategies/worse_and_worse.py
@@ -28,8 +28,11 @@ class WorseAndWorse(Player):
 
     def strategy(self, opponent):
         current_round = len(self.history) + 1
-        probability = 1 - current_round / 1000
-        return random_choice(probability)
+        p = 1 - current_round / 1000
+        p = min(p, 1)
+        p = max(0, p)
+        return random_choice(p)
+
 
 
 class KnowledgeableWorseAndWorse(Player):
@@ -55,8 +58,10 @@ class KnowledgeableWorseAndWorse(Player):
     def strategy(self, opponent):
         current_round = len(self.history) + 1
         expected_length = self.match_attributes['length']
-        probability = 1 - current_round / expected_length
-        return random_choice(probability)
+        p = 1 - current_round / expected_length
+        p = min(p, 1)
+        p = max(0, p)
+        return random_choice(p)
 
 
 class WorseAndWorse2(Player):

--- a/axelrod/strategy_transformers.py
+++ b/axelrod/strategy_transformers.py
@@ -13,6 +13,7 @@ import random
 from numpy.random import choice
 from .actions import Actions, flip_action
 from .random_ import random_choice
+from .history import History
 
 
 C, D = Actions.C, Actions.D
@@ -283,7 +284,7 @@ def history_track_wrapper(player, opponent, action):
     try:
         player._recorded_history.append(action)
     except AttributeError:
-        player._recorded_history = [action]
+        player._recorded_history = History(action)
     return action
 
 

--- a/axelrod/tests/unit/test_actions.py
+++ b/axelrod/tests/unit/test_actions.py
@@ -1,19 +1,29 @@
 import unittest
 from axelrod import Actions, flip_action
 
+C, D = Actions.C, Actions.D
+
+
 class TestAction(unittest.TestCase):
 
     def test_action_values(self):
-        self.assertEqual(Actions.C, 'C')
-        self.assertEqual(Actions.D, 'D')
-        self.assertNotEqual(Actions.D, 'd')
-        self.assertNotEqual(Actions.C, 'c')
-        self.assertNotEqual(Actions.C, Actions.D)
+        self.assertEqual(C, 'C')
+        self.assertEqual(D, 'D')
+        self.assertNotEqual(D, 'd')
+        self.assertNotEqual(C, 'c')
+        self.assertNotEqual(C, D)
 
+
+    def test_sums(self):
+        self.assertEqual("CC", C + C)
+        self.assertEqual("CD", C + D)
+        self.assertEqual("DC", D + C)
+        self.assertEqual("DD", D + D)
+        self.assertEqual("CDCD", (C + D) * 2)
 
     def test_flip_action(self):
-        self.assertEqual(flip_action(Actions.D), Actions.C)
-        self.assertEqual(flip_action(Actions.C), Actions.D)
+        self.assertEqual(flip_action(D), C)
+        self.assertEqual(flip_action(C), D)
 
         with self.assertRaises(ValueError):
             flip_action('R')

--- a/axelrod/tests/unit/test_adaptive.py
+++ b/axelrod/tests/unit/test_adaptive.py
@@ -1,7 +1,6 @@
-"""Test for the Adaptive strategy."""
+"""Tests for the Adaptive strategy."""
 
 import axelrod
-
 from .test_player import TestHeadsUp, TestPlayer
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
@@ -23,7 +22,7 @@ class TestAdaptive(TestPlayer):
 
     def test_strategy(self):
         # Test initial play sequence
-        self.responses_test([], [], [C] * 6 + [D] * 5)
+        self.responses_test(C * 6 + D * 5)
 
     def test_scoring(self):
         player = axelrod.Adaptive()
@@ -41,22 +40,22 @@ class TestAdaptivevsCooperator(TestHeadsUp):
     """Test TFT vs WSLS"""
     def test_rounds(self):
         self.versus_test(axelrod.Adaptive(), axelrod.Cooperator(),
-                         [C] * 6 + [D] * 5 + [D] * 3, [C] * 14)
+                         C * 6 + D * 5 + D * 3, C * 14)
 
 class TestAdaptivevsDefector(TestHeadsUp):
     """Test TFT vs WSLS"""
     def test_rounds(self):
         self.versus_test(axelrod.Adaptive(), axelrod.Defector(),
-                         [C] * 6 + [D] * 5 + [D] * 3, [D] * 14)
+                         C * 6 + D * 5 + D * 3, D * 14)
 
 class TestAdaptivevsAlternator(TestHeadsUp):
     """Test TFT vs WSLS"""
     def test_rounds(self):
         self.versus_test(axelrod.Adaptive(), axelrod.Alternator(),
-                         [C] * 6 + [D] * 5 + [D] * 3, [C, D] * 7)
+                         C * 6 + D * 5 + D * 3, (C + D) * 7)
 
 class TestAdaptivevsTFT(TestHeadsUp):
     """Test TFT vs WSLS"""
     def test_rounds(self):
         self.versus_test(axelrod.Adaptive(), axelrod.TitForTat(),
-                         [C] * 6 + [D] * 5 + [C, C], [C] * 7 + [D] * 4 + [D, C])
+                         C * 6 + D * 5 + C + C, C * 7 + D * 4 + D + C)

--- a/axelrod/tests/unit/test_alternator.py
+++ b/axelrod/tests/unit/test_alternator.py
@@ -1,7 +1,6 @@
-"""Test for the alternator strategy."""
+"""Tests for the alternator strategy."""
 
 import axelrod
-
 from .test_player import TestPlayer
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
@@ -22,13 +21,12 @@ class TestAlternator(TestPlayer):
     }
 
     def test_strategy(self):
-        """Starts by cooperating."""
+        # Starts by cooperating.
         self.first_play_test(C)
 
-    def test_effect_of_strategy(self):
-        """Simply does the opposite to what the strategy did last time."""
-        self.markov_test([D, D, C, C])
+        # Simply does the opposite to what the strategy did last time.
+        self.second_play_test(D, D, C, C)
         for i in range(10):
-            self.responses_test([], [], [C, D] * i)
-        self.responses_test([C, D, D, D], [C, C, C, C], [C])
-        self.responses_test([C, C, D, D, C], [C, D, C, C, C], [D])
+            self.responses_test((C + D) * i)
+        self.responses_test(C, C + D * 3, C * 4)
+        self.responses_test(D, C + C + D + D + C, C + D + C * 4)

--- a/axelrod/tests/unit/test_ann.py
+++ b/axelrod/tests/unit/test_ann.py
@@ -1,4 +1,4 @@
-"""Test for the Adaptive strategy."""
+"""Tests for the Adaptive strategy."""
 import unittest
 
 import axelrod
@@ -74,45 +74,43 @@ class TestEvolvedANNNoise05(TestPlayer):
         self.first_play_test(C)
 
 
-
 class TestEvolvedANNvsCooperator(TestHeadsUp):
     def test_rounds(self):
         self.versus_test(axelrod.EvolvedANN(), axelrod.Cooperator(),
-                         [C] * 5, [C] * 5)
+                         C * 5, C * 5)
 
 
 class TestEvolvedANNvsDefector(TestHeadsUp):
     def test_rounds(self):
         self.versus_test(axelrod.EvolvedANN(), axelrod.Defector(),
-                         [C, C, D, D, D], [D] * 5)
+                         C * 2 + D * 3, D * 5)
 
 
 class TestEvolvedANNvsTFT(TestHeadsUp):
     def test_rounds(self):
         self.versus_test(axelrod.EvolvedANN(), axelrod.TitForTat(),
-                         [C] * 5, [C] * 5)
+                         C * 5, C * 5)
 
 
 class TestEvolvedANN5vsCooperator(TestHeadsUp):
     def test_rounds(self):
         self.versus_test(axelrod.EvolvedANN5(), axelrod.Cooperator(),
-                         [C] * 5, [C] * 5)
+                         C * 5, C * 5)
 
 
 class TestEvolvedANN5vsDefector(TestHeadsUp):
     def test_rounds(self):
         self.versus_test(axelrod.EvolvedANN5(), axelrod.Defector(),
-                         [C] * 5 + [D], [D] * 6)
+                         C * 5 + D, D * 6)
 
 
 class TestEvolvedANNNoise05vsCooperator(TestHeadsUp):
     def test_rounds(self):
         self.versus_test(axelrod.EvolvedANNNoise05(), axelrod.Cooperator(),
-                         [C] * 5, [C] * 5)
+                         C * 5, C * 5)
 
 
 class TestEvolvedANNNoise05vsDefector(TestHeadsUp):
     def test_rounds(self):
         self.versus_test(axelrod.EvolvedANNNoise05(), axelrod.Defector(),
-                         [C] * 10, [D] * 10)
-
+                         C * 10, D * 10)

--- a/axelrod/tests/unit/test_apavlov.py
+++ b/axelrod/tests/unit/test_apavlov.py
@@ -7,7 +7,7 @@ C, D = axelrod.Actions.C, axelrod.Actions.D
 
 
 class TestAPavlov2006(TestPlayer):
-    name = "Adapative Pavlov 2006"
+    name = "Adaptive Pavlov 2006"
     player = axelrod.APavlov2006
 
     expected_classifier = {
@@ -22,19 +22,19 @@ class TestAPavlov2006(TestPlayer):
 
     def test_strategy(self):
         self.first_play_test(C)
-        self.responses_test([C] * 6, [C] * 6, [C],
+        self.responses_test(C, C * 6, C * 6,
                             attrs={"opponent_class": "Cooperative"})
-        self.responses_test([C, D, D, D, D, D], [D] * 6, [D],
+        self.responses_test(D, C + D * 5, D * 6,
                             attrs={"opponent_class": "ALLD"})
-        self.responses_test([C, D, C, D, C, D], [D, C, D, C, D, C], [C, C],
+        self.responses_test(C + C, (C + D) * 3, (D + C) * 3,
                             attrs={"opponent_class": "STFT"})
-        self.responses_test([C, D, D, C, D, D], [D, D, C, D, D, C], [D],
+        self.responses_test(D, (C + D + D) * 2, (D + D + C) * 2,
                             attrs={"opponent_class": "PavlovD"})
-        self.responses_test([C, D, D, C, D, D, C], [D, D, C, D, D, C, D], [C],
+        self.responses_test(C, (C + D + D) * 2 + C, (D + D + C) * 2 + D,
                             attrs={"opponent_class": "PavlovD"})
-        self.responses_test([C, D, D, C, D, D], [C, C, C, D, D, D], [D],
+        self.responses_test(D, (C + D + D) * 2, C * 3 + D * 3,
                             attrs={"opponent_class": "Random"})
-        self.responses_test([C, D, D, D, C, C], [D, D, D, C, C, C], [D],
+        self.responses_test(D, C + D * 3 + C * 2, D * 3 + C * 3,
                             attrs={"opponent_class": "Random"})
 
     def test_reset(self):
@@ -44,8 +44,9 @@ class TestAPavlov2006(TestPlayer):
         player.reset()
         self.assertEqual(player.opponent_class, None)
 
+
 class TestAPavlov2011(TestPlayer):
-    name = "Adapative Pavlov 2011"
+    name = "Adaptive Pavlov 2011"
     player = axelrod.APavlov2011
 
     expected_classifier = {
@@ -60,24 +61,21 @@ class TestAPavlov2011(TestPlayer):
 
     def test_strategy(self):
         self.first_play_test(C)
-        self.responses_test([C] * 6, [C] * 6, [C],
+        self.responses_test(C, C * 6, C * 6,
                             attrs={"opponent_class": "Cooperative"})
-        self.responses_test([C, D, D, D, D, D], [D] * 6, [D],
+        self.responses_test(D, C + D * 5, D * 6,
                             attrs={"opponent_class": "ALLD"})
-        self.responses_test([C, C, D, D, D, D], [C] + [D] * 5, [D],
+        self.responses_test(D, C * 2 + D * 4, C + D * 5,
                             attrs={"opponent_class": "ALLD"})
-        self.responses_test([C, C, C, D, D, D], [C, C] + [D] * 4, [D],
+        self.responses_test(D, C * 3 + D * 3, C * 2 + D * 4,
                             attrs={"opponent_class": "ALLD"})
-        self.responses_test([C, C, D, D, C, D], [C, D, D, C, D, D], [D],
+        self.responses_test(D, C * 2 + D * 2 + C + D, (C + D * 2) * 2,
                             attrs={"opponent_class": "ALLD"})
-
-        self.responses_test([C, C, D, D, D, C], [C, D, D, C, C, D], [C],
+        self.responses_test(C, C * 2 + D * 3 + C, C + D * 2 + C * 2 + D,
                             attrs={"opponent_class": "STFT"})
-        self.responses_test([C, C, D, C, D, C], [C, D, C, D, C, D], [C],
+        self.responses_test(C, C * 2 + (D + C) * 2, (C + D) * 3,
                             attrs={"opponent_class": "STFT"})
-        self.responses_test([C, D, D, D, C, C], [D, D, D, C, C, C], [C],
-                            attrs={"opponent_class": "STFT"})
-        self.responses_test([C, D, D, D, C, C], [D, D, D, C, C, C], [C],
+        self.responses_test(C, C + D * 3 + C * 2, D * 3 + C * 3,
                             attrs={"opponent_class": "STFT"})
 
         # Specific case for STFT when responding with TFT
@@ -90,14 +88,15 @@ class TestAPavlov2011(TestPlayer):
         opponent.history.append(C)
         self.assertEqual(player.strategy(opponent), C)
 
-        self.responses_test([C, C, C, C, C, D], [C, C, C, C, D, D], [D],
+        self.responses_test(D, C * 5 + D, C * 4 + D * 2,
                             attrs={"opponent_class": "Random"})
-        self.responses_test([C, D, D, C, C, C], [D, D, C, C, C, C], [D],
+        self.responses_test(D, C + D * 2 + C * 3, D * 2 + C * 4,
                             attrs={"opponent_class": "Random"})
 
     def test_reset(self):
         player = self.player()
         opponent = axelrod.Cooperator()
-        [player.play(opponent) for _ in range(10)]
+        for _ in range(10):
+            player.play(opponent)
         player.reset()
         self.assertEqual(player.opponent_class, None)

--- a/axelrod/tests/unit/test_appeaser.py
+++ b/axelrod/tests/unit/test_appeaser.py
@@ -1,7 +1,6 @@
-"""Test for the appeaser strategy."""
+"""Tests for the appeaser strategy."""
 
 import axelrod
-
 from .test_player import TestPlayer
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
@@ -22,16 +21,9 @@ class TestAppeaser(TestPlayer):
     }
 
     def test_strategy(self):
-        """Starts by cooperating."""
+        # Starts by cooperating.
         self.first_play_test(C)
-
-    def test_effect_of_strategy(self):
-        P1 = axelrod.Appeaser()
-        P2 = axelrod.Cooperator()
-        self.assertEqual(P1.strategy(P2), C)
-
-        self.responses_test([C], [C], [C, C, C])
-        self.responses_test([C, D, C, D], [C, C, D], [D])
-        self.responses_test([C, D, C, D, C], [C, C, D, D], [C])
-        self.responses_test([C, D, C, D, C, D], [C, C, D, D, D], [D])
-
+        self.responses_test(C * 3)
+        self.responses_test(D, (C + D) * 2, C + C + D)
+        self.responses_test(C, (C + D) * 2 + C, C * 2 + D * 2)
+        self.responses_test(D, (C + D) * 3, C * 2 + D * 3 + C)

--- a/axelrod/tests/unit/test_averagecopier.py
+++ b/axelrod/tests/unit/test_averagecopier.py
@@ -1,7 +1,6 @@
-"""Test for the average_copier strategy."""
+"""Tests for the average_copier strategy."""
 
 import axelrod
-
 from .test_player import TestPlayer
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
@@ -23,18 +22,16 @@ class TestAverageCopier(TestPlayer):
 
     def test_strategy(self):
         """Test that the first strategy is picked randomly."""
-        self.responses_test([], [], [C], random_seed=1)
-        self.responses_test([], [], [D], random_seed=2)
+        self.responses_test(C, random_seed=1)
+        self.responses_test(D, random_seed=2)
 
     def test_when_oppenent_all_Cs(self):
         """Tests that if opponent has played all C then player chooses C."""
-        self.responses_test([C, C, C, C], [C, C, C, C], [C, C, C],
-                            random_seed=5)
+        self.responses_test(C * 3, C * 4, C * 4, random_seed=5)
 
     def test_when_opponent_all_Ds(self):
         """Tests that if opponent has played all D then player chooses D."""
-        self.responses_test([C, C, C, C], [D, D, D, D], [D, D, D],
-                            random_seed=5)
+        self.responses_test(D * 4, C * 4, D * 4, random_seed=5)
 
 
 class TestNiceAverageCopier(TestPlayer):
@@ -52,19 +49,9 @@ class TestNiceAverageCopier(TestPlayer):
     }
 
     def test_strategy(self):
-        """Test that the first strategy is cooperation."""
+        # First move is cooperate.
         self.first_play_test(C)
-
-    def test_when_oppenent_all_Cs(self):
-        """
-        Tests that if opponent has played all C then player chooses C
-        """
-        self.responses_test([C, C, C, C], [C, C, C, C], [C, C, C],
-                            random_seed=5)
-
-    def test_when_opponent_all_Ds(self):
-        """
-        Tests that if opponent has played all D then player chooses D
-        """
-        self.responses_test([D, D, D, D], [D, D, D, D], [D, D, D],
-                            random_seed=5)
+        # If opponent has played all C then player chooses C.
+        self.responses_test(C * 3, C * 4, C * 4, random_seed=5)
+        # If opponent has played all D then player chooses D.
+        self.responses_test(D * 3, D * 4, D * 4, random_seed=5)

--- a/axelrod/tests/unit/test_axelrod_second.py
+++ b/axelrod/tests/unit/test_axelrod_second.py
@@ -1,9 +1,9 @@
-"""Test for the inverse strategy."""
+"""Tests for the Axelrod second tournament strategies."""
 
 import random
 
 import axelrod
-
+from axelrod import History
 from .test_player import TestPlayer
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
@@ -27,16 +27,15 @@ class TestChampion(TestPlayer):
         self.first_play_test(C)
         # Cooperates for num_rounds / 20 (10 by default)
         random.seed(3)
-        random_sample = []
+        random_sample = History()
         for i in range(10):
             random_sample.append(random.choice([C, D]))
-            self.responses_test([C] * i, random_sample, [C])
+            self.responses_test(C, C * i, random_sample)
 
         # Mirror opponent in the next stage (15 rounds by default)
-        my_responses = [C] * 10
+        my_responses = History(C * 10)
         for i in range(15):
-            self.responses_test(my_responses, random_sample,
-                                [random_sample[-1]])
+            self.responses_test(random_sample[-1], my_responses, random_sample)
             my_responses.append(random_sample[-1])
             random_sample.append(random.choice([C, D]))
 
@@ -45,14 +44,16 @@ class TestChampion(TestPlayer):
         for i in range(5):
             my_responses.append(C)
             random_sample.append(C)
-            self.responses_test(my_responses, random_sample, [C])
+            self.responses_test(C, my_responses, random_sample)
 
-        self.responses_test(my_responses + [C], random_sample + [D], [C],
+        self.responses_test(C, my_responses + C, random_sample + D,
+                            random_seed=1)
+        self.responses_test(D, my_responses + C, random_sample + D,
                             random_seed=50)
-        self.responses_test(my_responses + [C], random_sample + [D], [C],
+        self.responses_test(D, my_responses + C, random_sample + D,
                             random_seed=30)
-        self.responses_test(my_responses + [C] * 40, random_sample + [D] * 40,
-                            [D], random_seed=40)
+        self.responses_test(D, my_responses + C * 40, random_sample + D * 40,
+                            random_seed=50)
 
 
 class TestEatherley(TestPlayer):
@@ -73,14 +74,14 @@ class TestEatherley(TestPlayer):
         # Initially cooperates
         self.first_play_test(C)
         # Test cooperate after opponent cooperates
-        self.responses_test([C], [C], [C])
-        self.responses_test([C, C], [C, C], [C])
-        self.responses_test([D, C], [D, C], [C])
-        self.responses_test([D, C, C], [D, C, C], [C])
+        self.responses_test(C, C, C)
+        self.responses_test(C, C * 2, C * 2)
+        self.responses_test(C, D + C, D + C)
+        self.responses_test(C, D + C + C, D + C + C)
         # Test defection after opponent defection
-        self.responses_test([D], [D], [D])
-        self.responses_test([D, D], [D, D], [D])
-        self.responses_test([D, C, C, D], [D, C, C, D], [C, C], random_seed=8)
+        self.responses_test(D, D, D)
+        self.responses_test(D, D + D, D + D)
+        self.responses_test(C + C, D + C + C + D, D + C + C + D, random_seed=8)
 
 
 class TestTester(TestPlayer):
@@ -104,17 +105,17 @@ class TestTester(TestPlayer):
     def test_effect_of_strategy(self):
 
         # Test Alternating CD
-        self.responses_test([D], [C], [C])
-        self.responses_test([D, C], [C, C], [C])
-        self.responses_test([D, C, C], [C, C, C], [D])
-        self.responses_test([D, C, C, D], [C, C, C, C], [C])
-        self.responses_test([D, C, C, D, C], [C, C, C, C, C], [D])
+        self.responses_test(C, D, C)
+        self.responses_test(C, D + C, C + C)
+        self.responses_test(D, D + C + C, C * 3)
+        self.responses_test(C, D + C + C + D, C * 4)
+        self.responses_test(D, D + C + C + D + C, C * 5)
 
         # Test cooperation after opponent defection
-        self.responses_test([D, C], [D, C], [C])
+        self.responses_test(C, D + C, D + C)
 
         # Test TFT after defection
-        self.responses_test([D, C, C], [D, C, C], [C])
-        self.responses_test([D, C, C, C], [D, C, C, C], [C])
-        self.responses_test([D, C, D], [D, D, D], [D])
-        self.responses_test([D, C, C], [D, C, D], [D])
+        self.responses_test(C, D + C + C, D + C + C)
+        self.responses_test(C, D + C * 3, D + C * 3)
+        self.responses_test(D, D + C + D, D * 3)
+        self.responses_test(D, D + C + C, D + C + D)

--- a/axelrod/tests/unit/test_backstabber.py
+++ b/axelrod/tests/unit/test_backstabber.py
@@ -1,8 +1,9 @@
+"""Tests for Backstabber strategy."""
 import axelrod
-
 from .test_player import TestPlayer
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
+
 
 class TestBackStabber(TestPlayer):
 
@@ -23,25 +24,20 @@ class TestBackStabber(TestPlayer):
         Forgives the first 3 defections but on the fourth
         will defect forever. Defects after the 198th round unconditionally.
         """
-
         self.first_play_test(C)
 
         # Forgives three defections
-        self.responses_test([C], [D], [C], tournament_length=200)
-        self.responses_test([C, C], [D, D], [C], tournament_length=200)
-        self.responses_test([C, C, C], [D, D, D], [C], tournament_length=200)
-        self.responses_test([C, C, C, C], [D, D, D, D], [D],
-                            tournament_length=200)
+        self.responses_test(C, C, D, tournament_length=200)
+        self.responses_test(C, C * 2, D * 2, tournament_length=200)
+        self.responses_test(C, C * 3, D * 3, tournament_length=200)
+        self.responses_test(D, C * 4, D * 4, tournament_length=200)
 
         # Defects on rounds 199, and 200 no matter what
-        self.responses_test([C] * 197, [C] * 197, [C, D, D],
-                            tournament_length=200)
+        self.responses_test(C + D + D, C * 197, C * 197, tournament_length=200)
         # Test that exceeds tournament length
-        self.responses_test([C] * 198, [C] * 198, [D, D, C],
-                            tournament_length=200)
+        self.responses_test(D + D + C, C * 198, C * 198, tournament_length=200)
         # But only if the tournament is known
-        self.responses_test([C] * 198, [C] * 198, [C, C, C],
-                            tournament_length=-1)
+        self.responses_test(C * 3, C * 198, C * 198, tournament_length=-1)
 
 
 class TestDoubleCrosser(TestPlayer):
@@ -69,18 +65,16 @@ class TestDoubleCrosser(TestPlayer):
         self.first_play_test(C)
 
         # Forgives three defections
-        self.responses_test([C], [D], [C], tournament_length=200)
-        self.responses_test([C, C], [D, D], [C], tournament_length=200)
-        self.responses_test([C, C, C], [D, D, D], [C], tournament_length=200)
-        self.responses_test([C, C, C, C], [D, D, D, D], [D],
-                            tournament_length=200)
+        self.responses_test(C, C, D, tournament_length=200)
+        self.responses_test(C, C * 2, D * 2, tournament_length=200)
+        self.responses_test(C, C * 3, D * 3, tournament_length=200)
+        self.responses_test(D, C * 4, D * 4, tournament_length=200)
 
         # If opponent did not defect in the first six rounds, cooperate until
         # round 180
-        self.responses_test([C] * 6, [C] * 6, [C] * 174, tournament_length=200)
-        self.responses_test([C] * 12, [C] * 6 + [D] + [C] * 5, [C] * 160,
+        self.responses_test(C * 174, C * 6, C * 6, tournament_length=200)
+        self.responses_test(C* 160, C * 12, C * 6 + D + C * 5,
                             tournament_length=200)
 
         # Defects on rounds 199, and 200 no matter what
-        self.responses_test([C] * 197, [C] * 197, [C, D, D],
-                            tournament_length=200)
+        self.responses_test(C + D + D, C * 197, C * 197, tournament_length=200)

--- a/axelrod/tests/unit/test_better_and_better.py
+++ b/axelrod/tests/unit/test_better_and_better.py
@@ -1,10 +1,9 @@
-"""Test for the Better and Better strategy."""
-
+"""Tests for the Better and Better strategy."""
 import axelrod
-
 from .test_player import TestPlayer
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
+
 
 class TestBetterAndBetter(TestPlayer):
 
@@ -21,9 +20,5 @@ class TestBetterAndBetter(TestPlayer):
     }
 
     def test_strategy(self):
-        """
-        Test that the strategy gives expected behaviour
-        """
-
-        self.responses_test([], [], [D, D, D, D, C, D, D, D, D, D], random_seed=6)
-        self.responses_test([], [], [D, D, D, D, D, D, D, D, D, D], random_seed=8)
+        self.responses_test(D * 4 + C + D * 5, random_seed=6)
+        self.responses_test(D * 10, random_seed=8)

--- a/axelrod/tests/unit/test_calculator.py
+++ b/axelrod/tests/unit/test_calculator.py
@@ -1,7 +1,6 @@
 """Tests for calculator strategies."""
 
 import axelrod
-
 from .test_player import TestPlayer
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
@@ -23,23 +22,14 @@ class TestCalculator(TestPlayer):
 
     def test_strategy(self):
         self.first_play_test(C)
-
-        P1 = axelrod.Calculator()
-        P1.history = [C] * 20
-        P2 = axelrod.Player()
-        P2.history = [C, D] * 10
-        # Defects on cycle detection
-        self.assertEqual(D, P1.strategy(P2))
-
+        # Test cycle detection
+        self.responses_test(D, C * 20, (C + D) * 10)
         # Test non-cycle response
-        history = [C, C, D, C, C, D, C, C, C, D, C, C, C, C, D, C, C, C, C, C]
-        P2.history = history
-        self.assertEqual(C, P1.strategy(P2))
-
+        history = C * 2 + D + C * 2 + D + C * 3 + D + C * 4 + D + C * 5
+        self.responses_test(C, C * 20, history)
         # Test post 20 rounds responses
-        self.responses_test([C] * 21, [C] * 21, [D])
-        history = [C, C, D, C, C, D, C, C, C, D, C, C, C, C, D, C, C, C, C, C, D]
-        self.responses_test([C] * 21, history, [D])
-        history = [C, C, D, C, C, D, C, C, C, D, C, C, C, C, D, C, C, C, C, C, D, C]
-        self.responses_test([C] * 22, history, [C])
-
+        self.responses_test(D, C * 21, C * 21)
+        history = C * 2 + D + C * 2 + D + C * 3 + D + C * 4 + D + C * 5 + D
+        self.responses_test(D, C * 21, history)
+        history += C
+        self.responses_test(C, C * 22, history)

--- a/axelrod/tests/unit/test_classification.py
+++ b/axelrod/tests/unit/test_classification.py
@@ -197,7 +197,7 @@ class TestStrategies(unittest.TestCase):
         self.assertEqual(str_reps(long_run_time_strategies),
                          str_reps(axl.long_run_time_strategies))
         self.assertTrue(all(s().classifier['long_run_time']
-                             for s in axl.long_run_time_strategies))
+                            for s in axl.long_run_time_strategies))
 
     def test_short_run_strategies(self):
         short_run_time_strategies = [s for s in axl.strategies

--- a/axelrod/tests/unit/test_cooperator.py
+++ b/axelrod/tests/unit/test_cooperator.py
@@ -1,7 +1,6 @@
-"""Test for the cooperator strategy."""
+"""Tests for the cooperator strategy."""
 
 import axelrod
-
 from .test_player import TestPlayer
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
@@ -23,10 +22,7 @@ class TestCooperator(TestPlayer):
     def test_strategy(self):
         """Starts by cooperating."""
         self.first_play_test(C)
-
-    def test_effect_of_strategy(self):
-        """Simply does the opposite to what the strategy did last time."""
-        self.markov_test([C, C, C, C])
+        self.second_play_test(C, C, C, C)
 
 
 class TestTrickyCooperator(TestPlayer):
@@ -43,13 +39,9 @@ class TestTrickyCooperator(TestPlayer):
     }
 
     def test_strategy(self):
-        """Starts by cooperating."""
         self.first_play_test(C)
-
-    def test_effect_of_strategy(self):
-        """Test if it tries to trick opponent"""
-        self.responses_test([C, C, C], [C, C, C], [D])
-        self.responses_test([C, C, C, D, D], [C, C, C, C, D], [C])
-        history = [C, C, C, D, D] + [C] * 11
-        opponent_history = [C, C, C, C, D] + [D] + [C] * 10
-        self.responses_test(history, opponent_history, [D])
+        self.responses_test(D, C * 3, C * 3)
+        self.responses_test(C, C * 3 + D * 2 + C * 5)
+        history = C * 3 + D * 2 + C * 11
+        opponent_history = C * 4 + D * 2 + C * 10
+        self.responses_test(D, history, opponent_history)

--- a/axelrod/tests/unit/test_cycler.py
+++ b/axelrod/tests/unit/test_cycler.py
@@ -2,7 +2,7 @@
 
 import itertools
 import axelrod
-from .test_player import TestPlayer, test_four_vector
+from .test_player import TestPlayer
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
 
@@ -22,9 +22,8 @@ class TestAntiCycler(TestPlayer):
     }
 
     def test_strategy(self):
-        """Starts by cooperating"""
-        responses = [C, D, C, C, D, C, C, C, D, C, C, C, C, D, C, C, C]
-        self.responses_test([], [], responses)
+        responses = C + D + C + C + D + C * 3 + D + C * 4 + D + C * 3
+        self.responses_test(responses)
 
 
 def test_cycler_factory(cycle):
@@ -44,10 +43,9 @@ def test_cycler_factory(cycle):
         }
 
         def test_strategy(self):
-            """Starts by cooperating"""
             for i in range(20):
                 responses = itertools.islice(itertools.cycle(cycle), i)
-            self.responses_test([], [], responses)
+            self.responses_test(responses)
 
     return TestCycler
 

--- a/axelrod/tests/unit/test_darwin.py
+++ b/axelrod/tests/unit/test_darwin.py
@@ -1,6 +1,4 @@
-"""
-    Tests for the Darwin PD strategy.
-"""
+"""Tests for the Darwin PD strategy."""
 
 import axelrod
 from .test_player import TestPlayer
@@ -24,14 +22,16 @@ class TestDarwin(TestPlayer):
     def test_strategy(self):
         p1 = self.player()
         p2 = axelrod.Cooperator()
-        self.assertEqual(p1.strategy(p2), C) # Always cooperate first.
+        # Always cooperate first.
+        self.assertEqual(p1.strategy(p2), C)
         for i in range(10):
             p1.play(p2)
         self.assertEqual(p1.strategy(p2), C)
 
         p1 = self.player()
         p2 = axelrod.Defector()
-        self.assertEqual(p1.strategy(p2), C) # Always cooperate first.
+        # Always cooperate first.
+        self.assertEqual(p1.strategy(p2), C)
         for i in range(10):
             p1.play(p2)
         self.assertEqual(p1.strategy(p2), C)
@@ -57,7 +57,7 @@ class TestDarwin(TestPlayer):
         """Is instance correctly reset between rounds"""
         p1 = self.player()
         p1.reset()
-        self.assertEqual(p1.history, [])
+        self.assertEqual(len(p1.history), 0)
         self.assertEqual(p1.genome[0], C)
 
     def test_unique_genome(self):

--- a/axelrod/tests/unit/test_defector.py
+++ b/axelrod/tests/unit/test_defector.py
@@ -1,7 +1,6 @@
-"""Test for the defector strategy."""
+"""Tests for the defector strategy."""
 
 import axelrod
-
 from .test_player import TestPlayer
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
@@ -22,12 +21,8 @@ class TestDefector(TestPlayer):
     }
 
     def test_strategy(self):
-        """Starts by cooperating."""
         self.first_play_test(D)
-
-    def test_effect_of_strategy(self):
-        """Test that always defects."""
-        self.markov_test([D, D, D, D])
+        self.second_play_test(D, D, D, D)
 
 
 class TestTrickyDefector(TestPlayer):
@@ -45,14 +40,10 @@ class TestTrickyDefector(TestPlayer):
     }
 
     def test_strategy(self):
-        """Starts by cooperating."""
         self.first_play_test(D)
-
-    def test_effect_of_strategy(self):
-        """Test if it tries to trick opponent"""
-        self.markov_test([D, D, D, D])
-        self.responses_test([C, C, C], [C, C, C], [D])
-        self.responses_test([C, C, C, D, D], [C, C, C, C, D], [D])
-        history = [C, C, C, D, D] + [C] * 11
-        opponent_history = [C, C, C, C, D] + [D] + [C] * 10
-        self.responses_test(history, opponent_history,[D])
+        self.second_play_test(D, D, D, D)
+        self.responses_test(D, C * 3, C * 3)
+        self.responses_test(D, C * 3 + D * 2, C * 4 + D)
+        history = C * 3 + D * 2 + C * 11
+        opponent_history = C * 4 + D * 2 + C * 10
+        self.responses_test(D, history, opponent_history)

--- a/axelrod/tests/unit/test_deterministic_cache.py
+++ b/axelrod/tests/unit/test_deterministic_cache.py
@@ -1,9 +1,10 @@
-import unittest
-import os
-import sys
-from axelrod import DeterministicCache, TitForTat, Defector, Random
-
 import pickle
+import os
+import unittest
+
+from axelrod import Actions, DeterministicCache, TitForTat, Defector, Random
+
+C, D = Actions.C, Actions.D
 
 
 class TestDeterministicCache(unittest.TestCase):
@@ -11,7 +12,7 @@ class TestDeterministicCache(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.test_key = (TitForTat(), Defector(), 3)
-        cls.test_value = [('C', 'D'), ('D', 'D'), ('D', 'D')]
+        cls.test_value = [(C, D), (D, D), (D, D)]
         cls.test_save_file = 'test_cache_save.txt'
         cls.test_load_file = 'test_cache_load.txt'
         cls.test_pickle = b'\x80\x03}q\x00X\x0b\x00\x00\x00Tit For Tatq\x01X\x08\x00\x00\x00Defectorq\x02K\x03\x87q\x03]q\x04(X\x01\x00\x00\x00Cq\x05X\x01\x00\x00\x00Dq\x06\x86q\x07h\x06h\x06\x86q\x08h\x06h\x06\x86q\tes.'

--- a/axelrod/tests/unit/test_doubler.py
+++ b/axelrod/tests/unit/test_doubler.py
@@ -1,7 +1,6 @@
-"""Test for the doubler strategy."""
+"""Tests for the doubler strategy."""
 
 import axelrod
-
 from .test_player import TestPlayer
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
@@ -28,11 +27,11 @@ class TestDoubler(TestPlayer):
         # Defects when the opponent has defected and
         # the opponent's cooperation count
         # is less than twice their defection count
-        self.responses_test([C], [D], [D])
-        self.responses_test([D, D], [D, D], [D])
-        self.responses_test([C, D], [C, D], [D])
-        self.responses_test([C, C, D], [C, C, D], [D])
+        self.responses_test(D, C, D)
+        self.responses_test(D, D + D, D + D)
+        self.responses_test(D, C + D, C + D)
+        self.responses_test(D, C + C + D, C + C + D)
 
         # Cooperates otherwise
-        self.responses_test([C], [C], [C])
-        self.responses_test([C, C, C, C], [C, C, C, D], [C])
+        self.responses_test(C, C, C)
+        self.responses_test(C, C * 4, C * 3 + D)

--- a/axelrod/tests/unit/test_ecosystem.py
+++ b/axelrod/tests/unit/test_ecosystem.py
@@ -37,7 +37,8 @@ class TestEcosystem(unittest.TestCase):
         self.assertEqual(list(set(pops[0])), [0.25])
 
         # Can pass list of initial population distributions
-        eco = axelrod.Ecosystem(self.res_cooperators, population=[.7, .25, .03, .02])
+        eco = axelrod.Ecosystem(self.res_cooperators,
+                                population=[.7, .25, .03, .02])
         pops = eco.population_sizes
         self.assertEqual(eco.nplayers, 4)
         self.assertEqual(len(pops), 1)
@@ -55,10 +56,12 @@ class TestEcosystem(unittest.TestCase):
         self.assertEqual(pops[0], [.7, .25, .03, .02])
 
         # If passed list is of incorrect size get error
-        self.assertRaises(TypeError, axelrod.Ecosystem, self.res_cooperators, population=[.7, .2, .03, .1, .1])
+        self.assertRaises(TypeError, axelrod.Ecosystem, self.res_cooperators,
+                          population=[.7, .2, .03, .1, .1])
 
         # If passed list has negative values
-        self.assertRaises(TypeError, axelrod.Ecosystem, self.res_cooperators, population=[.7, -.2, .03, .2])
+        self.assertRaises(TypeError, axelrod.Ecosystem, self.res_cooperators,
+                          population=[.7, -.2, .03, .2])
 
     def test_fitness(self):
         fitness = lambda p: 2 * p

--- a/axelrod/tests/unit/test_filters.py
+++ b/axelrod/tests/unit/test_filters.py
@@ -1,9 +1,11 @@
 import unittest
-from axelrod.strategies._filters import *
-from axelrod import filtered_strategies
+
 from hypothesis import given, example
 from hypothesis.strategies import integers
-import operator
+
+from axelrod import filtered_strategies
+from axelrod.strategies._filters import *
+
 
 
 class TestFilters(unittest.TestCase):

--- a/axelrod/tests/unit/test_fingerprint.py
+++ b/axelrod/tests/unit/test_fingerprint.py
@@ -1,7 +1,6 @@
 import unittest
-import axelrod as axl
-from axelrod.fingerprint import *
 from hypothesis import given
+from axelrod.fingerprint import *
 from axelrod.tests.property import strategy_lists
 
 
@@ -125,7 +124,8 @@ class TestFingerprint(unittest.TestCase):
 
     def test_serial_fingerprint(self):
         af = AshlockFingerprint(self.strategy, self.probe)
-        data = af.fingerprint(turns=10, repetitions=2, step=0.5, progress_bar=False)
+        data = af.fingerprint(turns=10, repetitions=2, step=0.5,
+                              progress_bar=False)
         edge_keys = sorted(list(af.interactions.keys()))
         coord_keys = sorted(list(data.keys()))
         self.assertEqual(af.step, 0.5)

--- a/axelrod/tests/unit/test_finite_state_machines.py
+++ b/axelrod/tests/unit/test_finite_state_machines.py
@@ -4,7 +4,6 @@ import unittest
 import axelrod
 from .test_player import TestHeadsUp, TestPlayer
 
-
 C, D = axelrod.Actions.C, axelrod.Actions.D
 
 
@@ -38,8 +37,8 @@ class TestFSMPlayers(unittest.TestCase):
         opponent = axelrod.Alternator()
         for i in range(6):
             player.play(opponent)
-        self.assertEqual(opponent.history, [C, D] * 3)
-        self.assertEqual(player.history, [C] * 6)
+        self.assertEqual(opponent.history, (C + D) * 3)
+        self.assertEqual(player.history, C * 6)
 
     def test_defector(self):
         """Tests that the player defined by the table for Defector is in fact
@@ -49,8 +48,8 @@ class TestFSMPlayers(unittest.TestCase):
         opponent = axelrod.Alternator()
         for i in range(6):
             player.play(opponent)
-        self.assertEqual(opponent.history, [C, D] * 3)
-        self.assertEqual(player.history, [D] * 6)
+        self.assertEqual(opponent.history, (C + D) * 3)
+        self.assertEqual(player.history, D * 6)
 
     def test_tft(self):
         """Tests that the player defined by the table for TFT is in fact
@@ -60,8 +59,8 @@ class TestFSMPlayers(unittest.TestCase):
         opponent = axelrod.Alternator()
         for i in range(6):
             player.play(opponent)
-        self.assertEqual(opponent.history, [C, D] * 3)
-        self.assertEqual(player.history, [C, C, D, C, D, C])
+        self.assertEqual(opponent.history, (C + D) * 3)
+        self.assertEqual(player.history, C + C + D + C + D + C)
 
     def test_wsls(self):
         """Tests that the player defined by the table for TFT is in fact
@@ -71,8 +70,8 @@ class TestFSMPlayers(unittest.TestCase):
         opponent = axelrod.Alternator()
         for i in range(6):
             player.play(opponent)
-        self.assertEqual(opponent.history, [C, D] * 3)
-        self.assertEqual(player.history, [C, C, D, D, C, C])
+        self.assertEqual(opponent.history, (C + D) * 3)
+        self.assertEqual(player.history, C + C + D + D + C + C)
 
     def test_malformed_tables(self):
         # Test a malformed table
@@ -193,10 +192,10 @@ class TestPun1(TestFSMPlayer):
     def test_strategy(self):
         # Test initial play sequence
         self.first_play_test(D)
-        self.responses_test([D, C], [C, C], [C])
-        self.responses_test([D, C], [D, C], [C])
-        self.responses_test([D, C, C], [C, C, C], [C])
-        self.responses_test([D, C, C, C], [C, C, C, D], [D])
+        self.responses_test(C, D + C, C + C)
+        self.responses_test(C, D + C, D + C)
+        self.responses_test(C, D + C + C, C * 3)
+        self.responses_test(D, D + 3 * C, 3 * C + D)
 
 
 class TestRaider(TestFSMPlayer):
@@ -366,7 +365,7 @@ class TestFortress3vsTitForTat(TestHeadsUp):
 class TestFortress3vsCooperator(TestHeadsUp):
     def test_rounds(self):
         self.versus_test(axelrod.Fortress3(), axelrod.Cooperator(),
-                         [D, D, D, D, D, D], [C] * 6)
+                         D * 6, C * 6)
 
 
 class TestFortress4vsFortress4(TestHeadsUp):
@@ -384,4 +383,4 @@ class TestFortress4vsTitForTat(TestHeadsUp):
 class TestFortress4vsCooperator(TestHeadsUp):
     def test_rounds(self):
         self.versus_test(axelrod.Fortress4(), axelrod.Cooperator(),
-                         [D, D, D, D, D, D], [C] * 6)
+                         [D, D, D, D, D, D], C * 6)

--- a/axelrod/tests/unit/test_forgiver.py
+++ b/axelrod/tests/unit/test_forgiver.py
@@ -1,7 +1,6 @@
-"""Test for the forgiver strategies."""
+"""Tests for the forgiver strategies."""
 
 import axelrod
-
 from .test_player import TestPlayer
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
@@ -21,15 +20,12 @@ class TestForgiver(TestPlayer):
         'manipulates_state': False
     }
 
-    def test_initial_strategy(self):
-        """Starts by cooperating."""
-        self.first_play_test(C)
-
     def test_strategy(self):
         """If opponent has defected more than 10 percent of the time, defect."""
-        self.responses_test([C, C, C, C], [C, C, C, C], [C])
-        self.responses_test([C, C, C, C, D], [C, C, C, D, C], [D])
-        self.responses_test([C] * 11, [C] * 10 + [D], [C])
+        self.first_play_test(C)
+        self.responses_test(C, C * 4, C * 4)
+        self.responses_test(D, C * 4 + D, C * 3 + D + C)
+        self.responses_test(C, C * 11, C * 10 + D)
 
 
 class TestForgivingTitForTat(TestPlayer):
@@ -46,11 +42,8 @@ class TestForgivingTitForTat(TestPlayer):
         'manipulates_state': False
     }
 
-    def test_initial_strategy(self):
-        """Starts by cooperating."""
-        self.first_play_test(C)
-
     def test_strategy(self):
-        self.responses_test([C, C, C, C], [C, C, C, C], [C])
-        self.responses_test([C, C, C, C, D], [C, C, C, D, C], [C])
-        self.responses_test([C] * 11, [C] * 9 + [D] * 2, [D])
+        self.first_play_test(C)
+        self.responses_test(C, C * 4, C * 4)
+        self.responses_test(C, C * 4 + D, C * 3 + D + C)
+        self.responses_test(D, C * 11, C * 9 + D * 2)

--- a/axelrod/tests/unit/test_gambler.py
+++ b/axelrod/tests/unit/test_gambler.py
@@ -8,8 +8,6 @@ import copy
 import axelrod
 from .test_player import TestPlayer, TestHeadsUp
 
-import copy
-
 C, D = axelrod.Actions.C, axelrod.Actions.D
 
 
@@ -38,10 +36,10 @@ class TestGambler(TestPlayer):
         self.assertEqual(player.strategy(opponent), C)
         # Test default table
         tft_table = {
-            ('', 'C', 'D'): 0,
-            ('', 'D', 'D'): 0,
-            ('', 'C', 'C'): 1,
-            ('', 'D', 'C'): 1,
+            ('', C, D): 0,
+            ('', D, D): 0,
+            ('', C, C): 1,
+            ('', D, C): 1,
         }
         player = self.player(tft_table)
         opponent = axelrod.Defector()
@@ -50,14 +48,13 @@ class TestGambler(TestPlayer):
         player.play(opponent)
         self.assertEqual(player.history[-1], D)
         # Test malformed tables
-        table = {(C, C, C): 1, ('DD', 'DD', 'C'): 1}
+        table = {(C, C, C): 1, (D + D, D + D, C): 1}
         with self.assertRaises(ValueError):
             player = self.player(table)
 
-
     def test_strategy(self):
-        self.responses_test([C] * 4, [C, C, C, C], [C])
-        self.responses_test([C] * 5, [C, C, C, C, D], [D])
+        self.responses_test(C, C * 4, C * 4)
+        self.responses_test(D, C * 5, C * 4 + D)
 
     def test_defector_table(self):
         """
@@ -68,15 +65,15 @@ class TestGambler(TestPlayer):
         constructor with the lookup table we want.
         """
         defector_table = {
-            ('', C, D) : 0,
-            ('', D, D) : 0,
-            ('', C, C) : 0,
-            ('', D, C) : 0,
+            ('', C, D): 0,
+            ('', D, D): 0,
+            ('', C, C): 0,
+            ('', D, C): 0,
         }
-        self.player = lambda : axelrod.Gambler(defector_table)
-        self.responses_test([C, C], [C, C], [D])
-        self.responses_test([C, D], [D, C], [D])
-        self.responses_test([D, D], [D, D], [D])
+        self.player = lambda: axelrod.Gambler(defector_table)
+        self.responses_test(D, C + C, C + C)
+        self.responses_test(D, C + D, D + C)
+        self.responses_test(D, D + D, D + D)
 
 
 class TestPSOGamblerMem1(TestPlayer):
@@ -101,7 +98,7 @@ class TestPSOGamblerMem1(TestPlayer):
     def test_strategy(self):
         """Starts by cooperating."""
         self.first_play_test(C)
-        self.responses_test([C] * 197, [C] * 197, [C])
+        self.responses_test(C, C * 197, C * 197)
 
 
 class TestPSOGambler2_2_2(TestPlayer):
@@ -130,7 +127,7 @@ class TestPSOGambler2_2_2(TestPlayer):
     def test_strategy(self):
         """Starts by cooperating."""
         self.first_play_test(C)
-        self.responses_test([C] * 197, [C] * 197, [C])
+        self.responses_test(C, C * 197, C * 197)
 
 
 class TestPSOGambler1_1_1(TestPlayer):
@@ -151,7 +148,7 @@ class TestPSOGambler1_1_1(TestPlayer):
     def test_strategy(self):
         """Starts by cooperating."""
         self.first_play_test(C)
-        self.responses_test([C] * 197, [C] * 197, [C])
+        self.responses_test(C, C * 197, C * 197)
 
 
 class TestPSOGambler2_2_2_Noise05(TestPlayer):
@@ -171,7 +168,7 @@ class TestPSOGambler2_2_2_Noise05(TestPlayer):
     def test_strategy(self):
         """Starts by cooperating."""
         self.first_play_test(C)
-        self.responses_test([C] * 197, [C] * 197, [C])
+        self.responses_test(C, C * 197, C * 197)
 
 
 # Some heads up tests for PSOGambler

--- a/axelrod/tests/unit/test_game.py
+++ b/axelrod/tests/unit/test_game.py
@@ -1,10 +1,9 @@
 import unittest
 from hypothesis import given
-from hypothesis.strategies import integers, tuples
-
-from axelrod.tests.property import *
 
 import axelrod
+from axelrod.tests.property import *
+
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
 

--- a/axelrod/tests/unit/test_geller.py
+++ b/axelrod/tests/unit/test_geller.py
@@ -1,7 +1,6 @@
-"""Test for the geller strategy."""
+"""Tests for the geller strategy."""
 
 import axelrod
-
 from .test_player import TestPlayer
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
@@ -22,15 +21,13 @@ class TestGeller(TestPlayer):
     }
 
     def test_strategy(self):
-        """Should cooperate against cooperaters and defect against defectors."""
-
-        P1 = self.player()
-        P2 = axelrod.Cooperator()
-        self.assertEqual(P1.strategy(P2), C)
-
-        P1 = self.player()
-        P2 = axelrod.Defector()
-        self.assertEqual(P1.strategy(P2), D)
+        """Should cooperate against cooperators and defect against defectors."""
+        player1 = self.player()
+        player2 = axelrod.Cooperator()
+        self.assertEqual(player1.strategy(player2), C)
+        player1 = self.player()
+        player2 = axelrod.Defector()
+        self.assertEqual(player1.strategy(player2), D)
 
 
 class TestGellerCooperator(TestGeller):
@@ -48,9 +45,9 @@ class TestGellerCooperator(TestGeller):
     }
 
     def test_against_self(self):
-        P1 = self.player()
-        P2 = self.player()
-        self.assertEqual(P1.strategy(P2), C)
+        player1 = self.player()
+        player2 = self.player()
+        self.assertEqual(player1.strategy(player2), C)
 
 
 class TestGellerDefector(TestGeller):
@@ -68,6 +65,6 @@ class TestGellerDefector(TestGeller):
     }
 
     def test_against_self(self):
-        P1 = self.player()
-        P2 = self.player()
-        self.assertEqual(P1.strategy(P2), D)
+        player1 = self.player()
+        player2 = self.player()
+        self.assertEqual(player1.strategy(player2), D)

--- a/axelrod/tests/unit/test_gobymajority.py
+++ b/axelrod/tests/unit/test_gobymajority.py
@@ -1,7 +1,6 @@
-"""Test for the go by majority strategy."""
+"""Tests for the gobymajority strategy."""
 
 import axelrod
-
 from .test_player import TestPlayer
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
@@ -32,8 +31,8 @@ class TestGoByMajority(TestPlayer):
         If opponent cooperates at least as often as they defect then the player
         cooperates
         """
-        self.responses_test([C, D, D, D], [D, D, C, C], [C])
-        self.responses_test([C, C, D, D, C], [D, D, C, C, D], [D])
+        self.responses_test(C, C + D * 3, D + D + C + C)
+        self.responses_test(D, C + C + D + D + C, D + D + C + C + D)
 
         # Test tie break rule for soft=False
         player = self.player(soft=False)
@@ -78,23 +77,29 @@ class TestHardGoByMajority(TestGoByMajority):
     def test_strategy(self):
         """
         If opponent cooperates strictly more often as they defect then the
-        player cooperates
+        player cooperates.
         """
-        self.responses_test([C, D, D, D], [D, D, C, C], [D])
-        self.responses_test([C, C, D, D, C], [D, D, C, C, D], [D])
+        self.responses_test(D, C + D * 3, D + D + C + C)
+        self.responses_test(D, C + C + D + D + C, D + D + C + C + D)
 
         # Test tie break rule for soft=True
         player = self.player(soft=True)
         opponent = axelrod.Cooperator()
-        self.assertEqual('C', player.strategy(opponent))
+        self.assertEqual(C, player.strategy(opponent))
 
 
 def factory_TestGoByRecentMajority(L, soft=True):
 
+    prefix = "Hard"
+    prefix2 = "Hard"
+    if soft:
+        prefix = "Soft"
+        prefix2 = ""
+
     class TestGoByRecentMajority(TestPlayer):
 
-        name = "Soft Go By Majority: %i" % L
-        player = getattr(axelrod, 'GoByMajority%i' % L)
+        name = "{} Go By Majority: {}".format(prefix, L)
+        player = getattr(axelrod, "{}GoByMajority{}".format(prefix2, L))
 
         expected_classifier = {
             'stochastic': False,
@@ -108,41 +113,29 @@ def factory_TestGoByRecentMajority(L, soft=True):
 
         def test_initial_strategy(self):
             """Starts by cooperating."""
-            self.first_play_test(C)
+            if soft:
+                self.first_play_test(C)
+            else:
+                self.first_play_test(D)
 
         def test_strategy(self):
             """If opponent cooperates at least as often as they defect then the
             player cooperates."""
-            P1 = self.player()
-            P2 = axelrod.Player()
-            P1.history = [D] * int(1.5 * L)
-            P2.history = [D] * (L - 1) + [C] * (L // 2 + 1)
-            self.assertEqual(P1.strategy(P2), C)
-            P1.history = [C] * int(1.5 * L)
-            P2.history = [C] * (L - 1) + [D] * (L // 2 + 1)
-            self.assertEqual(P1.strategy(P2), D)
 
-    if not soft:  # Overwrite test class
+            self.responses_test(C, C * L, C * (L // 2 + 1) + D * (L // 2 - 1))
+            self.responses_test(D, C * L, D * (L // 2 + 1) + C * (L // 2 - 1))
 
-        class TestGoByRecentMajority(TestGoByRecentMajority):
-            name = "Hard Go By Majority: %i" % L
-            player = getattr(axelrod, 'HardGoByMajority%i' % L)
+            k = L
+            if L % 2 == 1:
+                k -= 1
 
-            expected_classifier = {
-                'stochastic': False,
-                'memory_depth': L,
-                'makes_use_of': set(),
-                'long_run_time': False,
-                'inspects_source': False,
-                'manipulates_source': False,
-                'manipulates_state': False
-            }
-
-            def test_initial_strategy(self):
-                """Starts by defecting."""
-                self.first_play_test(D)
+            if soft:
+                self.responses_test(C, C * k, C * (k // 2) + D * (k // 2))
+            else:
+                self.responses_test(D, C * k, C * (k // 2) + D * (k // 2))
 
     return TestGoByRecentMajority
+
 
 TestGoByMajority5 = factory_TestGoByRecentMajority(5)
 TestGoByMajority10 = factory_TestGoByRecentMajority(10)

--- a/axelrod/tests/unit/test_gradualkiller.py
+++ b/axelrod/tests/unit/test_gradualkiller.py
@@ -1,13 +1,7 @@
-"""Test for the gradual killer strategy."""
+"""Tests for the gradual killer strategy."""
 
 import axelrod
-from .test_player import TestHeadsUp, TestPlayer
-
-from hypothesis import given
-from hypothesis.strategies import integers
-from axelrod.tests.property import strategy_lists
-
-import random
+from .test_player import TestPlayer
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
 
@@ -28,77 +22,22 @@ class TestGradualKiller(TestPlayer):
     def test_strategy(self):
         """Starts by Defecting."""
         self.first_play_test(D)
+        self.second_play_test(D, D, D, D)
+        self.responses_test(D * 5 + C * 2)
 
-    def test_effect_of_strategy(self):
-        """Fist seven moves."""
-        self.markov_test([D, D, D, D])
-        self.responses_test([], [], [D, D, D, D, D, C, C])
+        self.responses_test(C * 4, D * 5 + C * 2, C * 7)
 
-    def test_effect_of_strategy_with_history_CC(self):
-        """Continues with C if opponent played CC on 6 and 7."""
-        P1 = axelrod.GradualKiller()
-        P2 = axelrod.Player()
-        P1.history = [D, D, D, D, D, C, C]
-        P2.history = [C, C, C, C, C, C, C]
-        self.assertEqual(P1.strategy(P2), 'C')
-        P1.history = [D, D, D, D, D, C, C, C]
-        P2.history = [C, C, C, C, C, C, C, C]
-        self.assertEqual(P1.strategy(P2), 'C')
-        P1.history = [D, D, D, D, D, C, C, C, C]
-        P2.history = [C, C, C, C, C, C, C, C, C]
-        self.assertEqual(P1.strategy(P2), 'C')
-        P1.history = [D, D, D, D, D, C, C, C, C, C]
-        P2.history = [C, C, C, C, C, C, C, C, C, C]
-        self.assertEqual(P1.strategy(P2), 'C')
+        self.responses_test(C, D * 5 + C * 2, C * 6 + D)
+        self.responses_test(C, D * 5 + C * 3, C * 6 + D * 2)
+        self.responses_test(C, D * 5 + C * 4, C * 6 + D * 2 + C)
+        self.responses_test(C, D * 5 + C * 5, C * 6 + D * 2 + C + C)
 
-    def test_effect_of_strategy_with_history_CD(self):
-        """Continues with C if opponent played CD on 6 and 7."""
-        P1 = axelrod.GradualKiller()
-        P2 = axelrod.Player()
-        P1.history = [D, D, D, D, D, C, C]
-        P2.history = [C, C, C, C, C, C, D]
-        self.assertEqual(P1.strategy(P2), 'C')
-        P1.history = [D, D, D, D, D, C, C, C]
-        P2.history = [C, C, C, C, C, C, D, D]
-        self.assertEqual(P1.strategy(P2), 'C')
-        P1.history = [D, D, D, D, D, C, C, C, C]
-        P2.history = [C, C, C, C, C, C, D, D, C]
-        self.assertEqual(P1.strategy(P2), 'C')
-        P1.history = [D, D, D, D, D, C, C, C, C, C]
-        P2.history = [C, C, C, C, C, C, D, D, C, C]
-        self.assertEqual(P1.strategy(P2), 'C')
+        self.responses_test(C, D * 5 + C * 2, C * 5 + D + C)
+        self.responses_test(C, D * 5 + C * 3, C * 5 + D + C * 2)
+        self.responses_test(C, D * 5 + C * 4, C * 5 + D + C * 2 + D)
+        self.responses_test(C, D * 5 + C * 5, C * 5 + D + C * 2 + D * 2)
 
-    def test_effect_of_strategy_with_history_DC(self):
-        """Continues with C if opponent played DC on 6 and 7."""
-        P1 = axelrod.GradualKiller()
-        P2 = axelrod.Player()
-        P1.history = [D, D, D, D, D, C, C]
-        P2.history = [C, C, C, C, C, D, C]
-        self.assertEqual(P1.strategy(P2), 'C')
-        P1.history = [D, D, D, D, D, C, C, C]
-        P2.history = [C, C, C, C, C, D, C, C]
-        self.assertEqual(P1.strategy(P2), 'C')
-        P1.history = [D, D, D, D, D, C, C, C, C]
-        P2.history = [C, C, C, C, C, D, C, C, D]
-        self.assertEqual(P1.strategy(P2), 'C')
-        P1.history = [D, D, D, D, D, C, C, C, C, C]
-        P2.history = [C, C, C, C, C, D, C, C, D, C]
-        self.assertEqual(P1.strategy(P2), 'C')
-
-    def test_effect_of_strategy_with_history_CC(self):
-        """Continues with D if opponent played DD on 6 and 7."""
-        P1 = axelrod.GradualKiller()
-        P2 = axelrod.Player()
-        P1.history = [D, D, D, D, D, C, C]
-        P2.history = [C, C, C, C, C, D, D]
-        self.assertEqual(P1.strategy(P2), 'D')
-        P1.history = [D, D, D, D, D, C, C, D]
-        P2.history = [C, C, C, C, C, D, D, C]
-        self.assertEqual(P1.strategy(P2), 'D')
-        P1.history = [D, D, D, D, D, C, C, D, D]
-        P2.history = [C, C, C, C, C, D, D, C, C]
-        self.assertEqual(P1.strategy(P2), 'D')
-        P1.history = [D, D, D, D, D, C, C, D, D, D]
-        P2.history = [C, C, C, C, C, D, D, C, C, D]
-        self.assertEqual(P1.strategy(P2), 'D')
-
+        self.responses_test(D, D * 5 + C * 2, C * 5 + D * 2)
+        self.responses_test(D, D * 5 + C * 2 + D, C * 5 + D * 2 + C)
+        self.responses_test(D, D * 5 + C * 2 + D * 2, C * 5 + D * 2 + C * 2)
+        self.responses_test(D, D * 5 + C * 2 + D * 3, C * 5 + D * 2 + C * 2 + D)

--- a/axelrod/tests/unit/test_grumpy.py
+++ b/axelrod/tests/unit/test_grumpy.py
@@ -1,4 +1,4 @@
-"""Test for the grumpy strategy."""
+"""Tests for the grumpy strategy."""
 
 import axelrod
 from .test_player import TestPlayer, test_responses, TestOpponent
@@ -20,50 +20,31 @@ class TestGrumpy(TestPlayer):
         'manipulates_state': False
     }
 
-    def test_initial_nice_strategy(self):
-        """
-        Starts by cooperating
-        """
-        self.first_play_test(C)
-
-    def test_initial_grumpy_strategy(self):
-        """
-        Starts by defecting if grumpy
-        """
-        P1 = axelrod.Grumpy(starting_state = 'Grumpy')
-        P2 = TestOpponent()
-        self.assertEqual(P1.strategy(P2), D)
-
     def test_strategy(self):
-        """
-        Tests that grumpy will play c until threshold is ht at which point it will become grumpy.
-        Player will then not become nice until lower nice threshold is hit.
-        """
-        P1 = axelrod.Grumpy(grumpy_threshold=3, nice_threshold=0)
-        P2 = TestOpponent()
-        test_responses(self, P1, P2, [C, D, D, D], [C, C, C, C], [C])
+        # Starts by cooperating.
+        self.first_play_test(C)
+        # Starts by defecting if grumpy initially.
+        self.responses_test(D, init_kwargs={"starting_state": "Grumpy"})
+        # Tests that grumpy will play C until threshold is hit at which point it
+        # will become grumpy. Player will then not become nice until lower nice
+        # threshold is hit.
 
-        P1 = axelrod.Grumpy(grumpy_threshold=3, nice_threshold=0)
-        P2 = TestOpponent()
-        test_responses(self, P1, P2, [C, C, D, D, D], [D, D, D, D, D], [D])
-
-        P1 = axelrod.Grumpy(grumpy_threshold=3, nice_threshold=0)
-        P2 = TestOpponent()
-        test_responses(self, P1, P2, [C, C, D, D, D, D, D, D],
-                       [D, D, D, D, D, C, C, C], [D])
-
-        P1 = axelrod.Grumpy(grumpy_threshold=3, nice_threshold=0)
-        P2 = TestOpponent()
-        test_responses(self, P1, P2, [C, C, D, D, D, D, D, D, D, D, D],
-                       [D, D, D, D, D, C, C, C, C, C, C], [C])
+        self.responses_test(C, C + D * 3, C * 4,
+                            init_kwargs={"grumpy_threshold": 3,
+                                         "nice_threshold": 0},
+                            attrs={"state": "Nice"})
+        self.responses_test(D, C * 2 + D * 3, D * 5,
+                            init_kwargs={"grumpy_threshold": 3,
+                                         "nice_threshold": 0})
+        self.responses_test(D, C * 2 + D * 6, D * 5 + C * 3,
+                            init_kwargs={"grumpy_threshold": 3,
+                                         "nice_threshold": 0})
+        self.responses_test(C, C * 2 + D * 9, D * 5 + C * 6,
+                            init_kwargs={"grumpy_threshold": 3,
+                                         "nice_threshold": 0})
 
     def test_reset_method(self):
-        """
-        tests the reset method
-        """
-        P1 = axelrod.Grumpy(starting_state = 'Grumpy')
-        P1.history = [C, D, D, D]
+        P1 = axelrod.Grumpy(starting_state='Grumpy')
         P1.state = 'Nice'
         P1.reset()
-        self.assertEqual(P1.history, [])
         self.assertEqual(P1.state, 'Grumpy')

--- a/axelrod/tests/unit/test_handshake.py
+++ b/axelrod/tests/unit/test_handshake.py
@@ -1,7 +1,6 @@
-"""Test for the Handshake strategy."""
+"""Tests for the Handshake strategy."""
 
 import axelrod
-
 from .test_player import TestPlayer
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
@@ -22,13 +21,12 @@ class TestHandshake(TestPlayer):
     }
 
     def test_strategy(self):
-        # Test initial play sequence
-        self.responses_test([], [], [C, D])
+        self.responses_test(C + D)
 
-        self.responses_test([C, D], [C, D], [C] * 20)
-        self.responses_test([C, D], [C, C], [D] * 20)
-        self.responses_test([C, D], [D, C], [D] * 20)
-        self.responses_test([C, D], [D, D], [D] * 20)
+        self.responses_test(C * 20, C + D, C + D)
+        self.responses_test(D * 20, C + D, C + C)
+        self.responses_test(D * 20, C + D, D + C)
+        self.responses_test(D * 20, C + D, D + D)
 
-        self.responses_test([C, D] * 2, [D, C] * 2, [D])
-        self.responses_test([C, D] * 2, [C, D] * 2, [C])
+        self.responses_test(D, (C + D) * 2, (D + C) * 2)
+        self.responses_test(C, (C + D) * 2, (C + D) * 2)

--- a/axelrod/tests/unit/test_headsup.py
+++ b/axelrod/tests/unit/test_headsup.py
@@ -1,4 +1,4 @@
-"""Test for the cooperator strategy."""
+"""Various 1v1 matches."""
 
 import axelrod
 
@@ -11,7 +11,7 @@ class TestTFTvsWSLS(TestHeadsUp):
     """Test TFT vs WSLS"""
     def test_rounds(self):
         self.versus_test(axelrod.TitForTat(), axelrod.WinStayLoseShift(),
-                         [C, C, C, C], [C, C, C, C])
+                         C * 4, C * 4)
 
 
 class TestTFTvSTFT(TestHeadsUp):
@@ -60,14 +60,14 @@ class FoolMeOncevsSTFT(TestHeadsUp):
     """Test Fool Me Once vs Suspicious TFT"""
     def test_rounds(self):
         self.versus_test(axelrod.FoolMeOnce(), axelrod.SuspiciousTitForTat(),
-                         [C] * 9, [D] + [C] * 8)
+                         C * 9, D + C * 8)
 
 
 class GrudgervsSTFT(TestHeadsUp):
     """Test Grudger vs Suspicious TFT"""
     def test_rounds(self):
         self.versus_test(axelrod.Grudger(), axelrod.SuspiciousTitForTat(),
-                         [C] + [D] * 9, [D, C] + [D] * 8)
+                         C + D * 9, D + C + D * 8)
 
 
 class TestWSLSvsBully(TestHeadsUp):

--- a/axelrod/tests/unit/test_history.py
+++ b/axelrod/tests/unit/test_history.py
@@ -1,7 +1,7 @@
 import unittest
 
 from axelrod import Actions
-from ...history import HistoryString, HistoryList
+from axelrod.history import HistoryString, HistoryList
 
 C, D = Actions.C, Actions.D
 

--- a/axelrod/tests/unit/test_history.py
+++ b/axelrod/tests/unit/test_history.py
@@ -1,0 +1,50 @@
+import unittest
+
+from axelrod import Actions, History
+
+C, D = Actions.C, Actions.D
+
+
+class TestHistory(unittest.TestCase):
+    def test_init(self):
+        h1 = History([C, C, D])
+        h2 = History("CCD")
+        h3 = History(C + C + D)
+        self.assertEqual(h1, h2)
+        self.assertEqual(h2, h3)
+        self.assertEqual(h3, h1)
+
+    def test_reset(self):
+        h = History()
+        h.append(C)
+        self.assertEqual(len(h), 1)
+        h.reset()
+        self.assertEqual(len(h), 0)
+
+    def test_compare(self):
+        h = History([C, D, C])
+        self.assertEqual(h, "CDC")
+        self.assertEqual(h, C + D + C)
+        self.assertEqual(h, [C, D, C])
+        h2 = History([C, D, C])
+        self.assertEqual(h, h2)
+        h2.reset()
+        self.assertNotEqual(h, h2)
+
+    def test_add(self):
+        h1 = History([C, C])
+        h2 = History([D, D])
+        h = h1 + h2
+        h3 = History([C, C, D, D])
+        self.assertEqual(h, h3)
+
+    def test_counts(self):
+        h1 = History([C, C])
+        self.assertEqual(h1.cooperations, 2)
+        self.assertEqual(h1.defections, 0)
+        h2 = History([D, D])
+        self.assertEqual(h2.cooperations, 0)
+        self.assertEqual(h2.defections, 2)
+        h3 = History([C, C, D, D])
+        self.assertEqual(h3.cooperations, 2)
+        self.assertEqual(h3.defections, 2)

--- a/axelrod/tests/unit/test_history.py
+++ b/axelrod/tests/unit/test_history.py
@@ -1,57 +1,111 @@
 import unittest
 
-from axelrod import Actions, History
+from axelrod import Actions
+from ...history import HistoryString, HistoryList
 
 C, D = Actions.C, Actions.D
 
 
-class TestHistory(unittest.TestCase):
+class TestHistoryList(unittest.TestCase):
     def test_init(self):
-        h1 = History([C, C, D])
-        h2 = History("CCD")
-        h3 = History(C + C + D)
+        h1 = HistoryList([C, C, D])
+        h2 = HistoryList("CCD")
+        h3 = HistoryList(C + C + D)
         self.assertEqual(h1, h2)
         self.assertEqual(h2, h3)
         self.assertEqual(h3, h1)
 
     def test_reset(self):
-        h = History()
+        h = HistoryList()
         h.append(C)
         self.assertEqual(len(h), 1)
         h.reset()
         self.assertEqual(len(h), 0)
 
     def test_compare(self):
-        h = History([C, D, C])
+        h = HistoryList([C, D, C])
         self.assertEqual(h, "CDC")
         self.assertEqual(h, C + D + C)
         self.assertEqual(h, [C, D, C])
-        h2 = History([C, D, C])
+        h2 = HistoryList([C, D, C])
         self.assertEqual(h, h2)
         h2.reset()
         self.assertNotEqual(h, h2)
 
     def test_add(self):
-        h1 = History([C, C])
-        h2 = History([D, D])
+        h1 = HistoryList([C, C])
+        h2 = HistoryList([D, D])
         h = h1 + h2
-        h3 = History([C, C, D, D])
+        h3 = HistoryList([C, C, D, D])
         self.assertEqual(h, h3)
 
     def test_counts(self):
-        h1 = History([C, C])
+        h1 = HistoryList([C, C])
         self.assertEqual(h1.cooperations, 2)
         self.assertEqual(h1.defections, 0)
-        h2 = History([D, D])
+        h2 = HistoryList([D, D])
         self.assertEqual(h2.cooperations, 0)
         self.assertEqual(h2.defections, 2)
-        h3 = History([C, C, D, D])
+        h3 = HistoryList([C, C, D, D])
         self.assertEqual(h3.cooperations, 2)
         self.assertEqual(h3.defections, 2)
 
     def test_pop(self):
-        h1 = History([C, D])
+        h1 = HistoryList([C, D])
         self.assertEqual(len(h1), 2)
         play = h1.pop(-1)
         self.assertEqual(play, D)
         self.assertEqual(len(h1), 1)
+
+
+class TestHistoryString(unittest.TestCase):
+    def test_init(self):
+        h1 = HistoryString([C, C, D])
+        h2 = HistoryString("CCD")
+        h3 = HistoryString(C + C + D)
+        self.assertEqual(h1, h2)
+        self.assertEqual(h2, h3)
+        self.assertEqual(h3, h1)
+
+    def test_reset(self):
+        h = HistoryString()
+        h.append(C)
+        self.assertEqual(len(h), 1)
+        h.reset()
+        self.assertEqual(len(h), 0)
+
+    def test_compare(self):
+        h = HistoryString([C, D, C])
+        self.assertEqual(h, "CDC")
+        self.assertEqual(h, C + D + C)
+        self.assertEqual(h, [C, D, C])
+        h2 = HistoryString([C, D, C])
+        self.assertEqual(h, h2)
+        h2.reset()
+        self.assertNotEqual(h, h2)
+
+    def test_add(self):
+        h1 = HistoryString([C, C])
+        h2 = HistoryString([D, D])
+        h = h1 + h2
+        h3 = HistoryString([C, C, D, D])
+        self.assertEqual(h, h3)
+
+    def test_counts(self):
+        h1 = HistoryString([C, C])
+        self.assertEqual(h1.cooperations, 2)
+        self.assertEqual(h1.defections, 0)
+        h2 = HistoryString([D, D])
+        self.assertEqual(h2.cooperations, 0)
+        self.assertEqual(h2.defections, 2)
+        h3 = HistoryString([C, C, D, D])
+        self.assertEqual(h3.cooperations, 2)
+        self.assertEqual(h3.defections, 2)
+
+    def test_pop(self):
+        h1 = HistoryString([C, D])
+        self.assertEqual(len(h1), 2)
+        play = h1.pop(-1)
+        self.assertEqual(play, D)
+        self.assertEqual(len(h1), 1)
+

--- a/axelrod/tests/unit/test_history.py
+++ b/axelrod/tests/unit/test_history.py
@@ -48,3 +48,10 @@ class TestHistory(unittest.TestCase):
         h3 = History([C, C, D, D])
         self.assertEqual(h3.cooperations, 2)
         self.assertEqual(h3.defections, 2)
+
+    def test_pop(self):
+        h1 = History([C, D])
+        self.assertEqual(len(h1), 2)
+        play = h1.pop(-1)
+        self.assertEqual(play, D)
+        self.assertEqual(len(h1), 1)

--- a/axelrod/tests/unit/test_hmm.py
+++ b/axelrod/tests/unit/test_hmm.py
@@ -30,14 +30,15 @@ class TestHMMPlayers(unittest.TestCase):
         t_C = [[1]]
         t_D = [[1]]
         p = [1]
-        player = axelrod.HMMPlayer(t_C, t_D, p, initial_state=0, initial_action=C)
+        player = axelrod.HMMPlayer(t_C, t_D, p, initial_state=0,
+                                   initial_action=C)
         self.assertFalse(player.is_stochastic())
         self.assertFalse(player.classifier['stochastic'])
         opponent = axelrod.Alternator()
         for i in range(6):
             player.play(opponent)
-        self.assertEqual(opponent.history, [C, D] * 3)
-        self.assertEqual(player.history, [C] * 6)
+        self.assertEqual(opponent.history, (C + D) * 3)
+        self.assertEqual(player.history, C * 6)
 
     def test_defector(self):
         """Tests that the player defined by the table for Defector is in fact
@@ -45,14 +46,15 @@ class TestHMMPlayers(unittest.TestCase):
         t_C = [[1]]
         t_D = [[1]]
         p = [0]
-        player = axelrod.HMMPlayer(t_C, t_D, p, initial_state=0, initial_action=D)
+        player = axelrod.HMMPlayer(t_C, t_D, p, initial_state=0,
+                                   initial_action=D)
         self.assertFalse(player.is_stochastic())
         self.assertFalse(player.classifier['stochastic'])
         opponent = axelrod.Alternator()
         for i in range(6):
             player.play(opponent)
-        self.assertEqual(opponent.history, [C, D] * 3)
-        self.assertEqual(player.history, [D] * 6)
+        self.assertEqual(opponent.history, (C + D) * 3)
+        self.assertEqual(player.history, D * 6)
 
     def test_tft(self):
         """Tests that the player defined by the table for TFT is in fact
@@ -60,14 +62,15 @@ class TestHMMPlayers(unittest.TestCase):
         t_C = [[1, 0], [1, 0]]
         t_D = [[0, 1], [0, 1]]
         p = [1, 0]
-        player = axelrod.HMMPlayer(t_C, t_D, p, initial_state=0, initial_action=C)
+        player = axelrod.HMMPlayer(t_C, t_D, p, initial_state=0,
+                                   initial_action=C)
         self.assertFalse(player.is_stochastic())
         self.assertFalse(player.classifier['stochastic'])
         opponent = axelrod.Alternator()
         for i in range(6):
             player.play(opponent)
-        self.assertEqual(opponent.history, [C, D] * 3)
-        self.assertEqual(player.history, [C, C, D, C, D, C])
+        self.assertEqual(opponent.history, (C + D) * 3)
+        self.assertEqual(player.history, C + C + D + C + D + C)
 
     def test_wsls(self):
         """Tests that the player defined by the table for TFT is in fact
@@ -75,14 +78,15 @@ class TestHMMPlayers(unittest.TestCase):
         t_C = [[1, 0], [0, 1]]
         t_D = [[0, 1], [1, 0]]
         p = [1, 0]
-        player = axelrod.HMMPlayer(t_C, t_D, p, initial_state=0, initial_action=C)
+        player = axelrod.HMMPlayer(t_C, t_D, p, initial_state=0,
+                                   initial_action=C)
         self.assertFalse(player.is_stochastic())
         self.assertFalse(player.classifier['stochastic'])
         opponent = axelrod.Alternator()
         for i in range(6):
             player.play(opponent)
-        self.assertEqual(opponent.history, [C, D] * 3)
-        self.assertEqual(player.history, [C, C, D, D, C, C])
+        self.assertEqual(opponent.history, (C + D) * 3)
+        self.assertEqual(player.history, C + C + D + D + C + C)
 
     def test_malformed_params(self):
         # Test a malformed table
@@ -157,11 +161,10 @@ class TestEvolvedHMM5(TestPlayer):
 class TestEvolvedHMM5vsCooperator(TestHeadsUp):
     def test_rounds(self):
         self.versus_test(axelrod.EvolvedHMM5(), axelrod.Cooperator(),
-                         [C] * 5, [C] * 5)
+                         C * 5, C * 5)
 
 
 class TestEvolvedHMM5vsDefector(TestHeadsUp):
     def test_rounds(self):
         self.versus_test(axelrod.EvolvedHMM5(), axelrod.Defector(),
-                         [C, C, D], [D, D, D])
-
+                         C + C + D, D * 3)

--- a/axelrod/tests/unit/test_human.py
+++ b/axelrod/tests/unit/test_human.py
@@ -1,9 +1,10 @@
+from os import linesep
 from unittest import TestCase
+from prompt_toolkit.validation import ValidationError
+
 from axelrod import Actions, Player
 from axelrod.strategies.human import Human, ActionValidator
 from .test_player import TestPlayer
-from prompt_toolkit.validation import ValidationError
-from os import linesep
 
 C, D = Actions.C, Actions.D
 
@@ -54,14 +55,10 @@ class TestHumanClass(TestPlayer):
         actual_content = human._history_toolbar(None)[0][1]
         self.assertEqual(actual_content, expected_content)
 
-        human.history = ['C']
-        human.opponent_history = ['C']
-        # We can't test for this expected content properly until we drop
-        # support for Python 2 as the strings within a string aren't handled
-        # properly.
+        human.history = C
+        human.opponent_history = C
         expected_content = "History (Human, opponent): [('C', 'C')]"
-        actual_content = human._history_toolbar(None)[0][1]
-        self.assertIn('History (Human, opponent)', actual_content)
+        self.assertIn('History (Human, opponent)', expected_content)
 
     def test_status_messages(self):
         human = Human()
@@ -90,15 +87,23 @@ class TestHumanClass(TestPlayer):
 
     def test_strategy(self):
         human = Human()
-        expected_action = 'C'
-        actual_action = human.strategy(Player(), lambda: 'C')
+        expected_action = C
+        actual_action = human.strategy(Player(), lambda: C)
         self.assertEqual(actual_action, expected_action)
+
+    def test_reset_clone(self):
+        # Overwrite standard test to prevent input blocking
+        pass
+
+    def test_reset_history(self):
+        # Overwrite standard test to prevent input blocking
+        pass
 
     def test_reset(self):
         # Overwrite standard test to prevent input blocking
         p = self.player()
         p.reset()
-        self.assertEqual(p.history, [])
+        self.assertEqual(len(p.history), 0)
         self.assertEqual(self.player().cooperations, 0)
         self.assertEqual(self.player().defections, 0)
-        self.assertEqual(self.player().state_distribution, {})
+        self.assertEqual(self.player().state_distribution, dict())

--- a/axelrod/tests/unit/test_hunter.py
+++ b/axelrod/tests/unit/test_hunter.py
@@ -4,7 +4,6 @@ import random
 import unittest
 
 import axelrod
-
 from .test_player import TestPlayer
 from axelrod.strategies.hunter import detect_cycle
 
@@ -13,15 +12,15 @@ C, D = axelrod.Actions.C, axelrod.Actions.D
 
 class TestCycleDetection(unittest.TestCase):
     def test_cycles(self):
-        history = [C] * 10
+        history = C * 10
         self.assertEqual(detect_cycle(history), (C,))
         self.assertEqual(detect_cycle(history, min_size=2), (C, C))
-        history = [C, D] * 10
+        history = (C + D) * 10
         self.assertEqual(detect_cycle(history, min_size=2), (C, D))
         self.assertEqual(detect_cycle(history, min_size=3), (C, D, C, D))
-        history = [C, D, C] * 10
+        history = (C + D + C) * 10
         self.assertTrue(detect_cycle(history), (C, D, C))
-        history = [C, C, D] * 10
+        history = (C + C + D) * 10
         self.assertTrue(detect_cycle(history), (C, C, D))
 
     def test_noncycles(self):
@@ -48,8 +47,8 @@ class TestDefectorHunter(TestPlayer):
     def test_strategy(self):
         self.first_play_test(C)
         for i in range(3):
-            self.responses_test([C] * i, [D] * i, [C])
-        self.responses_test([C] * 4, [D] * 4, [D])
+            self.responses_test(C, C * i, D * i)
+        self.responses_test(D, C * 4, D * 4)
 
 
 class TestCooperatorHunter(TestPlayer):
@@ -69,8 +68,8 @@ class TestCooperatorHunter(TestPlayer):
     def test_strategy(self):
         self.first_play_test(C)
         for i in range(3):
-            self.responses_test([C] * i, [C] * i, [C])
-        self.responses_test([C] * 4, [C] * 4, [D])
+            self.responses_test(C, C * i, C * i)
+        self.responses_test(D, C * 4, C * 4)
 
 
 class TestAlternatorHunter(TestPlayer):
@@ -89,12 +88,12 @@ class TestAlternatorHunter(TestPlayer):
 
     def test_strategy(self):
         self.first_play_test(C)
-        self.responses_test([C] * 2, [C, D], [C])
-        self.responses_test([C] * 3, [C, D, C], [C])
-        self.responses_test([C] * 4, [C, D] * 2, [C])
-        self.responses_test([C] * 5, [C, D] * 2 + [C], [C])
-        self.responses_test([C] * 6, [C, D] * 3, [D])
-        self.responses_test([C] * 7, [C, D] * 3 + [C], [D])
+        self.responses_test(C, C * 2, C + D)
+        self.responses_test(C, C * 3, C + D + C)
+        self.responses_test(C, C * 4, (C + D) * 2)
+        self.responses_test(C, C * 5, (C + D) * 2 + C)
+        self.responses_test(D, C * 6, (C + D) * 3)
+        self.responses_test(D, C * 7, (C + D) * 3 + C)
 
 
 class TestCycleHunter(TestPlayer):
@@ -178,7 +177,7 @@ class TestMathConstantHunter(TestPlayer):
     }
 
     def test_strategy(self):
-        self.responses_test([C] * 8, [C] * 7 + [D], [D])
+        self.responses_test(D, C * 8, C * 7 + D)
 
 
 class TestRandomHunter(TestPlayer):
@@ -196,23 +195,23 @@ class TestRandomHunter(TestPlayer):
     }
 
     def test_strategy(self):
-
         # We should catch the alternator here.
-        self.responses_test([C] * 12, [C, D] * 6, [D])
+        self.responses_test(D, C * 12, (C + D) * 6)
 
         # It is still possible for this test to fail, but very unlikely.
-        history1 = [C] * 100
-        history2 = [random.choice([C, D]) for i in range(100)]
-        self.responses_test(history1, history2, D)
+        history1 = C * 100
+        history2 = [random.choice([C, D]) for _ in range(100)]
+        self.responses_test(D, history1, history2)
 
-        history1 = [D] * 100
-        history2 = [random.choice([C, D]) for i in range(100)]
-        self.responses_test(history1, history2, D)
+        history1 = D * 100
+        history2 = [random.choice([C, D]) for _ in range(100)]
+        self.responses_test(D, history1, history2)
 
     def test_reset(self):
         player = self.player()
         opponent = axelrod.Cooperator()
-        for _ in range(100): player.play(opponent)
+        for _ in range(100):
+            player.play(opponent)
         self.assertFalse(player.countCC == 0)
         player.reset()
         self.assertTrue(player.countCC == 0)

--- a/axelrod/tests/unit/test_hunter.py
+++ b/axelrod/tests/unit/test_hunter.py
@@ -121,8 +121,9 @@ class TestCycleHunter(TestPlayer):
                 player.play(opponent)
             self.assertEqual(player.history[-1], D)
         # Test against non-cyclers
-        for opponent in [axelrod.Random(), axelrod.AntiCycler(),
-                         axelrod.Cooperator(), axelrod.Defector()]:
+        axelrod.seed(43)
+        for opponent in [axelrod.Cooperator(), axelrod.Defector(),
+                         axelrod.Random(), axelrod.AntiCycler()]:
             player.reset()
             for i in range(30):
                 player.play(opponent)
@@ -154,6 +155,7 @@ class TestEventualCycleHunter(TestPlayer):
                 player.play(opponent)
             self.assertEqual(player.history[-1], D)
         # Test against non-cyclers and cooperators
+        axelrod.seed(43)
         for opponent in [axelrod.Random(), axelrod.AntiCycler(),
                          axelrod.DoubleCrosser(), axelrod.Cooperator()]:
             player.reset()

--- a/axelrod/tests/unit/test_interaction_utils.py
+++ b/axelrod/tests/unit/test_interaction_utils.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
-import unittest
-import tempfile
 from collections import Counter
+import tempfile
+import unittest
+
 import axelrod
 import axelrod.interaction_utils as iu
-
 from axelrod import Actions
 
 C, D = Actions.C, Actions.D
@@ -18,16 +17,15 @@ class TestMatch(unittest.TestCase):
     winners = [False, 0, 1, None]
     cooperations = [(1, 1), (0, 2), (2, 1), None]
     normalised_cooperations = [(.5, .5), (0, 1), (1, .5), None]
-    state_distribution = [Counter({('C', 'D'): 1, ('D', 'C'): 1}),
-                          Counter({('D', 'C'): 2}),
-                          Counter({('C', 'C'): 1, ('C', 'D'): 1}),
+    state_distribution = [Counter({(C, D): 1, (D, C): 1}),
+                          Counter({(D, C): 2}),
+                          Counter({(C, C): 1, (C, D): 1}),
                           None]
-    normalised_state_distribution = [Counter({('C', 'D'): 0.5, ('D', 'C'): 0.5}),
-                                     Counter({('D', 'C'): 1.0}),
-                                     Counter({('C', 'C'): 0.5, ('C', 'D'): 0.5}),
+    normalised_state_distribution = [Counter({(C, D): 0.5, (D, C): 0.5}),
+                                     Counter({(D, C): 1.0}),
+                                     Counter({(C, C): 0.5, (C, D): 0.5}),
                                      None]
     sparklines = [ u'█ \n █', u'  \n██', u'██\n█ ', None ]
-
 
     def test_compute_scores(self):
         for inter, score in zip(self.interactions, self.scores):
@@ -74,11 +72,11 @@ class TestMatch(unittest.TestCase):
         tournament = axelrod.Tournament(players=players, turns=2, repetitions=3)
         tournament.play(filename=tmp_file.name)
         tmp_file.close()
-        expected_interactions = {(0, 0): [[('C', 'C'), ('C', 'C')] for _ in
+        expected_interactions = {(0, 0): [[(C, C), (C, C)] for _ in
                                           range(3)],
-                                 (0, 1): [[('C', 'D'), ('C', 'D')] for _ in
+                                 (0, 1): [[(C, D), (C, D)] for _ in
                                           range(3)],
-                                 (1, 1): [[('D', 'D'), ('D', 'D')] for _ in
+                                 (1, 1): [[(D, D), (D, D)] for _ in
                                           range(3)]}
         interactions = iu.read_interactions_from_file(tmp_file.name,
                                                       progress_bar=False)
@@ -86,5 +84,5 @@ class TestMatch(unittest.TestCase):
 
     def test_string_to_interactions(self):
         string = 'CDCDDD'
-        interactions = [('C', 'D'), ('C', 'D'), ('D', 'D')]
+        interactions = [(C, D), (C, D), (D, D)]
         self.assertEqual(iu.string_to_interactions(string), interactions)

--- a/axelrod/tests/unit/test_inverse.py
+++ b/axelrod/tests/unit/test_inverse.py
@@ -1,9 +1,5 @@
-"""Test for the inverse strategy."""
-
-import random
-
+"""Tests for the inverse strategy."""
 import axelrod
-
 from .test_player import TestPlayer
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
@@ -24,33 +20,16 @@ class TestInverse(TestPlayer):
     }
 
     def test_strategy(self):
-        """
-        Test that initial strategy cooperates.
-        """
         self.first_play_test(C)
 
-    def test_that_cooperate_if_opponent_has_not_defected(self):
-        """
-        Test that as long as the opponent has not defected the player will
-        cooperate.
-        """
-        self.responses_test([C] * 4, [C] * 4, [C])
-        self.responses_test([C] * 5, [C] * 5, [C])
+        self.responses_test(C, C * 4, C * 4)
+        self.responses_test(C, C * 5, C * 5)
 
-    def test_when_opponent_has_all_Ds(self):
-        """
-        Tests that if opponent has played all D then player chooses D
-        """
-        self.responses_test([C], [D], [D], random_seed=5)
-        self.responses_test([C], [D, D], [D])
-        self.responses_test([C] * 8, [D] * 8, [D])
+        self.responses_test(D, C, D, random_seed=5)
+        self.responses_test(D, C + D, D + D)
+        self.responses_test(D, C + D * 7, D * 8)
 
-    def test_when_opponent_som_Ds(self):
-        """
-        Tests that if opponent has played all D then player chooses D
-        """
-        random.seed(5)
-        self.responses_test([C] * 4, [C, D, C, D], [C], random_seed=6)
-        self.responses_test([C] * 6, [C, C, C, C, D, D], [C])
-        self.responses_test([C] * 9, [D] * 8 + [C], [D])
-        self.responses_test([C] * 9, [D] * 8 + [C], [D], random_seed=6)
+        self.responses_test(C, C * 4, (C + D) * 2, random_seed=6)
+        self.responses_test(C, C * 6, C * 4 + D * 2)
+        self.responses_test(D, C * 9, D * 8 + C)
+        self.responses_test(D, C * 9, D * 8 + C, random_seed=6)

--- a/axelrod/tests/unit/test_lookerup.py
+++ b/axelrod/tests/unit/test_lookerup.py
@@ -1,4 +1,4 @@
-"""Test for the Looker Up strategy."""
+"""Tests for the LookerUp strategy."""
 import copy
 import unittest
 
@@ -25,11 +25,11 @@ class TestCreateTables(unittest.TestCase):
 
     def test_create_table_from_pattern(self):
         with self.assertRaises(ValueError):
-            pattern = ''.join([C] * 8)
+            pattern = C * 8
             create_lookup_table_from_pattern(2, 2, 2, pattern)
-    # Doesn't Raise
-    pattern = ''.join([C] * 8)
-    create_lookup_table_from_pattern(1, 1, 1, pattern)
+        # Doesn't Raise
+        pattern = C * 8
+        create_lookup_table_from_pattern(1, 1, 1, pattern)
 
 
 class TestLookerUp(TestPlayer):
@@ -58,10 +58,10 @@ class TestLookerUp(TestPlayer):
         # Test default table
         player = self.player()
         expected_lookup_table = {
-            ('', 'C', 'D'): D,
-            ('', 'D', 'D'): D,
-            ('', 'C', 'C'): C,
-            ('', 'D', 'C'): C,
+            ('', C, D): D,
+            ('', D, D): D,
+            ('', C, C): C,
+            ('', D, C): C,
         }
         self.assertEqual(player.lookup_table, expected_lookup_table)
         # Test malformed tables
@@ -70,9 +70,9 @@ class TestLookerUp(TestPlayer):
             player = self.player(table)
 
     def test_strategy(self):
-        self.markov_test([C, D, C, D])  # TFT
-        self.responses_test([C] * 4, [C, C, C, C], [C])
-        self.responses_test([C] * 5, [C, C, C, C, D], [D])
+        self.second_play_test(C, D, C, D)  # TFT
+        self.responses_test(C, C * 4, C * 4)
+        self.responses_test(D, C * 5, C * 4 + D)
 
     def test_defector_table(self):
         """
@@ -89,9 +89,9 @@ class TestLookerUp(TestPlayer):
             ('', D, C): D,
         }
         self.player = lambda : axelrod.LookerUp(defector_table)
-        self.responses_test([C, C], [C, C], [D])
-        self.responses_test([C, D], [D, C], [D])
-        self.responses_test([D, D], [D, D], [D])
+        self.responses_test(D, [C, C], [C, C])
+        self.responses_test(D, [C, D], [D, C])
+        self.responses_test(D, [D, D], [D, D])
 
     def test_zero_tables(self):
         """Test the corner case where n=0."""
@@ -127,16 +127,16 @@ class TestLookerUp(TestPlayer):
         self.player = lambda: axelrod.LookerUp(first_move_table)
 
         # if the opponent started by cooperating, we should always cooperate
-        self.responses_test([C, C, C], [C, C, C], [C])
-        self.responses_test([D, D, D], [C, C, C], [C])
-        self.responses_test([C, C, C], [C, D, C], [C])
-        self.responses_test([C, C, D], [C, D, C], [C])
+        self.responses_test(C, [C, C, C], [C, C, C])
+        self.responses_test(C, [D, D, D], [C, C, C])
+        self.responses_test(C, [C, C, C], [C, D, C])
+        self.responses_test(C, [C, C, D], [C, D, C])
 
         # if the opponent started by defecting, we should always defect
-        self.responses_test([C, C, C], [D, C, C], [D])
-        self.responses_test([D, D, D], [D, C, C], [D])
-        self.responses_test([C, C, C], [D, D, C], [D])
-        self.responses_test([C, C, D], [D, D, C], [D])
+        self.responses_test(D, [C, C, C], [D, C, C])
+        self.responses_test(D, [D, D, D], [D, C, C])
+        self.responses_test(D, [C, C, C], [D, D, C])
+        self.responses_test(D, [C, C, D], [D, D, C])
 
 
 class TestEvolvedLookerUp2_2_2(TestPlayer):
@@ -156,9 +156,9 @@ class TestEvolvedLookerUp2_2_2(TestPlayer):
 
     def test_init(self):
         # Check for a few known keys
-        known_pairs = {('DD', 'CC', 'CD'): 'D', ('DC', 'CD', 'CD'): 'C',
-                       ('DD', 'CD', 'CD'): 'C', ('DC', 'DC', 'DC'): 'C',
-                       ('DD', 'DD', 'CC'): 'D', ('CD', 'CC', 'DC'): 'D'}
+        known_pairs = {('DD', 'CC', 'CD'): D, ('DC', 'CD', 'CD'): C,
+                       ('DD', 'CD', 'CD'): C, ('DC', 'DC', 'DC'): C,
+                       ('DD', 'DD', 'CC'): D, ('CD', 'CC', 'DC'): D}
         player = self.player()
         for k, v in known_pairs.items():
             self.assertEqual(player.lookup_table[k], v)
@@ -190,14 +190,13 @@ class EvolvedLookerUpvsDefector(TestHeadsUp):
 class EvolvedLookerUpvsCooperator(TestHeadsUp):
     def test_vs(self):
         self.versus_test(axelrod.EvolvedLookerUp2_2_2(), axelrod.Cooperator(),
-                         [C] * 10, [C] * 10)
+                         C * 10, C * 10)
 
 
 class EvolvedLookerUpvsTFT(TestHeadsUp):
     def test_vs(self):
-        outcomes = zip()
         self.versus_test(axelrod.EvolvedLookerUp2_2_2(), axelrod.TitForTat(),
-                         [C] * 10, [C] * 10)
+                         C * 10, C * 10)
 
 
 class EvolvedLookerUpvsAlternator(TestHeadsUp):
@@ -225,7 +224,7 @@ class TestWinner12(TestPlayer):
 
     def test_strategy(self):
         """Starts by cooperating twice."""
-        self.responses_test([], [], [C, C])
+        self.responses_test(C * 2)
 
 
 class TestWinner21(TestPlayer):
@@ -245,7 +244,5 @@ class TestWinner21(TestPlayer):
     expected_class_classifier = copy.copy(expected_classifier)
     expected_class_classifier['memory_depth'] = float('inf')
 
-
     def test_strategy(self):
-        """Starts by cooperating twice."""
-        self.responses_test([], [], [D, C])
+        self.responses_test(D + C)

--- a/axelrod/tests/unit/test_match.py
+++ b/axelrod/tests/unit/test_match.py
@@ -1,12 +1,9 @@
-# -*- coding: utf-8 -*-
 import unittest
+from hypothesis import given, example
+from hypothesis.strategies import integers, floats, assume
 import axelrod
 from axelrod import Actions
 from axelrod.deterministic_cache import DeterministicCache
-
-from hypothesis import given, example
-from hypothesis.strategies import integers, floats, assume
-
 from axelrod.tests.property import games
 
 C, D = Actions.C, Actions.D
@@ -41,7 +38,8 @@ class TestMatch(unittest.TestCase):
             'game': game,
             'noise': 0.5
         }
-        match = axelrod.Match((p1, p2), turns, game=game, match_attributes=match_attributes)
+        match = axelrod.Match((p1, p2), turns, game=game,
+                              match_attributes=match_attributes)
         self.assertEqual(match.players[0].match_attributes['length'], 500)
         self.assertEqual(match.players[0].match_attributes['noise'], 0.5)
 

--- a/axelrod/tests/unit/test_match_generator.py
+++ b/axelrod/tests/unit/test_match_generator.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import unittest
 
 from hypothesis import given, example

--- a/axelrod/tests/unit/test_mathematicalconstants.py
+++ b/axelrod/tests/unit/test_mathematicalconstants.py
@@ -1,7 +1,6 @@
-"""Test for the golden and other mathematical strategies."""
+"""Tests for the golden and other mathematical strategies."""
 
 import axelrod
-
 from .test_player import TestPlayer
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
@@ -22,20 +21,23 @@ class TestGolden(TestPlayer):
     }
 
     def test_strategy(self):
-        """test initial strategy co-operates"""
+        """Test initial strategy co-operates."""
         self.first_play_test(C)
 
     def test_when_no_defection(self):
-        """tests that if the opposing player does not defect initially then strategy defects"""
-        self.responses_test([C], [C], [D])
+        """Tests that if the opposing player does not defect initially then
+        strategy defects."""
+        self.responses_test(D, C, C)
 
     def test_when_greater_than_golden_ratio(self):
-        """tests that if the ratio of Cs to Ds is greater than the golden ratio then strategy defects"""
-        self.responses_test([C] * 4, [C, C, D, D], [D])
+        """Tests that if the ratio of Cs to Ds is greater than the golden ratio
+        then strategy defects."""
+        self.responses_test(D, C * 4, C + C + D + D)
 
     def test_when_less_than_golder_ratio(self):
-        """tests that if the ratio of Cs to Ds is less than the golden ratio then strategy co-operates"""
-        self.responses_test([C] * 4, [D] * 4, [C])
+        """Tests that if the ratio of Cs to Ds is less than the golden ratio
+        then strategy co-operates."""
+        self.responses_test(C, C * 4, D * 4)
 
 
 class TestPi(TestPlayer):
@@ -53,20 +55,23 @@ class TestPi(TestPlayer):
     }
 
     def test_strategy(self):
-        """test initial strategy co-operates"""
+        """Test initial strategy co-operates."""
         self.first_play_test(C)
 
     def test_when_no_defection(self):
-        """tests that if the opposing player does not defect initially then strategy defects"""
-        self.responses_test([C], [C], [D])
+        """Tests that if the opposing player does not defect initially then
+        strategy defects."""
+        self.responses_test(D, C, C)
 
     def test_when_greater_than_pi(self):
-        """tests that if the ratio of Cs to Ds is greater than pi then strategy defects"""
-        self.responses_test([C] * 4, [C, C, C, D], [D])
+        """Tests that if the ratio of Cs to Ds is greater than pi then strategy
+        defects."""
+        self.responses_test(D, C * 4, C * 3 + D)
 
-    def test_when_less_than_pi(self):
-        """tests that if the ratio of Cs to Ds is less than pi then strategy co-operates"""
-        self.responses_test([C] * 4, [C, C, D, D], [C])
+    def Test_when_less_than_pi(self):
+        """Tests that if the ratio of Cs to Ds is less than pi then strategy
+        co-operates."""
+        self.responses_test(C, C * 4, C + C + D + D)
 
 
 class Teste(TestPlayer):
@@ -84,17 +89,20 @@ class Teste(TestPlayer):
     }
 
     def test_strategy(self):
-        """test initial strategy co-operates"""
+        """Test initial strategy co-operates."""
         self.first_play_test(C)
 
     def test_when_no_defection(self):
-        """tests that if the opposing player does not defect initially then strategy defects"""
-        self.responses_test([C], [C], [D])
+        """Tests that if the opposing player does not defect initially then
+        strategy defects."""
+        self.responses_test(D, C, C)
 
     def test_when_greater_than_e(self):
-        """tests that if the ratio of Cs to Ds is greater than e then strategy defects"""
-        self.responses_test([C] * 4, [C, C, D, D], [D])
+        """Tests that if the ratio of Cs to Ds is greater than e then strategy
+        defects."""
+        self.responses_test(D, C * 4, C + C + D + D)
 
     def test_when_less_than_e(self):
-        """tests that if the ratio of Cs to Ds is less than e then strategy co-operates"""
-        self.responses_test([C] * 4, [C, D, D, D], [C])
+        """Tests that if the ratio of Cs to Ds is less than e then strategy
+        co-operates."""
+        self.responses_test(C, C * 4, C + D * 3)

--- a/axelrod/tests/unit/test_mathematicalconstants.py
+++ b/axelrod/tests/unit/test_mathematicalconstants.py
@@ -68,7 +68,7 @@ class TestPi(TestPlayer):
         defects."""
         self.responses_test(D, C * 4, C * 3 + D)
 
-    def Test_when_less_than_pi(self):
+    def test_when_less_than_pi(self):
         """Tests that if the ratio of Cs to Ds is less than pi then strategy
         co-operates."""
         self.responses_test(C, C * 4, C + C + D + D)

--- a/axelrod/tests/unit/test_memoryone.py
+++ b/axelrod/tests/unit/test_memoryone.py
@@ -1,4 +1,4 @@
-"""Test for the memoryone strategies."""
+"""Tests for the memoryone strategies."""
 
 import unittest
 
@@ -9,9 +9,10 @@ from .test_player import TestPlayer, test_four_vector
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
 
+
 class TestGenericPlayerOne(unittest.TestCase):
     """
-    A class to test the naming and classification of generic memory one players
+    A class to test the naming and classification of generic memory one players.
     """
     p1 = axelrod.MemoryOnePlayer((0, 0, 0, 0))
     p2 = axelrod.MemoryOnePlayer((1, 0, 1, 0))
@@ -55,7 +56,7 @@ class TestWinStayLoseShift(TestPlayer):
 
     def test_effect_of_strategy(self):
         """Check that switches if does not get best payoff."""
-        self.markov_test([C, D, D, C])
+        self.second_play_test(C, D, D, C)
 
 
 class TestWinShiftLoseStayTestPlayer(TestPlayer):
@@ -78,7 +79,7 @@ class TestWinShiftLoseStayTestPlayer(TestPlayer):
 
     def test_effect_of_strategy(self):
         """Check that switches if does not get best payoff."""
-        self.markov_test([D, C, C, D])
+        self.second_play_test(D, C, C, D)
 
 
 class TestGTFT(TestPlayer):
@@ -129,11 +130,11 @@ class TestFirmButFair(TestPlayer):
 
     def test_strategy(self):
         self.first_play_test(C)
-        self.responses_test([C], [C], [C])
-        self.responses_test([C], [D], [D])
-        self.responses_test([D], [C], [C])
-        self.responses_test([D], [D], [C], random_seed=1)
-        self.responses_test([D], [D], [D], random_seed=2)
+        self.responses_test(C, C, C)
+        self.responses_test(D, C, D)
+        self.responses_test(C, D, C)
+        self.responses_test(C, D, D, random_seed=1)
+        self.responses_test(D, D, D, random_seed=2)
 
 class TestStochasticCooperator(TestPlayer):
 
@@ -150,21 +151,20 @@ class TestStochasticCooperator(TestPlayer):
     }
 
     def test_four_vector(self):
-        expected_dictionary = {(C, C): 0.935, (C, D): 0.229, (D, C): 0.266, (D, D): 0.42}
+        expected_dictionary = {(C, C): 0.935, (C, D): 0.229, (D, C): 0.266,
+                               (D, D): 0.42}
         test_four_vector(self, expected_dictionary)
 
     def test_strategy(self):
         self.first_play_test(C)
-
-    def test_effect_of_strategy(self):
         # With probability 0.065 will defect
-        self.responses_test([C], [C], [D, C, C, C], random_seed=15)
+        self.responses_test(D + C * 3, C, C, random_seed=15)
         # With probability 0.266 will cooperate
-        self.responses_test([C], [D], [C], random_seed=1)
+        self.responses_test(C, C, D, random_seed=1)
         # With probability 0.42 will cooperate
-        self.responses_test([D], [C], [C], random_seed=3)
+        self.responses_test(C, D, C, random_seed=3)
         # With probability 0.229 will cooperate
-        self.responses_test([D], [D], [C], random_seed=13)
+        self.responses_test(C, D, D, random_seed=13)
 
 
 class TestStochasticWSLS(TestPlayer):
@@ -181,24 +181,23 @@ class TestStochasticWSLS(TestPlayer):
         'manipulates_state': False
     }
 
-    def test_strategy(self):
-        self.first_play_test(C)
-
     def test_four_vector(self):
         player = self.player()
         ep = player.ep
-        expected_dictionary = {(C, C): 1.-ep, (C, D): ep, (D, C): ep, (D, D): 1.-ep}
+        expected_dictionary = {(C, C): 1.-ep, (C, D): ep, (D, C): ep,
+                               (D, D): 1.-ep}
         test_four_vector(self, expected_dictionary)
 
-    def test_effect_of_strategy(self):
+    def test_strategy(self):
+        self.first_play_test(C)
         # With probability 0.05 will defect
-        self.responses_test([C], [C], [D], random_seed=2)
+        self.responses_test(D, C, C, random_seed=2)
         # With probability 0.05 will cooperate
-        self.responses_test([C], [D], [C], random_seed=31)
+        self.responses_test(C, C, D, random_seed=31)
         # With probability 0.05 will cooperate
-        self.responses_test([D], [C], [C], random_seed=31)
+        self.responses_test(C, D, C, random_seed=31)
         # With probability 0.05 will defect
-        self.responses_test([D], [D], [D], random_seed=2)
+        self.responses_test(D, D, D, random_seed=2)
 
 
 class TestMemoryOnePlayer(unittest.TestCase):
@@ -247,10 +246,10 @@ class TestZDExtort2(TestPlayer):
         self.first_play_test(C)
 
     def test_effect_of_strategy(self):
-        self.responses_test([C], [C], [D, D, C, C], random_seed=2)
-        self.responses_test([C], [D], [D, D, C, C], random_seed=2)
-        self.responses_test([D], [C], [D, D, C, C], random_seed=2)
-        self.responses_test([C], [D], [D, D, C, C], random_seed=2)
+        self.responses_test(D + D + C + C, C, C, random_seed=2)
+        self.responses_test(D + D + C + C, C, D, random_seed=2)
+        self.responses_test(D + D + C + C, D, C, random_seed=2)
+        self.responses_test(D + D + C + C, C, D, random_seed=2)
 
 
 class TestZDExtort2v2(TestPlayer):
@@ -344,10 +343,10 @@ class TestZDGTFT2(TestPlayer):
         self.first_play_test(C)
 
     def test_effect_of_strategy(self):
-        self.responses_test([C], [C], [C, C, C, C], random_seed=2)
-        self.responses_test([C], [D], [D], random_seed=2)
-        self.responses_test([D], [C], [C, C, C, C], random_seed=2)
-        self.responses_test([D], [D], [D], random_seed=2)
+        self.responses_test(C * 4, C, C, random_seed=2)
+        self.responses_test(D, C, D, random_seed=2)
+        self.responses_test(C * 4, D, C, random_seed=2)
+        self.responses_test(D, D, D, random_seed=2)
 
 
 class TestZDSet2(TestPlayer):
@@ -392,8 +391,8 @@ class TestSoftJoss(TestPlayer):
         test_four_vector(self, expected_dictionary)
 
     def test_strategy(self):
-        self.responses_test([C], [C], [C], random_seed=2)
-        self.responses_test([C], [D], [D], random_seed=5)
+        self.responses_test(C, C, C, random_seed=2)
+        self.responses_test(D, C, D, random_seed=5)
 
 
 class TestALLCorALLD(TestPlayer):
@@ -411,8 +410,8 @@ class TestALLCorALLD(TestPlayer):
     }
 
     def test_strategy(self):
-        self.responses_test([], [], [D] * 10, random_seed=2)
-        self.responses_test([], [], [C] * 10, random_seed=3)
-        self.responses_test([], [], [C] * 10, random_seed=4)
-        self.responses_test([], [], [D] * 10, random_seed=5)
-        self.responses_test([], [], [D] * 10, random_seed=6)
+        self.responses_test(D * 10, random_seed=2)
+        self.responses_test(C * 10, random_seed=3)
+        self.responses_test(C * 10, random_seed=4)
+        self.responses_test(D * 10, random_seed=5)
+        self.responses_test(D * 10, random_seed=6)

--- a/axelrod/tests/unit/test_memorytwo.py
+++ b/axelrod/tests/unit/test_memorytwo.py
@@ -1,7 +1,6 @@
-"""Test for the memorytwo strategies."""
+"""Tests for the memorytwo strategies."""
 
 import axelrod
-from axelrod.strategies.memorytwo import MEM2
 from .test_player import TestPlayer
 
 
@@ -24,21 +23,21 @@ class TestMEM2(TestPlayer):
 
     def test_strategy(self):
         # Start with TFT
-        self.responses_test([], [], [C])
-        self.responses_test([C], [C], [C])
-        self.responses_test([C], [D], [D])
+        self.responses_test(C)
+        self.responses_test(C, C, C)
+        self.responses_test(D, C, D)
         # TFT if mutual cooperation on first two rounds
-        self.responses_test([C, C], [C, C], [C])
-        self.responses_test([C, D], [D, D], [D])
+        self.responses_test(C, C * 2, C * 2)
+        self.responses_test(D, C + D, D * 2)
         # TFTT if C, D and D, C
-        self.responses_test([C, C, C, D], [C, C, D, C], [C])
-        self.responses_test([C, C, C, D, C, D], [C, C, D, C, D, D], [D])
+        self.responses_test(C, C * 3 + D, C + C + D + C)
+        self.responses_test(D, C * 3 + D + C + D, C + C + D + C + D + D)
         # TFTT if D, C and C, D
-        self.responses_test([C, C, D, C], [C, D, C, D], [C])
-        self.responses_test([C, C, D, C, C, D], [C, C, D, C, D, D], [D])
+        self.responses_test(C, C + C + D + C, C + D + C + D)
+        self.responses_test(D, C + C + D + C + C + D, C + C + D + C + D + D)
         # ALLD Otherwise
-        self.responses_test([C, D], [D, D], [D])
-        self.responses_test([C, D, D], [D, D, D], [D])
+        self.responses_test(D, C + D, D * 2)
+        self.responses_test(D, C + D + D, D * 3)
         # ALLD forever if all D twice
-        self.responses_test([C, D, D, D, D, D], [D, D, D, D, D, D], [D] * 10)
-        self.responses_test([C] + [D] * 5 + [C] * 4, [D] * 6 + [C] * 4, [D] * 9)
+        self.responses_test(D * 10, C + D * 5, D * 6)
+        self.responses_test(D * 9, C + D * 5 + C * 4, D * 6 + C * 4)

--- a/axelrod/tests/unit/test_meta.py
+++ b/axelrod/tests/unit/test_meta.py
@@ -1,6 +1,5 @@
 """Tests for the various Meta strategies."""
 
-import copy
 import random
 
 import axelrod
@@ -185,14 +184,9 @@ class TestNiceMetaWinnerEnsemble(TestMetaPlayer):
 
     def test_strategy(self):
         self.first_play_test(C)
-
-        P1 = axelrod.NiceMetaWinner(team=[axelrod.Cooperator, axelrod.Defector])
-        P2 = axelrod.Cooperator()
-        test_responses(self, P1, P2, [C] * 4, [C] * 4, [C] * 4)
-
-        P1 = axelrod.NiceMetaWinner(team=[axelrod.Cooperator, axelrod.Defector])
-        P2 = axelrod.Defector()
-        test_responses(self, P1, P2, [C] * 4, [D] * 4, [D] * 4)
+        team = [axelrod.Cooperator, axelrod.Defector]
+        self.responses_test(C * 4, C * 4, C * 4, init_args=[team])
+        self.responses_test(D * 4, C * 4, D * 4, init_args=[team])
 
 
 class TestMetaHunter(TestMetaPlayer):
@@ -214,20 +208,20 @@ class TestMetaHunter(TestMetaPlayer):
 
         # We are not using the Cooperator Hunter here, so this should lead to
         #  cooperation.
-        self.responses_test([C, C, C, C], [C, C, C, C], [C])
+        self.responses_test(C, C * 4, C * 4)
 
         # After long histories tit-for-tat should come into play.
-        self.responses_test([C] * 101, [C] * 100 + [D], [D])
+        self.responses_test(D, C * 101, C * 100 + D)
 
         # All these others, however, should trigger a defection for the hunter.
-        self.responses_test([C] * 4, [D] * 4, [D])
-        self.responses_test([C] * 6, [C, D] * 3, [D])
-        self.responses_test([C] * 8, [C, C, C, D, C, C, C, D], [D])
-        self.responses_test([C] * 100,
-                            [random.choice([C, D]) for i in range(100)], [D])
+        self.responses_test(D, C * 4, D * 4)
+        self.responses_test(D, C * 6, (C + D) * 3)
+        self.responses_test(D, C * 8, [C, C, C, D, C, C, C, D])
+        self.responses_test(D, C * 100,
+                            [random.choice([C, D]) for _ in range(100)])
         # Test post 100 rounds responses
-        self.responses_test([C] * 101, [C] * 101, [C])
-        self.responses_test([C] * 101, [C] * 100 + [D], [D])
+        self.responses_test(C, C * 101, C * 101)
+        self.responses_test(D, C * 101, C * 100 + D)
 
 
 class TestMetaHunterAggressive(TestMetaPlayer):
@@ -249,20 +243,20 @@ class TestMetaHunterAggressive(TestMetaPlayer):
 
         # We are using CooperatorHunter here, so this should lead to
         # defection
-        self.responses_test([C, C, C, C], [C, C, C, C], [D])
+        self.responses_test(D, C * 4, C * 4)
 
         # After long histories tit-for-tat should come into play.
-        self.responses_test([C] * 101, [C] * 100 + [D], [D])
+        self.responses_test(D, C * 101, C * 100 + D)
 
         # All these others, however, should trigger a defection for the hunter.
-        self.responses_test([C] * 4, [D] * 4, [D])
-        self.responses_test([C] * 6, [C, D] * 3, [D])
-        self.responses_test([C] * 8, [C, C, C, D, C, C, C, D], [D])
-        self.responses_test([C] * 100,
-                            [random.choice([C, D]) for i in range(100)], [D])
+        self.responses_test(D, C * 4, D * 4)
+        self.responses_test(D, C * 6, (C + D) * 3)
+        self.responses_test(D, C * 8, (C * 3 + D) * 2)
+        self.responses_test(D, C * 100,
+                            [random.choice([C, D]) for _ in range(100)])
         # Test post 100 rounds responses
-        self.responses_test([C] * 101, [C] * 101, [D])
-        self.responses_test([C] * 101, [C] * 100 + [D], [D])
+        self.responses_test(D, C * 101, C * 101)
+        self.responses_test(D, C * 101, C * 100 + D)
 
 
 class TestMetaMajorityMemoryOne(TestMetaPlayer):

--- a/axelrod/tests/unit/test_meta.py
+++ b/axelrod/tests/unit/test_meta.py
@@ -245,9 +245,6 @@ class TestMetaHunterAggressive(TestMetaPlayer):
         # defection
         self.responses_test(D, C * 4, C * 4)
 
-        # After long histories tit-for-tat should come into play.
-        self.responses_test(D, C * 101, C * 100 + D)
-
         # All these others, however, should trigger a defection for the hunter.
         self.responses_test(D, C * 4, D * 4)
         self.responses_test(D, C * 6, (C + D) * 3)
@@ -255,8 +252,8 @@ class TestMetaHunterAggressive(TestMetaPlayer):
         self.responses_test(D, C * 100,
                             [random.choice([C, D]) for _ in range(100)])
         # Test post 100 rounds responses
-        self.responses_test(D, C * 101, C * 101)
-        self.responses_test(D, C * 101, C * 100 + D)
+        self.responses_test(D * 5, C * 101, C * 101)
+        self.responses_test(D * 5, C * 101, C * 100 + D)
 
 
 class TestMetaMajorityMemoryOne(TestMetaPlayer):

--- a/axelrod/tests/unit/test_meta.py
+++ b/axelrod/tests/unit/test_meta.py
@@ -424,7 +424,7 @@ class TestMetaMixer(TestMetaPlayer):
         P2 = axelrod.Cooperator()
 
         for k in range(100):
-            P1.play(P2)
+            play = P1.play(P2)
             self.assertEqual(P1.history[-1], C)
 
         team.append(axelrod.Defector)
@@ -433,7 +433,7 @@ class TestMetaMixer(TestMetaPlayer):
         P1 = axelrod.MetaMixer(team, distribution)
 
         for k in range(100):
-            P1.play(P2)
+            play = P1.play(P2)
             self.assertEqual(P1.history[-1], C)
 
         distribution = [0, 0, 0, 1]  # If defector is only one that is played
@@ -441,7 +441,7 @@ class TestMetaMixer(TestMetaPlayer):
         P1 = axelrod.MetaMixer(team, distribution)
 
         for k in range(100):
-            P1.play(P2)
+            play = P1.play(P2)
             self.assertEqual(P1.history[-1], D)
 
     def test_raise_error_in_distribution(self):

--- a/axelrod/tests/unit/test_mindcontrol.py
+++ b/axelrod/tests/unit/test_mindcontrol.py
@@ -37,28 +37,6 @@ class TestMindController(TestPlayer):
         self.assertEqual(P1.strategy(P2), D)
         self.assertEqual(P2.strategy(P1), C)
 
-    def test_vs_grudger(self):
-        """ Will force even Grudger to forget its grudges"""
-
-        P1 = axelrod.MindController()
-        P2 = axelrod.Grudger()
-        P1.history = [D, D, D, D]
-        self.assertEqual(P1.strategy(P2), D)
-        self.assertEqual(P2.strategy(P1), C)
-
-    def test_init(self):
-        """Test to make sure parameters are initialised correctly """
-
-        P1 = axelrod.MindController()
-        self.assertEqual(P1.history, [])
-
-    def test_reset(self):
-        """ test for the reset method """
-        P1 = axelrod.MindController()
-        P1.history = [C, D, D, D]
-        P1.reset()
-        self.assertEqual(P1.history, [])
-
 
 class TestMindWarper(TestMindController):
 
@@ -76,15 +54,15 @@ class TestMindWarper(TestMindController):
 
     def test_setattr(self):
         player = self.player()
-        player.strategy = lambda opponent: 'C'
+        player.strategy = lambda opponent: C
 
     def test_strategy(self):
         player = self.player()
         opponent = axelrod.Defector()
         play1 = player.strategy(opponent)
         play2 = opponent.strategy(player)
-        self.assertEqual(play1, 'D')
-        self.assertEqual(play2, 'C')
+        self.assertEqual(play1, D)
+        self.assertEqual(play2, C)
 
 
 class TestMindBender(TestMindController):
@@ -106,5 +84,5 @@ class TestMindBender(TestMindController):
         opponent = axelrod.Defector()
         play1 = player.strategy(opponent)
         play2 = opponent.strategy(player)
-        self.assertEqual(play1, 'D')
-        self.assertEqual(play2, 'C')
+        self.assertEqual(play1, D)
+        self.assertEqual(play2, C)

--- a/axelrod/tests/unit/test_mindreader.py
+++ b/axelrod/tests/unit/test_mindreader.py
@@ -1,9 +1,9 @@
-"""Test for the mindreader strategy."""
+"""Tests for the mindreader strategy."""
 
 import axelrod
-
-from .test_player import TestPlayer
 from axelrod._strategy_utils import simulate_match
+from .test_player import TestPlayer
+
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
 
@@ -48,7 +48,7 @@ class TestMindReader(TestPlayer):
 
     def test_vs_tit_for_tat(self):
         """
-        Will keep nasty strategies happy if it can
+        Will keep nasty strategies happy if it can.
         """
         P1 = axelrod.MindReader()
         P2 = axelrod.TitForTat()
@@ -56,43 +56,31 @@ class TestMindReader(TestPlayer):
 
     def test_simulate_matches(self):
         """
-        Simulates a number of matches
+        Simulates a number of matches.
         """
         P1 = axelrod.MindReader()
         P2 = axelrod.Grudger()
         simulate_match(P1, P2, C, 4)
-        self.assertEqual(P2.history, [C, C, C, C])
+        self.assertEqual(P2.history, C * 4)
 
     def test_history_is_same(self):
         """
-        Checks that the history is not altered by the player
+        Checks that the history is not altered by the player.
         """
         P1 = axelrod.MindReader()
         P2 = axelrod.Grudger()
-        P1.history = [C, C]
-        P2.history = [C, D]
+        P1.play(P2)
+        P1.play(P2)
         P1.strategy(P2)
-        self.assertEqual(P1.history, [C, C])
-        self.assertEqual(P2.history, [C, D])
+        self.assertEqual(P1.history, C + C)
+        self.assertEqual(P2.history, C + C)
 
     def test_vs_geller(self):
-        """Ensures that a recursion error does not occur """
+        """Ensures that a recursion error does not occur."""
         P1 = axelrod.MindReader()
         P2 = axelrod.Geller()
         P1.strategy(P2)
         P2.strategy(P1)
-
-    def test_init(self):
-        """Tests for init method """
-        P1 = axelrod.MindReader()
-        self.assertEqual(P1.history, [])
-
-    def test_reset(self):
-        """Tests to see if the class is reset correctly """
-        P1 = axelrod.MindReader()
-        P1.history = [C, D, D, D]
-        P1.reset()
-        self.assertEqual(P1.history, [])
 
 
 class TestProtectedMindReader(TestPlayer):

--- a/axelrod/tests/unit/test_mock_player.py
+++ b/axelrod/tests/unit/test_mock_player.py
@@ -1,6 +1,6 @@
 import unittest
-import axelrod
 
+import axelrod
 from axelrod import MockPlayer, simulate_play, update_history
 from axelrod.tests.unit.test_player import TestOpponent
 
@@ -10,10 +10,10 @@ C, D = axelrod.Actions.C, axelrod.Actions.D
 class TestMockPlayer(unittest.TestCase):
 
     def test_strategy(self):
-        for move in [C, D]:
-            m = MockPlayer(axelrod.Player(), move)
+        for action in [C, D]:
+            m = MockPlayer(axelrod.Player(), action)
             p2 = axelrod.Player()
-            self.assertEqual(move, m.strategy(p2))
+            self.assertEqual(action, m.strategy(p2))
 
     def test_cloning(self):
         p1 = axelrod.Cooperator()
@@ -40,8 +40,8 @@ class TestUpdateHistories(unittest.TestCase):
         p2 = TestOpponent()
         update_history(p1, C)
         update_history(p2, C)
-        self.assertEqual(p1.history, [C])
-        self.assertEqual(p2.history, [C])
+        self.assertEqual(p1.history, C)
+        self.assertEqual(p2.history, C)
         self.assertEqual(p1.cooperations, 1)
         self.assertEqual(p2.cooperations, 1)
         self.assertEqual(p1.defections, 0)
@@ -49,8 +49,8 @@ class TestUpdateHistories(unittest.TestCase):
 
         update_history(p1, D)
         update_history(p2, D)
-        self.assertEqual(p1.history, [C, D])
-        self.assertEqual(p2.history, [C, D])
+        self.assertEqual(p1.history, C + D)
+        self.assertEqual(p2.history, C + D)
         self.assertEqual(p1.cooperations, 1)
         self.assertEqual(p2.cooperations, 1)
         self.assertEqual(p1.defections, 1)
@@ -91,5 +91,5 @@ class TestSimulatePlay(unittest.TestCase):
         self.assertEqual(p1.defections, 0)
         self.assertEqual(p2.defections, 2)
 
-        self.assertEqual(p1.history, [C] * 2)
-        self.assertEqual(p2.history, [D] * 2)
+        self.assertEqual(p1.history, C * 2)
+        self.assertEqual(p2.history, D * 2)

--- a/axelrod/tests/unit/test_moran.py
+++ b/axelrod/tests/unit/test_moran.py
@@ -131,7 +131,9 @@ class TestMoranProcess(unittest.TestCase):
         p3 = axelrod.Defector()
         players = [p1, p2, p3]
         mp = MoranProcess(players, mutation_rate=0.2)
-        self.assertDictEqual(mp.mutation_targets, {str(p1): [p3, p2], str(p2): [p1, p3], str(p3): [p1, p2]})
+        self.assertDictEqual(
+            mp.mutation_targets,
+            {str(p1): [p3, p2], str(p2): [p1, p3], str(p3): [p1, p2]})
         # Test that mutation causes the population to alternate between fixations
         counters = [
             Counter({'Cooperator': 3}),

--- a/axelrod/tests/unit/test_mutual.py
+++ b/axelrod/tests/unit/test_mutual.py
@@ -1,8 +1,5 @@
 """Tests for strategies Desperate, Hopeless, Willing, and Grim"""
 import axelrod
-
-from axelrod.random_ import seed
-
 from .test_player import TestPlayer
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
@@ -22,15 +19,13 @@ class TestDesperate(TestPlayer):
     }
 
     def test_strategy(self):
-        seed(1)
-        self.first_play_test(C)
-        seed(2)
-        self.first_play_test(D)
+        self.first_play_test(C, random_seed=1)
+        self.first_play_test(D, random_seed=2)
 
     def test_responses(self):
-        self.responses_test([C] * 4, [D] * 4, [D])
-        self.responses_test([D, D, C], [C, C, D], [D])
-        self.responses_test([D, D, D], [C, C, D], [C])
+        self.responses_test(D, C * 4, D * 4)
+        self.responses_test(D, D + D + C, C + C + D)
+        self.responses_test(C, D * 3, C + C + D)
 
 
 class TestHopeless(TestPlayer):
@@ -48,15 +43,14 @@ class TestHopeless(TestPlayer):
     }
 
     def test_strategy(self):
-        seed(1)
-        self.first_play_test(C)
-        seed(2)
-        self.first_play_test(D)
+        self.first_play_test(C, random_seed=1)
+        self.first_play_test(D, random_seed=2)
 
     def test_responses(self):
-        self.responses_test([C] * 4, [D] * 4, [C])
-        self.responses_test([D] * 5, [C] * 5, [C])
-        self.responses_test([C, D, C], [C, C, C], [D])
+        self.responses_test(C, C * 4, D * 4,)
+        self.responses_test(C, D * 5, C * 5)
+        self.responses_test(D, C + D + C, C * 3)
+
 
 class TestWilling(TestPlayer):
 
@@ -73,12 +67,8 @@ class TestWilling(TestPlayer):
     }
 
     def test_strategy(self):
-        seed(1)
-        self.first_play_test(C)
-        seed(2)
-        self.first_play_test(D)
-
-    def test_responses(self):
-        self.responses_test([C] * 4, [D] * 4, [C])
-        self.responses_test([D] * 5, [C] * 5, [C])
-        self.responses_test([C, C, D], [C, C, D], [D])
+        self.first_play_test(C, random_seed=1)
+        self.first_play_test(D, random_seed=2)
+        self.responses_test(C, C * 4, D * 4)
+        self.responses_test(C, D * 5, C * 5)
+        self.responses_test(D, C + C + D, C + C + D)

--- a/axelrod/tests/unit/test_negation.py
+++ b/axelrod/tests/unit/test_negation.py
@@ -1,9 +1,10 @@
-"""Test for the Neg Strategy"""
+"""Tests for the Negation strategy."""
 
 import axelrod
 from .test_player import TestPlayer
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
+
 
 class TestNegation(TestPlayer):
 
@@ -19,7 +20,8 @@ class TestNegation(TestPlayer):
         'manipulates_state': False
     }
 
-    def test_effect_of_strategy(self):
+    def test_strategy(self):
+        self.first_play_test(C, random_seed=1)
+        self.first_play_test(D, random_seed=2)
         """Repeats opposite of opponents last action."""
-        self.markov_test([D, C, D, C])
-		
+        self.second_play_test(D, C, D, C)

--- a/axelrod/tests/unit/test_oncebitten.py
+++ b/axelrod/tests/unit/test_oncebitten.py
@@ -3,7 +3,6 @@
 import random
 
 import axelrod
-
 from .test_player import TestPlayer
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
@@ -27,22 +26,21 @@ class TestOnceBitten(TestPlayer):
         """If opponent defects at any point then the player will defect
         forever."""
         # Become grudged if the opponent defects twice in a row
-        self.responses_test([], [], [C], attrs={"grudged": False})
-        self.responses_test([C], [C], [C], attrs={"grudged": False})
-        self.responses_test([C, C], [C, C], [C], attrs={"grudged": False})
-        self.responses_test([C, C, C], [C, C, D], [C], attrs={"grudged": False})
-        self.responses_test([C, C, C, C], [C, C, D, D], [D],
-                            attrs={"grudged": True})
+        self.responses_test(C, attrs={"grudged": False})
+        self.responses_test(C, C, C, attrs={"grudged": False})
+        self.responses_test(C, C + C, C + C, attrs={"grudged": False})
+        self.responses_test(C, C * 3, C + C + D, attrs={"grudged": False})
+        self.responses_test(D, C * 4, C + C + D + D, attrs={"grudged": True})
 
         mem_length = self.player().mem_length
         for i in range(mem_length - 1):
-            self.responses_test([C, C, C, C] + [D] * i, [C, C, D, D] + [D] * i,
-                                [D], attrs={"grudged": True,
-                                            "grudge_memory": i})
+            self.responses_test(D, C * 4 + D * i, C + C + D + D + D * i,
+                                attrs={"grudged": True,
+                                       "grudge_memory": i})
         i = mem_length + 1
-        self.responses_test([C, C, C, C] + [D] * i, [C, C, D, D] + [C] * i,
-                            [C], attrs={"grudged": False,
-                                        "grudge_memory": 0})
+        self.responses_test(C, C * 4 + D * i, C + C + D + D + C * i,
+                            attrs={"grudged": False,
+                                   "grudge_memory": 0})
 
     def test_reset(self):
         """Check that grudged gets reset properly"""
@@ -54,7 +52,6 @@ class TestOnceBitten(TestPlayer):
         self.assertTrue(p1.grudged)
         p1.reset()
         self.assertFalse(p1.grudged)
-        self.assertEqual(p1.history, [])
 
 
 class TestFoolMeOnce(TestPlayer):
@@ -71,17 +68,14 @@ class TestFoolMeOnce(TestPlayer):
         'manipulates_state': False
     }
 
-    def test_initial(self):
-        self.first_play_test(C)
-
     def test_strategy(self):
-        """
-        If opponent defects more than once, defect forever
-        """
-        self.responses_test([C], [D], [C])
-        self.responses_test([C, C], [D, D], [D])
-        self.responses_test([C, C], [D, C], [C])
-        self.responses_test([C, C, C], [D, D, D], [D])
+        # Start by cooperating.
+        self.first_play_test(C)
+        # If opponent defects more than once, defect forever.
+        self.responses_test(C, C, D)
+        self.responses_test(D, C + C, D + D)
+        self.responses_test(C, C + C, D + C)
+        self.responses_test(D, C * 3, D * 3)
 
 
 class TestForgetfulFoolMeOnce(TestPlayer):
@@ -98,17 +92,15 @@ class TestForgetfulFoolMeOnce(TestPlayer):
         'manipulates_state': False
     }
 
-    def test_initial(self):
-        self.first_play_test(C)
-
     def test_strategy(self):
-        """Test that will forgive one D but will grudge after 2 Ds, randomly
-        forgets count"""
+        self.first_play_test(C)
+        # Test that will forgive one D but will grudge after 2 Ds, randomly
+        # forgets count
         random.seed(2)
-        self.responses_test([C], [D], [C])
-        self.responses_test([C, C], [D, D], [D])
+        self.responses_test(C, C, D)
+        self.responses_test(D, C + C, D + D)
         # Sometime eventually forget count:
-        self.responses_test([C, C], [D, D], [D] * 18 + [C],
+        self.responses_test(D * 18 + C, C + C, D + D,
                             attrs={"D_count": 0}, random_seed=2)
 
     def test_reset(self):
@@ -122,7 +114,7 @@ class TestForgetfulFoolMeOnce(TestPlayer):
         self.assertEqual(P1.D_count, 1)
         P1.reset()
         self.assertEqual(P1.D_count, 0)
-        self.assertEqual(P1.history, [])
+        self.assertEqual(len(P1.history), 0)
 
 
 class TestFoolMeForever(TestPlayer):
@@ -140,11 +132,9 @@ class TestFoolMeForever(TestPlayer):
     }
 
     def test_strategy(self):
-        """
-        If opponent defects more than once, defect forever
-        """
-        self.responses_test([], [], [D])
-        self.responses_test([D], [D], [C])
-        self.responses_test([D], [C], [D])
-        self.responses_test([D, C], [D, C], [C])
-        self.responses_test([D, C, C], [D, C, C], [C])
+        # If opponent defects more than once, defect forever.
+        self.responses_test(D)
+        self.responses_test(C, D, D)
+        self.responses_test(D, D, C)
+        self.responses_test(C, D + C, D + C)
+        self.responses_test(C, D + C + C, D + C + C)

--- a/axelrod/tests/unit/test_player.py
+++ b/axelrod/tests/unit/test_player.py
@@ -11,10 +11,8 @@ C, D = axelrod.Actions.C, axelrod.Actions.D
 def cooperate(self):
     return C
 
-
 def defect(self):
     return D
-
 
 def randomize(self):
     return random.choice([C, D])
@@ -73,14 +71,13 @@ class TestPlayerClass(unittest.TestCase):
 
     def test_state_distribution(self):
         p1, p2 = self.player(), self.player()
-        history_1 = [C, C, D, D, C]
-        history_2 = [C, D, C, D, D]
         p1.strategy = randomize
         p2.strategy = randomize
-        simulate_play(p1, p2, history_1, history_2)
-        self.assertEqual(p1.state_distribution,
+        for h1, h2 in zip([C, C, D, D, C], [C, D, C, D, D]):
+            simulate_play(p1, p2, h1, h2)
+        self.assertEqual(dict(p1.state_distribution),
                          {(C, C): 1, (C, D): 2, (D, C): 1, (D, D): 1})
-        self.assertEqual(p2.state_distribution,
+        self.assertEqual(dict(p2.state_distribution),
                          {(C, C): 1, (C, D): 1, (D, C): 2, (D, D): 1})
 
     def test_noisy_play(self):

--- a/axelrod/tests/unit/test_player.py
+++ b/axelrod/tests/unit/test_player.py
@@ -18,7 +18,6 @@ def randomize(self):
     return random.choice([C, D])
 
 
-
 class TestPlayerClass(unittest.TestCase):
 
     name = "Player"
@@ -41,54 +40,54 @@ class TestPlayerClass(unittest.TestCase):
         self.assertEqual(noisy_s2, D)
 
     def test_play(self):
-        p1, p2 = self.player(), self.player()
-        p1.strategy = cooperate
-        p2.strategy = defect
-        p1.play(p2)
-        self.assertEqual(p1.history[0], C)
-        self.assertEqual(p2.history[0], D)
+        player1, player2 = self.player(), self.player()
+        player1.strategy = cooperate
+        player2.strategy = defect
+        player1.play(player2)
+        self.assertEqual(player1.history[0], C)
+        self.assertEqual(player2.history[0], D)
 
         # Test cooperation / defection counts
-        self.assertEqual(p1.cooperations, 1)
-        self.assertEqual(p1.defections, 0)
-        self.assertEqual(p2.cooperations, 0)
-        self.assertEqual(p2.defections, 1)
+        self.assertEqual(player1.cooperations, 1)
+        self.assertEqual(player1.defections, 0)
+        self.assertEqual(player2.cooperations, 0)
+        self.assertEqual(player2.defections, 1)
         # Test state distribution
-        self.assertEqual(p1.state_distribution, {(C, D): 1})
-        self.assertEqual(p2.state_distribution, {(D, C): 1})
+        self.assertEqual(player1.state_distribution, {(C, D): 1})
+        self.assertEqual(player2.state_distribution, {(D, C): 1})
 
-        p1.play(p2)
-        self.assertEqual(p1.history[-1], C)
-        self.assertEqual(p2.history[-1], D)
+        player1.play(player2)
+        self.assertEqual(player1.history[-1], C)
+        self.assertEqual(player2.history[-1], D)
         # Test cooperation / defection counts
-        self.assertEqual(p1.cooperations, 2)
-        self.assertEqual(p1.defections, 0)
-        self.assertEqual(p2.cooperations, 0)
-        self.assertEqual(p2.defections, 2)
+        self.assertEqual(player1.cooperations, 2)
+        self.assertEqual(player1.defections, 0)
+        self.assertEqual(player2.cooperations, 0)
+        self.assertEqual(player2.defections, 2)
         # Test state distribution
-        self.assertEqual(p1.state_distribution, {(C, D): 2})
-        self.assertEqual(p2.state_distribution, {(D, C): 2})
+        self.assertEqual(player1.state_distribution, {(C, D): 2})
+        self.assertEqual(player2.state_distribution, {(D, C): 2})
 
     def test_state_distribution(self):
-        p1, p2 = self.player(), self.player()
-        p1.strategy = randomize
-        p2.strategy = randomize
+        player1, player2 = self.player(), self.player()
+        player1.strategy = randomize
+        player2.strategy = randomize
         for h1, h2 in zip([C, C, D, D, C], [C, D, C, D, D]):
-            simulate_play(p1, p2, h1, h2)
-        self.assertEqual(dict(p1.state_distribution),
+            simulate_play(player1, player2, h1, h2)
+        self.assertEqual(dict(player1.state_distribution),
                          {(C, C): 1, (C, D): 2, (D, C): 1, (D, D): 1})
-        self.assertEqual(dict(p2.state_distribution),
+        self.assertEqual(dict(player2.state_distribution),
                          {(C, C): 1, (C, D): 1, (D, C): 2, (D, D): 1})
 
     def test_noisy_play(self):
         random.seed(1)
         noise = 0.2
-        p1, p2 = self.player(), self.player()
-        p1.strategy = cooperate
-        p2.strategy = defect
-        p1.play(p2, noise)
-        self.assertEqual(p1.history[0], D)
-        self.assertEqual(p2.history[0], D)
+        player1, player2 = self.player(), self.player()
+        player1.strategy = cooperate
+        player2.strategy = defect
+        player1.play(player2, noise)
+        self.assertEqual(player1.history[0], D)
+        self.assertEqual(player2.history[0], D)
 
     def test_strategy(self):
         self.assertRaises(
@@ -96,47 +95,49 @@ class TestPlayerClass(unittest.TestCase):
 
     def test_clone(self):
         """Tests player cloning."""
-        p1 = axelrod.Random(0.75)  # 0.5 is the default
-        p2 = p1.clone()
+        player1 = axelrod.Random(0.75)  # 0.5 is the default
+        player2 = player1.clone()
         turns = 50
         for op in [axelrod.Cooperator(), axelrod.Defector(),
                    axelrod.TitForTat()]:
-            p1.reset()
-            p2.reset()
+            player1.reset()
+            player2.reset()
             seed = random.randint(0, 10 ** 6)
-            for p in [p1, p2]:
+            for p in [player1, player2]:
                 axelrod.seed(seed)
                 m = axelrod.Match((p, op), turns=turns)
                 m.play()
-            self.assertEqual(len(p1.history), turns)
-            self.assertEqual(p1.history, p2.history)
+            self.assertEqual(len(player1.history), turns)
+            self.assertEqual(player1.history, player2.history)
 
 
-def test_responses(test_class, P1, P2, history_1, history_2, responses,
-                   random_seed=None, attrs=None):
+def test_responses(test_class, player1, player2, responses, history1=None,
+                   history2=None, random_seed=None, attrs=None):
     """
     Test responses to arbitrary histories. Used for the following tests
-    in TestPlayer: first_play_test, markov_test, and responses_test.
+    in TestPlayer: first_play_test, second_play_test, and responses_test.
     Works for arbitrary players as well. Input response_lists is a list of
     lists, each of which consists of a list for the history of player 1, a
     list for the history of player 2, and a list for the subsequent moves
     by player one to test.
     """
 
-    if random_seed:
-        axelrod.seed(random_seed)
+    if random_seed is None:
+        random_seed = 0
+    axelrod.seed(random_seed)
     # Force the histories, In case either history is impossible or if some
     # internal state needs to be set, actually submit to moves to the strategy
     # method. Still need to append history manually.
-    for h1, h2 in zip(history_1, history_2):
-        simulate_play(P1, P2, h1, h2)
+    if history1 and history2:
+        for h1, h2 in zip(history1, history2):
+            simulate_play(player1, player2, h1, h2)
     # Run the tests
     for response in responses:
-        s1, s2 = simulate_play(P1, P2)
+        s1, s2 = simulate_play(player1, player2)
         test_class.assertEqual(s1, response)
     if attrs:
         for attr, value in attrs.items():
-            test_class.assertEqual(getattr(P1, attr), value)
+            test_class.assertEqual(getattr(player1, attr), value)
 
 
 class TestOpponent(Player):
@@ -154,7 +155,7 @@ class TestOpponent(Player):
 
     @staticmethod
     def strategy(opponent):
-        return 'C'
+        return C
 
 
 class TestPlayer(unittest.TestCase):
@@ -201,100 +202,124 @@ class TestPlayer(unittest.TestCase):
         self.assertEqual(t_attrs['noise'], .5)
 
     def test_reset(self):
-        """Make sure resetting works correctly."""
+        """Override to make sure any internal variables are reset."""
+
+    def test_reset_history(self):
+        """Make sure history resetting works correctly, regardless
+        if self.test_reset() is overwritten."""
         p = self.player()
-        p_clone = p.clone()
-        p2 = axelrod.Random()
+        player2 = axelrod.Cooperator()
         for _ in range(10):
-            p.play(p2)
+            p.play(player2)
         p.reset()
-        self.assertEqual(p.history, [])
+        self.assertEqual(len(p.history), 0)
         self.assertEqual(self.player().cooperations, 0)
         self.assertEqual(self.player().defections, 0)
-        self.assertEqual(self.player().state_distribution, {})
+        self.assertEqual(self.player().state_distribution, dict())
 
-        for k, v in p_clone.__dict__.items():
-            self.assertEqual(v, getattr(p_clone, k))
+    def test_reset_clone(self):
+        """Make sure history resetting with cloning works correctly, regardless
+        if self.test_reset() is overwritten."""
+        player = self.player()
+        clone = player.clone()
+
+        for k, v in clone.__dict__.items():
+            self.assertEqual(v, getattr(clone, k))
 
     def test_clone(self):
         # Test that the cloned player produces identical play
-        p1 = self.player()
-        if str(p1) in ["Darwin", "Human"]:
+        player1 = self.player()
+        if str(player1) in ["Darwin", "Human"]:
             # Known exceptions
             return
-        p2 = p1.clone()
-        self.assertEqual(len(p2.history), 0)
-        self.assertEqual(p2.cooperations, 0)
-        self.assertEqual(p2.defections, 0)
-        self.assertEqual(p2.state_distribution, {})
-        self.assertEqual(p2.classifier, p1.classifier)
-        self.assertEqual(p2.match_attributes, p1.match_attributes)
+        player2 = player1.clone()
+        self.assertEqual(len(player2.history), 0)
+        self.assertEqual(player2.cooperations, 0)
+        self.assertEqual(player2.defections, 0)
+        self.assertEqual(player2.state_distribution, {})
+        self.assertEqual(player2.classifier, player1.classifier)
+        self.assertEqual(player2.match_attributes, player1.match_attributes)
 
         turns = 50
         r = random.random()
         for op in [axelrod.Cooperator(), axelrod.Defector(),
                    axelrod.TitForTat(), axelrod.Random(r)]:
-            p1.reset()
-            p2.reset()
+            player1.reset()
+            player2.reset()
             seed = random.randint(0, 10 ** 6)
-            for p in [p1, p2]:
+            for p in [player1, player2]:
                 axelrod.seed(seed)
                 m = axelrod.Match((p, op), turns=turns)
                 m.play()
-            self.assertEqual(len(p1.history), turns)
-            self.assertEqual(p1.history, p2.history)
+            self.assertEqual(len(player1.history), turns)
+            self.assertEqual(player1.history, player2.history)
 
     def first_play_test(self, play, random_seed=None):
         """Tests first move of a strategy."""
-        P1 = self.player()
-        P2 = TestOpponent()
-        test_responses(
-            self, P1, P2, [], [], [play],
-            random_seed=random_seed)
+        player1 = self.player()
+        player2 = TestOpponent()
+        test_responses(self, player1, player2, play, random_seed=random_seed)
 
-    def markov_test(self, responses, random_seed=None):
+    def second_play_test(self, *responses, random_seed=None):
         """Test responses to the four possible one round histories. Input
         responses is simply the four responses to CC, CD, DC, and DD."""
         # Construct the test lists
-        histories = [
-            [[C], [C]], [[C], [D]], [[D], [C]],
-            [[D], [D]]]
+        histories = [[C, C], [C, D], [D, C], [D, D]]
         for i, history in enumerate(histories):
             # Needs to be in the inner loop in case player retains some state
-            P1 = self.player()
-            P2 = TestOpponent()
-            test_responses(self, P1, P2, history[0], history[1], responses[i],
-                           random_seed=random_seed)
+            player1 = self.player()
+            player2 = TestOpponent()
+            test_responses(self, player1, player2, responses[i], history[0],
+                           history[1], random_seed=random_seed)
 
-    def responses_test(self, history_1, history_2, responses, random_seed=None,
-                       tournament_length=200, attrs=None):
-        """Test responses to arbitrary histories. Input response_list is a
-        list of lists, each of which consists of a list for the history of
-        player 1, a list for the history of player 2, and a list for the
-        subsequent moves by player one to test.
+    def responses_test(self, responses, history1=None, history2=None,
+                       random_seed=None, tournament_length=200, attrs=None,
+                       init_args=(), init_kwargs=None):
+        """Test responses to arbitrary histories. A match is played where the
+        histories are enforced and the sequence of plays in responses is
+        checked to be the outcome. Internal variables can be checked with the
+        attrs attribute and arguments to the first player can be passed in
+        init_args.
+
+        Parameters
+        ----------
+        responses: History or sequence of axelrod.Actions
+            The expected outcomes
+        history1, history2: sequences of prior history to enforce
+        random_seed: int
+            A random seed if needed for reproducibility
+        tournament_length: int
+            Some players require the length of the match
+        attrs: dict
+            dictionary of internal attributes to check at the end of all plays
+            in player
+        init_args: tuple or list
+            A list of arguments to instantiate player with
+        init_kwargs: dictionary
+            A list of keyword arguments to instantiate player with
         """
-        P1 = self.player()
-        P1.match_attributes['length'] = tournament_length
-        P2 = TestOpponent()
-        P2.match_attributes['length'] = tournament_length
+        if init_kwargs is None:
+            init_kwargs = dict()
+        player1 = self.player(*init_args, **init_kwargs)
+        player1.match_attributes['length'] = tournament_length
+        player2 = TestOpponent()
+        player2.match_attributes['length'] = tournament_length
         test_responses(
-            self, P1, P2, history_1, history_2, responses,
+            self, player1, player2, responses, history1, history2,
             random_seed=random_seed, attrs=attrs)
 
         # Test that we get the same sequence after a reset
-        P1.reset()
-        P2 = TestOpponent()
-        P2.match_attributes['length'] = tournament_length
+        player1.reset()
+        player2.reset()
         test_responses(
-            self, P1, P2, history_1, history_2, responses,
+            self, player1, player2, responses, history1, history2,
             random_seed=random_seed, attrs=attrs)
 
         # Test that we get the same sequence after a clone
-        P1 = P1.clone()
-        P2 = TestOpponent()
-        P2.match_attributes['length'] = tournament_length
+        player1 = player1.clone()
+        player2 = player2.clone()
         test_responses(
-            self, P1, P2, history_1, history_2, responses,
+            self, player1, player2, responses, history1, history2,
             random_seed=random_seed, attrs=attrs)
 
     def classifier_test(self, expected_class_classifier=None):
@@ -342,7 +367,7 @@ def test_four_vector(test_class, expected_dictionary):
     Checks that two dictionaries match -- the four-vector defining
     a memory-one strategy and the given expected dictionary.
     """
-    P1 = test_class.player()
+    player1 = test_class.player()
     for key in sorted(expected_dictionary.keys()):
         test_class.assertAlmostEqual(
-            P1._four_vector[key], expected_dictionary[key])
+            player1._four_vector[key], expected_dictionary[key])

--- a/axelrod/tests/unit/test_prober.py
+++ b/axelrod/tests/unit/test_prober.py
@@ -1,8 +1,6 @@
 """Tests for prober strategies."""
 
 import axelrod
-import random
-
 from .test_player import TestPlayer, test_responses
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
@@ -24,16 +22,16 @@ class TestCollectiveStrategy(TestPlayer):
 
     def test_initial_strategy(self):
         """Starts by playing CD."""
-        self.responses_test([], [], [C, D])
+        self.responses_test(C + D)
 
     def test_strategy(self):
         # Defects forever unless opponent matched first two moves
-        self.responses_test([C, D], [C, C], [D] * 10)
-        self.responses_test([C, D], [D, C], [D] * 10)
-        self.responses_test([C, D], [D, D], [D] * 10)
+        self.responses_test(D * 10, C + D, C + C)
+        self.responses_test(D * 10, C + D, D + C)
+        self.responses_test(D * 10, C + D, D + D)
 
-        self.responses_test([C, D], [C, D], [C] * 10)
-        self.responses_test([C, D, D], [C, D, D], [D] * 10)
+        self.responses_test(C * 10, C + D, C + D)
+        self.responses_test(D * 10, C + D + D, C + D + D)
 
 
 class TestProber(TestPlayer):
@@ -50,20 +48,18 @@ class TestProber(TestPlayer):
         'manipulates_state': False
     }
 
-    def test_initial_strategy(self):
-        """Starts by playing DCC."""
-        self.responses_test([], [], [D, C, C])
-
     def test_strategy(self):
+        # Starts by playing DCC.
+        self.responses_test(D + C + C)
         # Defects forever if opponent cooperated in moves 2 and 3
-        self.responses_test([D, C, C], [C, C, C], [D] * 10)
-        self.responses_test([D, C, C], [D, C, C], [D] * 10)
+        self.responses_test(D * 10, D + C + C, C * 3)
+        self.responses_test(D * 10, D + C + C, D + C + C)
 
         # Otherwise it plays like TFT
-        self.responses_test([D, C, C], [C, D, C], [C])
-        self.responses_test([D, C, C], [C, D, D], [D])
-        self.responses_test([D, C, C, C], [C, D, C, D], [D])
-        self.responses_test([D, C, C, D], [C, D, D], [D])
+        self.responses_test(C, [D, C, C], [C, D, C])
+        self.responses_test(D, [D, C, C], [C, D, D])
+        self.responses_test(D, [D, C, C, C], [C, D, C, D])
+        self.responses_test(D, [D, C, C, D], [C, D, D])
 
 
 class TestProber2(TestPlayer):
@@ -80,20 +76,19 @@ class TestProber2(TestPlayer):
         'manipulates_state': False
     }
 
-    def test_initial_strategy(self):
-        """Starts by playing DCC."""
-        self.responses_test([], [], [D, C, C])
-
     def test_strategy(self):
+        # Starts by playing DCC.
+        self.responses_test(D + C + C)
+
         # Cooperates forever if opponent played D, C in moves 2 and 3
-        self.responses_test([D, C, C], [C, D, C], [C] * 10)
-        self.responses_test([D, C, C], [D, D, C], [C] * 10)
+        self.responses_test(C * 10, [D, C, C], [C, D, C])
+        self.responses_test(C * 10, [D, C, C], [D, D, C])
 
         # Otherwise it plays like TFT
-        self.responses_test([D, C, C], [C, C, C], [C])
-        self.responses_test([D, C, C], [C, D, D], [D])
-        self.responses_test([D, C, C, D], [C, D, D, D], [D])
-        self.responses_test([D, C, C, D], [C, D, D, C], [C])
+        self.responses_test(C, [D, C, C], [C, C, C])
+        self.responses_test(D, [D, C, C], [C, D, D])
+        self.responses_test(D, [D, C, C, D], [C, D, D, D])
+        self.responses_test(C, [D, C, C, D], [C, D, D, C])
 
 
 class TestProber3(TestPlayer):
@@ -110,21 +105,20 @@ class TestProber3(TestPlayer):
         'manipulates_state': False
     }
 
-    def test_initial_strategy(self):
-        """Starts by playing DC."""
-        self.responses_test([], [], [D, C])
-
     def test_strategy(self):
+        # Starts by playing DC.
+        self.responses_test(D + C)
+
         # Defects forever if opponent played C in move 2
         self.responses_test([D, C], [C, C], [D] * 10)
         self.responses_test([D, C], [D, C], [D] * 10)
 
         # Otherwise it plays like TFT
-        self.responses_test([D, C, C], [C, D], [D])
-        self.responses_test([D, C, C], [D, D], [D])
-        self.responses_test([D, C, C, D], [C, D, C], [C])
-        self.responses_test([D, C, C, D], [D, D, D], [D])
-        self.responses_test([D, C, C, D, C], [C, D, C, C], [C])
+        self.responses_test(D, [D, C, C], [C, D])
+        self.responses_test(D, [D, C, C], [D, D])
+        self.responses_test(C, [D, C, C, D], [C, D, C])
+        self.responses_test(D, [D, C, C, D], [D, D, D])
+        self.responses_test(C, [D, C, C, D, C], [C, D, C, C])
 
 
 class TestProber4(TestPlayer):
@@ -144,11 +138,10 @@ class TestProber4(TestPlayer):
         C, C, D, C, D, D, D, C, C, D, C, D, C, C, D, C, D, D, C, D
     ]
 
-    def test_initial_strategy(self):
-        """Starts by playing CCDCDDDCCDCDCCDCDDCD."""
-        self.responses_test([], [], self.initial_sequence)
-
     def test_strategy(self):
+        # Starts by playing CCDCDDDCCDCDCCDCDDCD.
+        self.responses_test(self.initial_sequence)
+
         # After playing the initial sequence defects forever
         # if the absolute difference in the number of retaliating
         # and provocative defections of the opponent is smaller or equal to 2
@@ -163,10 +156,10 @@ class TestProber4(TestPlayer):
         ]
 
         history1 = self.initial_sequence
-        responses = [D] * 10
+        responses = D * 10
         attrs = {'turned_defector': True}
         for history2 in provocative_histories:
-            self.responses_test(history1, history2, responses, attrs=attrs)
+            self.responses_test(responses, history1, history2, attrs=attrs)
 
         # Otherwise cooperates for 5 rounds
         unprovocative_histories = [
@@ -180,24 +173,24 @@ class TestProber4(TestPlayer):
         responses = [C] * 5
         attrs = {'turned_defector': False}
         for history2 in unprovocative_histories:
-            self.responses_test(history1, history2, responses, attrs=attrs)
+            self.responses_test(responses, history1, history2, attrs=attrs)
 
         # and plays like TFT afterwards
             history1 += responses
             history2 += responses
-            self.responses_test(history1, history2, [C], attrs=attrs)
+            self.responses_test(C, history1, history2, attrs=attrs)
 
-            history1 += [C]
-            history2 += [D]
-            self.responses_test(history1, history2, [D], attrs=attrs)
+            history1 += C
+            history2 += D
+            self.responses_test(D, history1, history2, attrs=attrs)
 
-            history1 += [D]
-            history2 += [C]
-            self.responses_test(history1, history2, [C], attrs=attrs)
+            history1 += D
+            history2 += C
+            self.responses_test(C, history1, history2, attrs=attrs)
 
-            history1 += [C]
-            history2 += [D]
-            self.responses_test(history1, history2, [D], attrs=attrs)
+            history1 += C
+            history2 += D
+            self.responses_test(D, history1, history2, attrs=attrs)
 
 
 class TestHardProber(TestPlayer):
@@ -214,24 +207,23 @@ class TestHardProber(TestPlayer):
         'manipulates_state': False
     }
 
-    def test_initial_strategy(self):
-        """Starts by playing DC."""
-        self.responses_test([], [], [D, D, C, C])
-
     def test_strategy(self):
+        # Starts by playing D C C C."""
+        self.responses_test(D + D + C + C)
+
         # Cooperates forever if opponent played C in moves 2 and 3
-        self.responses_test([D, D, C, C], [C, C, C, C], [D] * 10)
-        self.responses_test([D, D, C, C], [C, C, C, D], [D] * 10)
-        self.responses_test([D, D, C, C], [D, C, C, C], [D] * 10)
-        self.responses_test([D, D, C, C], [D, C, C, D], [D] * 10)
+        self.responses_test(D * 10, [D, D, C, C], [C, C, C, C])
+        self.responses_test(D * 10, [D, D, C, C], [C, C, C, D])
+        self.responses_test(D * 10, [D, D, C, C], [D, C, C, C])
+        self.responses_test(D * 10, [D, D, C, C], [D, C, C, D])
 
         # Otherwise it plays like TFT
-        self.responses_test([D, D, C, C], [C, C, D, C], [C, C])
-        self.responses_test([D, D, C, C], [C, C, D, D], [D])
-        self.responses_test([D, D, C, C], [D, D, C, C], [C, C])
-        self.responses_test([D, D, C, C], [D, D, C, D], [D])
-        self.responses_test([D, D, C, C, D], [C, C, D, D], [D])
-        self.responses_test([D, D, C, C, D], [D, D, C, C], [C])
+        self.responses_test(C + C, [D, D, C, C], [C, C, D, C])
+        self.responses_test(D, [D, D, C, C], [C, C, D, D])
+        self.responses_test(C + C, [D, D, C, C], [D, D, C, C])
+        self.responses_test(D, [D, D, C, C], [D, D, C, D])
+        self.responses_test(D, [D, D, C, C, D], [C, C, D, D])
+        self.responses_test(C, [D, D, C, C, D], [D, D, C, C])
 
 
 class TestNaiveProber(TestPlayer):
@@ -249,24 +241,22 @@ class TestNaiveProber(TestPlayer):
     }
 
     def test_strategy(self):
-        "Randomly defects and always retaliates like tit for tat."
+        """Randomly defects and always retaliates like tit for tat."""
         self.first_play_test(C)
         # Always retaliate a defection
-        self.responses_test([C] * 2, [C, D], [D])
+        self.responses_test(D, C + C, C + D)
 
-    def test_random_defection(self):
         # Random defection
         player = self.player(0.4)
         opponent = axelrod.Random()
-        test_responses(self, player, opponent, [C], [C], [D], random_seed=1)
+        test_responses(self, player, opponent, D, C, C, random_seed=1)
 
-    def test_reduction_to_TFT(self):
         player = self.player(0)
         opponent = axelrod.Random()
-        test_responses(self, player, opponent, [C], [C], [C], random_seed=1)
-        test_responses(self, player, opponent, [C], [D], [D])
-        test_responses(self, player, opponent, [C, D], [D, C], [C])
-        test_responses(self, player, opponent, [C, D], [D, D], [D])
+        test_responses(self, player, opponent, C, C, C, random_seed=1)
+        test_responses(self, player, opponent, D, C, D)
+        test_responses(self, player, opponent, C, C + D, D + C)
+        test_responses(self, player, opponent, D, C + D, D + D)
 
 
 class TestRemorsefulProber(TestPlayer):
@@ -287,49 +277,42 @@ class TestRemorsefulProber(TestPlayer):
         """Randomly defects (probes) and always retaliates like tit for tat."""
         self.first_play_test(C)
 
-        player = self.player(0.4)
-        opponent = axelrod.Random()
-        player.history = [C, C]
-        opponent.history = [C, D]
-        self.assertEqual(player.strategy(opponent), D)
+        # Test retaliation
+        self.responses_test(C, C, C, random_seed=1)
+        self.responses_test(D, C + C, C + D)
+        self.responses_test(C, C + C + D, C + D + C)
+
+        # Test Random defection
+        self.responses_test(D, C, C, init_kwargs={'p': 0.4}, random_seed=5)
+        self.responses_test(C, C, C, init_kwargs={'p': 0.1}, random_seed=5)
 
     def test_remorse(self):
         """After probing, if opponent retaliates, will offer a C."""
-        player = self.player(0.4)
-        opponent = axelrod.Cooperator()
 
-        test_responses(self, player, opponent, [C], [C], [C],
-                       random_seed=0, attrs={'probing': False})
+        self.responses_test(C, C, C, init_kwargs={'p': 0.4}, random_seed=4,
+                            attrs={'probing': False})
 
-        test_responses(self, player, opponent, [C], [C], [D],
-                       random_seed=1, attrs={'probing': True})
+        self.responses_test(D, C, C, init_kwargs={'p': 0.4}, random_seed=5,
+                            attrs={'probing': True})
 
-        test_responses(self, player, opponent, [C, D], [C, D], [D],
-                       attrs={'probing': False})
+        self.responses_test(C, C + D, C + D, init_kwargs={'p': 0.4},
+                            random_seed=5, attrs={'probing': False})
 
-        test_responses(self, player, opponent, [C, D, C], [C, D, D], [D],
-                       attrs={'probing': False})
+        self.responses_test(D, C + D + C, C + D + D, init_kwargs={'p': 0.4},
+                            random_seed=5, attrs={'probing': False})
 
     def test_reduction_to_TFT(self):
-        player = self.player(0)
-        opponent = axelrod.Random()
-        test_responses(self, player, opponent, [C], [C], [C], random_seed=1,
-                       attrs={'probing': False})
-        test_responses(self, player, opponent, [C], [D], [D],
-                       attrs={'probing': False})
-        test_responses(self, player, opponent, [C, D], [D, C], [C],
-                       attrs={'probing': False})
-        test_responses(self, player, opponent, [C, D], [D, D], [D],
-                       attrs={'probing': False})
+        self.responses_test(C, init_kwargs={'p': 0},
+                            attrs={'probing': False})
+        self.responses_test(C, C, C, init_kwargs={'p': 0},
+                            attrs={'probing': False})
+        self.responses_test(D, C, D, init_kwargs={'p': 0},
+                            attrs={'probing': False})
+        self.responses_test(D, C + C, C + D, init_kwargs={'p': 0},
+                            attrs={'probing': False})
 
-    def test_reset_probing(self):
-        player = self.player(0.4)
+    def test_reset(self):
+        player = self.player()
         player.probing = True
         player.reset()
         self.assertFalse(player.probing)
-
-    def test_random_defection(self):
-        # Random defection
-        player = self.player(0.4)
-        opponent = axelrod.Random()
-        test_responses(self, player, opponent, [C], [C], [D], random_seed=1)

--- a/axelrod/tests/unit/test_property.py
+++ b/axelrod/tests/unit/test_property.py
@@ -1,13 +1,10 @@
-from __future__ import absolute_import
 import unittest
-import axelrod
-from axelrod.tests.property import (strategy_lists,
-                                    matches, tournaments,
-                                    prob_end_tournaments, spatial_tournaments,
-                                    prob_end_spatial_tournaments,
-                                    games)
-
 from hypothesis import given, settings
+import axelrod
+from axelrod.tests.property import (
+    strategy_lists, matches, tournaments, prob_end_tournaments,
+    spatial_tournaments, prob_end_spatial_tournaments, games)
+
 
 stochastic_strategies = [s for s in axelrod.strategies if
                          s().classifier['stochastic']]

--- a/axelrod/tests/unit/test_punisher.py
+++ b/axelrod/tests/unit/test_punisher.py
@@ -1,4 +1,4 @@
-"""Test for the punisher strategy."""
+"""Tests for the punisher strategy."""
 
 import axelrod
 from .test_player import TestPlayer
@@ -23,38 +23,36 @@ class TestPunisher(TestPlayer):
     def test_init(self):
         """Tests for the __init__ method."""
         P1 = axelrod.Punisher()
-        self.assertEqual(P1.history, [])
+        self.assertEqual(len(P1.history), 0)
         self.assertEqual(P1.mem_length, 1)
         self.assertEqual(P1.grudged, False)
         self.assertEqual(P1.grudge_memory, 1)
 
     def test_strategy(self):
-        self.responses_test([], [], [C], attrs={"grudged": False})
-        self.responses_test([C], [C], [C], attrs={"grudged": False})
-        self.responses_test([C], [D], [D], attrs={"grudged": True})
+        self.responses_test(C, attrs={"grudged": False})
+        self.responses_test(C, C, C, attrs={"grudged": False})
+        self.responses_test(D, C, D, attrs={"grudged": True})
         for i in range(10):
-            self.responses_test([C, C] + [D] * i, [C, D] + [C] * i, [D],
+            self.responses_test(D, C + C + D * i, C + D + C * i,
                                 attrs={"grudged": True, "grudge_memory": i,
                                        "mem_length": 10})
         # Eventually the grudge is dropped
         i = 11
-        self.responses_test([C, C] + [D] * i, [C, D] + [C] * i, [C],
+        self.responses_test(C, C * 2 + D * i, C + D + C * i,
                             attrs={"grudged": False, "grudge_memory": 0,
                                     "mem_length": 10})
 
         # Grudged again on opponent's D
-        self.responses_test([C, C] + [D] * i + [C], [C, D] + [C] * i + [D], [D],
+        self.responses_test(D, C + C + D * i + C, C + D + C * i + D,
                             attrs={"grudged": True, "grudge_memory": 0,
                                    "mem_length": 2})
 
     def test_reset_method(self):
         """Tests the reset method."""
         P1 = axelrod.Punisher()
-        P1.history = [C, D, D, D]
         P1.grudged = True
         P1.grudge_memory = 4
         P1.reset()
-        self.assertEqual(P1.history, [])
         self.assertEqual(P1.grudged, False)
         self.assertEqual(P1.grudge_memory, 0)
 
@@ -76,40 +74,37 @@ class TestInversePunisher(TestPlayer):
     def test_init(self):
         """Tests for the __init__ method."""
         P1 = axelrod.InversePunisher()
-        self.assertEqual(P1.history, [])
+        self.assertEqual(len(P1.history), 0)
         self.assertEqual(P1.mem_length, 1)
         self.assertEqual(P1.grudged, False)
         self.assertEqual(P1.grudge_memory, 1)
 
     def test_strategy(self):
-        self.responses_test([], [], [C], attrs={"grudged": False})
-        self.responses_test([C], [C], [C], attrs={"grudged": False})
-        self.responses_test([C], [D], [D], attrs={"grudged": True})
+        self.responses_test(C, attrs={"grudged": False})
+        self.responses_test(C, C, C, attrs={"grudged": False})
+        self.responses_test(D, C, D, attrs={"grudged": True})
         for i in range(10):
-            self.responses_test([C, C] + [D] * i, [C, D] + [C] * i, [D],
+            self.responses_test(D, C + C + D * i, C + D + C * i,
                                 attrs={"grudged": True, "grudge_memory": i,
                                        "mem_length": 10})
         # Eventually the grudge is dropped
         i = 11
-        self.responses_test([C, C] + [D] * i, [C, D] + [C] * i, [C],
+        self.responses_test(C, C + C + D * i, C + D + C * i,
                             attrs={"grudged": False, "grudge_memory": 0,
-                                    "mem_length": 10})
+                                   "mem_length": 10})
         # Grudged again on opponent's D
-        self.responses_test([C, C] + [D] * i + [C], [C, D] + [C] * i + [D], [D],
+        self.responses_test(D, C + C + D * i + C, C + D + C * i + D,
                             attrs={"grudged": True, "grudge_memory": 0,
                                    "mem_length": 17})
-
         # Test a different grudge length period
-        self.responses_test([C] * 5, [C] * 4 + [D],
-                            [D], attrs={"grudged": True, "grudge_memory": 0,
-                                        "mem_length": 16})
+        self.responses_test(D, C * 5, C * 4 + D,
+                            attrs={"grudged": True, "grudge_memory": 0,
+                                   "mem_length": 16})
 
     def test_reset_method(self):
         P1 = axelrod.InversePunisher()
-        P1.history = [C, D, D, D]
         P1.grudged = True
         P1.grudge_memory = 4
         P1.reset()
-        self.assertEqual(P1.history, [])
         self.assertEqual(P1.grudged, False)
         self.assertEqual(P1.grudge_memory, 0)

--- a/axelrod/tests/unit/test_qlearner.py
+++ b/axelrod/tests/unit/test_qlearner.py
@@ -1,4 +1,4 @@
-"""Test for the qlearner strategy."""
+"""Tests for the qlearner strategy."""
 
 import random
 
@@ -38,7 +38,8 @@ class TestRiskyQLearner(TestPlayer):
         simulate_play(p1, p2)
         self.assertEqual(p1.Qs, {'': {C: 0, D: 0.9}, '0.0': {C: 0, D: 0}})
         simulate_play(p1, p2)
-        self.assertEqual(p1.Qs,{'': {C: 0, D: 0.9}, '0.0': {C: 2.7, D: 0}, 'C1.0': {C: 0, D: 0}})
+        self.assertEqual(p1.Qs, {'': {C: 0, D: 0.9}, '0.0': {C: 2.7, D: 0},
+                                 'C1.0': {C: 0, D: 0}})
 
     def test_vs_update(self):
         """Test that the q and v values update."""
@@ -76,11 +77,9 @@ class TestRiskyQLearner(TestPlayer):
         P1 = axelrod.RiskyQLearner()
         P1.Qs = {'': {C: 0, D: -0.9}, '0.0': {C: 0, D: 0}}
         P1.Vs = {'': 0, '0.0': 0}
-        P1.history = [C, D, D, D]
         P1.prev_state = C
         P1.reset()
         self.assertEqual(P1.prev_state, '')
-        self.assertEqual(P1.history, [])
         self.assertEqual(P1.Vs, {'': 0})
         self.assertEqual(P1.Qs, {'': {C: 0, D: 0}})
 
@@ -109,7 +108,8 @@ class TestArrogantQLearner(TestPlayer):
         play_1, play_2 = simulate_play(p1, p2)
         self.assertEqual(p1.Qs, {'': {C: 0, D: 0.9}, '0.0': {C: 0, D: 0}})
         simulate_play(p1, p2)
-        self.assertEqual(p1.Qs,{'': {C: 0, D: 0.9}, '0.0': {C: 2.7, D: 0}, 'C1.0': {C: 0, D: 0}})
+        self.assertEqual(p1.Qs, {'': {C: 0, D: 0.9}, '0.0': {C: 2.7, D: 0},
+                                 'C1.0': {C: 0, D: 0}})
 
     def test_vs_update(self):
         """
@@ -149,11 +149,9 @@ class TestArrogantQLearner(TestPlayer):
         P1 = axelrod.ArrogantQLearner()
         P1.Qs = {'': {C: 0, D: -0.9}, '0.0': {C: 0, D: 0}}
         P1.Vs = {'': 0, '0.0': 0}
-        P1.history = [C, D, D, D]
         P1.prev_state = C
         P1.reset()
         self.assertEqual(P1.prev_state, '')
-        self.assertEqual(P1.history, [])
         self.assertEqual(P1.Vs, {'':0})
         self.assertEqual(P1.Qs, {'':{C:0, D:0}})
 
@@ -180,7 +178,9 @@ class TestHesitantQLearner(TestPlayer):
         simulate_play(p1, p2)
         self.assertEqual(p1.Qs, {'': {C: 0, D: 0.1}, '0.0': {C: 0, D: 0}})
         simulate_play(p1, p2)
-        self.assertEqual(p1.Qs,{'': {C: 0, D: 0.1}, '0.0': {C: 0.30000000000000004, D: 0}, 'C1.0': {C: 0, D: 0}})
+        self.assertEqual(p1.Qs, {'': {C: 0, D: 0.1},
+                                 '0.0': {C: 0.30000000000000004, D: 0},
+                                 'C1.0': {C: 0, D: 0}})
 
     def test_vs_update(self):
         """
@@ -192,7 +192,8 @@ class TestHesitantQLearner(TestPlayer):
         simulate_play(p1, p2)
         self.assertEqual(p1.Vs, {'': 0.1, '0.0': 0})
         simulate_play(p1, p2)
-        self.assertEqual(p1.Vs,{'': 0.1, '0.0': 0.30000000000000004, 'C1.0': 0})
+        self.assertEqual(p1.Vs, {'': 0.1, '0.0': 0.30000000000000004,
+                                 'C1.0': 0})
 
     def test_prev_state_updates(self):
         """
@@ -222,11 +223,9 @@ class TestHesitantQLearner(TestPlayer):
         P1 = axelrod.HesitantQLearner()
         P1.Qs = {'': {C: 0, D: -0.9}, '0.0': {C: 0, D: 0}}
         P1.Vs = {'': 0, '0.0': 0}
-        P1.history = [C, D, D, D]
         P1.prev_state = C
         P1.reset()
         self.assertEqual(P1.prev_state, '')
-        self.assertEqual(P1.history, [])
         self.assertEqual(P1.Vs, {'': 0})
         self.assertEqual(P1.Qs, {'': {C: 0, D: 0}})
 
@@ -253,7 +252,9 @@ class TestCautiousQLearner(TestPlayer):
         simulate_play(p1, p2)
         self.assertEqual(p1.Qs, {'': {C: 0, D: 0.1}, '0.0': {C: 0, D: 0}})
         simulate_play(p1, p2)
-        self.assertEqual(p1.Qs,{'': {C: 0, D: 0.1}, '0.0': {C: 0.30000000000000004, D: 0}, 'C1.0': {C: 0, D: 0.0}})
+        self.assertEqual(p1.Qs, {'': {C: 0, D: 0.1},
+                                 '0.0': {C: 0.30000000000000004, D: 0},
+                                 'C1.0': {C: 0, D: 0.0}})
 
     def test_vs_update(self):
         """Test that the q and v values update."""
@@ -263,7 +264,8 @@ class TestCautiousQLearner(TestPlayer):
         simulate_play(p1, p2)
         self.assertEqual(p1.Vs, {'': 0.1, '0.0': 0})
         simulate_play(p1, p2)
-        self.assertEqual(p1.Vs,{'': 0.1, '0.0': 0.30000000000000004, 'C1.0': 0})
+        self.assertEqual(p1.Vs, {'': 0.1, '0.0': 0.30000000000000004,
+                                 'C1.0': 0})
 
     def test_prev_state_updates(self):
         """Test that the q and v values update."""
@@ -282,17 +284,15 @@ class TestCautiousQLearner(TestPlayer):
         p1.state = 'CCDC'
         p1.Qs = {'': {C: 0, D: 0}, 'CCDC': {C: 2, D: 6}}
         p2 = axelrod.Cooperator()
-        test_responses(self, p1, p2, [], [], [C, C, C, C, C, C, C])
+        test_responses(self, p1, p2, C * 7)
 
     def test_reset_method(self):
         """Tests the reset method."""
         P1 = axelrod.CautiousQLearner()
         P1.Qs = {'': {C: 0, D: -0.9}, '0.0': {C: 0, D: 0}}
         P1.Vs = {'': 0, '0.0': 0}
-        P1.history = [C, D, D, D]
         P1.prev_state = C
         P1.reset()
         self.assertEqual(P1.prev_state, '')
-        self.assertEqual(P1.history, [])
         self.assertEqual(P1.Vs, {'': 0})
         self.assertEqual(P1.Qs, {'': {C: 0, D: 0}})

--- a/axelrod/tests/unit/test_rand.py
+++ b/axelrod/tests/unit/test_rand.py
@@ -1,4 +1,4 @@
-"""Test for the random strategy."""
+"""Tests for the random strategy."""
 
 import axelrod
 from .test_player import TestPlayer
@@ -27,7 +27,7 @@ class TestRandom(TestPlayer):
 
         self.first_play_test(C, random_seed=1)
         self.first_play_test(D, random_seed=2)
-        self.responses_test(response_1, response_2, [C], random_seed=1)
+        self.responses_test(C, response_1, response_2, random_seed=1)
 
     def test_deterministic_classification(self):
         """Test classification when p is 0 or 1"""

--- a/axelrod/tests/unit/test_random_.py
+++ b/axelrod/tests/unit/test_random_.py
@@ -1,8 +1,8 @@
-"""Test for the random strategy."""
+"""Tests for the random utilities."""
 
-import numpy
 import random
 import unittest
+import numpy
 
 from axelrod import random_choice, seed, Actions
 

--- a/axelrod/tests/unit/test_resultset.py
+++ b/axelrod/tests/unit/test_resultset.py
@@ -1,13 +1,12 @@
-import unittest
-import axelrod
-import axelrod.interaction_utils as iu
-
-from numpy import mean, std, nanmedian
-
 import csv
 from collections import Counter
+import unittest
 
 from hypothesis import given, settings
+from numpy import mean, std, nanmedian
+
+import axelrod
+import axelrod.interaction_utils as iu
 from axelrod.tests.property import tournaments, prob_end_tournaments
 
 

--- a/axelrod/tests/unit/test_sequence_player.py
+++ b/axelrod/tests/unit/test_sequence_player.py
@@ -1,10 +1,10 @@
-"""Test for the Thue-Morse strategies."""
+"""Tests for the Thue-Morse strategies."""
 import unittest
 
 import axelrod
-from .test_player import TestPlayer, TestOpponent
 from axelrod.strategies.sequence_player import SequencePlayer
 from axelrod._strategy_utils import recursive_thue_morse
+from .test_player import TestPlayer, TestOpponent
 
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
@@ -42,15 +42,13 @@ class TestThueMorse(TestPlayer):
 
     def test_strategy(self):
         self.first_play_test(D)
-        self.markov_test([C, C, C, C])
-        self.responses_test([], [], [D, C, C, D, C, D, D, C, C, D, D, C, D, C,
+        self.second_play_test(C, C, C, C)
+        self.responses_test([D, C, C, D, C, D, D, C, C, D, D, C, D, C,
                                      C, D])
-        self.responses_test([C], [C], [C, C, D, C, D, D, C, C, D, D, C, D, C, C,
-                                       D])
-        self.responses_test([D], [D], [C, C, D, C, D, D, C, C, D, D, C, D, C, C,
-                                       D])
-        self.responses_test([C, C, C, D], [C, C, C, D], [C, D, D, C, C, D, D, C,
-                                                         D, C, C, D])
+        self.responses_test([C, C, D, C, D, D, C, C, D, D, C, D, C, C, D], C, C)
+        self.responses_test([C, C, D, C, D, D, C, C, D, D, C, D, C, C, D], D, D)
+        self.responses_test([C, D, D, C, C, D, D, C, D, C, C, D],
+                            [C, C, C, D], [C, C, C, D])
 
 
 class TestThueMorseInverse(TestPlayer):
@@ -69,12 +67,9 @@ class TestThueMorseInverse(TestPlayer):
 
     def test_strategy(self):
         self.first_play_test(C)
-        self.markov_test([D, D, D, D])
-        self.responses_test([], [], [C, D, D, C, D, C, C, D, D, C, C, D, C, D,
-                                     D, C])
-        self.responses_test([C], [C], [D, D, C, D, C, C, D, D, C, C, D, C, D, D,
-                                       C])
-        self.responses_test([D], [D], [D, D, C, D, C, C, D, D, C, C, D, C, D, D,
-                                       C])
-        self.responses_test([C, C, C, D], [C, C, C, D], [D, C, C, D, D, C, C, D,
-                                                         C, D, D, C])
+        self.second_play_test(D, D, D, D)
+        self.responses_test([C, D, D, C, D, C, C, D, D, C, C, D, C, D, D, C])
+        self.responses_test([D, D, C, D, C, C, D, D, C, C, D, C, D, D, C], C, C)
+        self.responses_test([D, D, C, D, C, C, D, D, C, C, D, C, D, D, C], D, D)
+        self.responses_test([D, C, C, D, D, C, C, D, C, D, D, C],
+                            [C, C, C, D], [C, C, C, D])

--- a/axelrod/tests/unit/test_strategy_transformers.py
+++ b/axelrod/tests/unit/test_strategy_transformers.py
@@ -128,14 +128,14 @@ class TestTransformers(unittest.TestCase):
         p2 = axelrod.Cooperator()
         for _ in range(5):
             p1.play(p2)
-        self.assertEqual(p1.history, [C, C, C, C, C])
+        self.assertEqual(p1.history, C * 5)
 
         probability = (0, 1)
         p1 = JossAnnTransformer(probability)(axelrod.Cooperator)()
         p2 = axelrod.Cooperator()
         for _ in range(5):
             p1.play(p2)
-        self.assertEqual(p1.history, [D, D, D, D, D])
+        self.assertEqual(p1.history, D * 5)
 
         probability = (0.3, 0.3)
         p1 = JossAnnTransformer(probability)(axelrod.TitForTat)()
@@ -143,7 +143,7 @@ class TestTransformers(unittest.TestCase):
         axelrod.seed(0)
         for _ in range(5):
             p1.play(p2)
-        self.assertEqual(p1.history, [D, C, C, D, D])
+        self.assertEqual(p1.history, D + C + C + D + D)
 
     def test_noisy_transformer(self):
         """Tests that the noisy transformed does flip some moves."""
@@ -153,7 +153,7 @@ class TestTransformers(unittest.TestCase):
         p2 = NoisyTransformer(0.5)(axelrod.Cooperator)()
         for _ in range(10):
             p1.play(p2)
-        self.assertEqual(p2.history, [C, C, C, C, C, C, D, D, C, C])
+        self.assertEqual(p2.history, C * 6 + D + D + C + C)
 
     def test_forgiving(self):
         """Tests that the forgiving transformer flips some defections."""
@@ -182,19 +182,19 @@ class TestTransformers(unittest.TestCase):
         """Tests the FinalTransformer when tournament length is known."""
         # Final play transformer
         p1 = axelrod.Cooperator()
-        p2 = FinalTransformer([D, D, D])(axelrod.Cooperator)()
+        p2 = FinalTransformer(D * 3)(axelrod.Cooperator)()
         p2.match_attributes["length"] = 6
         for _ in range(6):
             p1.play(p2)
-        self.assertEqual(p2.history, [C, C, C, D, D, D])
+        self.assertEqual(p2.history, C * 3 + D * 3)
 
     def test_final_transformer2(self):
         """Tests the FinalTransformer when tournament length is not known."""
         p1 = axelrod.Cooperator()
-        p2 = FinalTransformer([D, D])(axelrod.Cooperator)()
+        p2 = FinalTransformer(D + D)(axelrod.Cooperator)()
         for _ in range(6):
             p1.play(p2)
-        self.assertEqual(p2.history, [C, C, C, C, C, C])
+        self.assertEqual(p2.history, C * 6)
 
     def test_history_track(self):
         """Tests the history tracking transformer."""
@@ -206,31 +206,32 @@ class TestTransformers(unittest.TestCase):
 
     def test_composition(self):
         """Tests that transformations can be chained or composed."""
-        cls1 = InitialTransformer([D, D])(axelrod.Cooperator)
-        cls2 = FinalTransformer([D, D])(cls1)
+        cls1 = InitialTransformer(D + D)(axelrod.Cooperator)
+        cls2 = FinalTransformer(D + D)(cls1)
         p1 = cls2()
         p2 = axelrod.Cooperator()
         p1.match_attributes["length"] = 8
         for _ in range(8):
             p1.play(p2)
-        self.assertEqual(p1.history, [D, D, C, C, C, C, D, D])
+        self.assertEqual(p1.history, D * 2 + 4 * C + 2 * D)
 
-        cls1 = FinalTransformer([D, D])(InitialTransformer([D, D])(axelrod.Cooperator))
+        cls1 = FinalTransformer(D + D)(InitialTransformer(D + D)(axelrod.Cooperator))
         p1 = cls1()
         p2 = axelrod.Cooperator()
         p1.match_attributes["length"] = 8
         for _ in range(8):
             p1.play(p2)
-        self.assertEqual(p1.history, [D, D, C, C, C, C, D, D])
+        self.assertEqual(p1.history, D * 2 + 4 * C + 2 * D)
 
     def test_compose_transformers(self):
-        cls1 = compose_transformers(FinalTransformer([D, D]), InitialTransformer([D, D]))
+        cls1 = compose_transformers(FinalTransformer(D + D),
+                                    InitialTransformer(D + D))
         p1 = cls1(axelrod.Cooperator)()
         p2 = axelrod.Cooperator()
         p1.match_attributes["length"] = 8
         for _ in range(8):
             p1.play(p2)
-        self.assertEqual(p1.history, [D, D, C, C, C, C, D, D])
+        self.assertEqual(p1.history, D * 2 + 4 * C + 2 * D)
 
     def test_retailiation(self):
         """Tests the RetaliateTransformer."""
@@ -238,8 +239,8 @@ class TestTransformers(unittest.TestCase):
         p2 = axelrod.Defector()
         for _ in range(5):
             p1.play(p2)
-        self.assertEqual(p1.history, [C, D, D, D, D])
-        self.assertEqual(p2.history, [D, D, D, D, D])
+        self.assertEqual(p1.history, C + 4 * D)
+        self.assertEqual(p2.history, 5 * D)
 
         p1 = RetaliationTransformer(1)(axelrod.Cooperator)()
         p2 = axelrod.Alternator()
@@ -280,13 +281,13 @@ class TestTransformers(unittest.TestCase):
 
     def test_apology(self):
         """Tests the ApologyTransformer."""
-        ApologizingDefector = ApologyTransformer([D], [C])(axelrod.Defector)
+        ApologizingDefector = ApologyTransformer(D, C)(axelrod.Defector)
         p1 = ApologizingDefector()
         p2 = axelrod.Cooperator()
         for _ in range(5):
             p1.play(p2)
         self.assertEqual(p1.history, [D, C, D, C, D])
-        ApologizingDefector = ApologyTransformer([D, D], [C, C])(axelrod.Defector)
+        ApologizingDefector = ApologyTransformer(D + D, C + C)(axelrod.Defector)
         p1 = ApologizingDefector()
         p2 = axelrod.Cooperator()
         for _ in range(6):
@@ -465,7 +466,7 @@ class TestRUAisTFT(TestTitForTat):
     player = TFT
     name = "RUA Cooperator"
     expected_classifier = {
-        'memory_depth': 0, # really 1
+        'memory_depth': 0,  # really 1
         'stochastic': False,
         'makes_use_of': set(),
         'long_run_time': False,

--- a/axelrod/tests/unit/test_strategy_transformers.py
+++ b/axelrod/tests/unit/test_strategy_transformers.py
@@ -341,7 +341,7 @@ class TestTransformers(unittest.TestCase):
 
     def test_deadlock(self):
         """Test the DeadlockBreakingTransformer."""
-        # We can induce a deadlock by alterting TFT to defect first
+        # We can induce a deadlock by altering TFT to defect first
         p1 = axelrod.TitForTat()
         p2 = InitialTransformer([D])(axelrod.TitForTat)()
         for _ in range(4):
@@ -399,7 +399,7 @@ class TestTransformers(unittest.TestCase):
 
     def test_nilpotency(self):
         """Show that some of the transformers are (sometimes) nilpotent, i.e.
-        that transfomer(transformer(PlayerClass)) == PlayerClass"""
+        that transformer(transformer(PlayerClass)) == PlayerClass"""
         for transformer in [IdentityTransformer(),
                             FlipTransformer(),
                             TrackHistoryTransformer()]:
@@ -409,7 +409,7 @@ class TestTransformers(unittest.TestCase):
                     transformed = transformer(transformer(PlayerClass))()
                     for _ in range(5):
                         self.assertEqual(player.strategy(third_player),
-                                        transformed.strategy(third_player))
+                                         transformed.strategy(third_player))
                         player.play(third_player)
                         third_player.history.pop(-1)
                         transformed.play(third_player)
@@ -433,7 +433,7 @@ class TestTransformers(unittest.TestCase):
                     transformed = transformer(transformer(PlayerClass))()
                     for i in range(5):
                         self.assertEqual(player.strategy(third_player),
-                                        transformed.strategy(third_player))
+                                         transformed.strategy(third_player))
                         player.play(third_player)
                         third_player.history.pop(-1)
                         transformed.play(third_player)

--- a/axelrod/tests/unit/test_strategy_utils.py
+++ b/axelrod/tests/unit/test_strategy_utils.py
@@ -20,8 +20,8 @@ class TestDetectCycle(unittest.TestCase):
         self.assertIsNotNone(detect_cycle(history))
 
     def test_no_cycle(self):
-        history = [C, D, C, C]
+        history = C + D + C + C
         self.assertIsNone(detect_cycle(history))
 
-        history = [D, D, C, C, C]
+        history = D * 2 + C * 3
         self.assertIsNone(detect_cycle(history))

--- a/axelrod/tests/unit/test_titfortat.py
+++ b/axelrod/tests/unit/test_titfortat.py
@@ -1,13 +1,11 @@
-"""Test for the tit for tat strategies."""
-
-import axelrod
-from .test_player import TestHeadsUp, TestPlayer
+"""Tests for the tit for tat strategies."""
+import random
 
 from hypothesis import given
 from hypothesis.strategies import integers
+import axelrod
 from axelrod.tests.property import strategy_lists
-
-import random
+from .test_player import TestHeadsUp, TestPlayer
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
 
@@ -31,14 +29,10 @@ class TestTitForTat(TestPlayer):
     }
 
     def test_strategy(self):
-        """Starts by cooperating."""
         self.first_play_test(C)
-
-    def test_effect_of_strategy(self):
-        """Repeats last action of opponent history."""
-        self.markov_test([C, D, C, D])
-        self.responses_test([C] * 4, [C, C, C, C], [C])
-        self.responses_test([C] * 5, [C, C, C, C, D], [D])
+        self.second_play_test(C, D, C, D)
+        self.responses_test(C, C * 4, C * 4)
+        self.responses_test(D, C * 5, C * 4 + D)
 
 
 class TestTitFor2Tats(TestPlayer):
@@ -55,13 +49,10 @@ class TestTitFor2Tats(TestPlayer):
     }
 
     def test_strategy(self):
-        """Starts by cooperating."""
         self.first_play_test(C)
-
-    def test_effect_of_strategy(self):
-        """Will defect only when last two turns of opponent were defections."""
-        self.responses_test([C, C, C], [D, D, D], [D])
-        self.responses_test([C, C, D, D], [D, D, D, C], [C])
+        # Will defect only when last two turns of opponent were defections.
+        self.responses_test(D, C + C, D + D)
+        self.responses_test(C, C + C + D + D, D * 3 + C)
 
 
 class TestTwoTitsForTat(TestPlayer):
@@ -78,15 +69,12 @@ class TestTwoTitsForTat(TestPlayer):
     }
 
     def test_strategy(self):
-        """Starts by cooperating."""
         self.first_play_test(C)
-
-    def test_effect_of_strategy(self):
-        """Will defect twice when last turn of opponent was defection."""
-        self.responses_test([C], [D], [D])
-        self.responses_test([C, C], [D, D], [D])
-        self.responses_test([C, C, C], [D, D, C], [D])
-        self.responses_test([C, C, D, D], [D, D, C, C], [C])
+        # Will defect twice when last turn of opponent was defection.
+        self.responses_test(D, C, D)
+        self.responses_test(D, C + C, D + D)
+        self.responses_test(D, C * 3, D + D + C)
+        self.responses_test(C, C + C + D + D, D + D + C + C)
 
 
 class TestBully(TestPlayer):
@@ -103,12 +91,8 @@ class TestBully(TestPlayer):
     }
 
     def test_strategy(self):
-        """Starts by defecting"""
         self.first_play_test(D)
-
-    def test_effect_of_strategy(self):
-        """Will do opposite of what opponent does."""
-        self.markov_test([D, C, D, C])
+        self.second_play_test(D, C, D, C)
 
 
 class TestSneakyTitForTat(TestPlayer):
@@ -125,14 +109,11 @@ class TestSneakyTitForTat(TestPlayer):
     }
 
     def test_strategy(self):
-        """Starts by cooperating."""
         self.first_play_test(C)
-
-    def test_effect_of_strategy(self):
-        """Will try defecting after two turns of cooperation, but will stop
-        if punished."""
-        self.responses_test([C, C], [C, C], [D])
-        self.responses_test([C, C, D, D], [C, C, C, D], [C])
+        # Will try defecting after two turns of cooperation, but will stop if
+        # punished.
+        self.responses_test(D, C + C, C + C)
+        self.responses_test(C, C + C + D + D, C + C + C + D)
 
 
 class TestSuspiciousTitForTat(TestPlayer):
@@ -149,13 +130,8 @@ class TestSuspiciousTitForTat(TestPlayer):
     }
 
     def test_strategy(self):
-        """Starts by Defecting"""
         self.first_play_test(D)
-
-    def test_effect_of_strategy(self):
-        """Plays like TFT after the first move, repeating the opponents last
-        move."""
-        self.markov_test([C, D, C, D])
+        self.second_play_test(C, D, C, D)
 
 
 class TestAntiTitForTat(TestPlayer):
@@ -172,12 +148,9 @@ class TestAntiTitForTat(TestPlayer):
     }
 
     def test_strategy(self):
-        """Starts by Cooperating"""
         self.first_play_test(C)
-
-    def test_effect_of_strategy(self):
-        """Will do opposite of what opponent does."""
-        self.markov_test([D, C, D, C])
+        # Will do opposite of what opponent does.
+        self.second_play_test(D, C, D, C)
 
 
 class TestHardTitForTat(TestPlayer):
@@ -194,16 +167,12 @@ class TestHardTitForTat(TestPlayer):
     }
 
     def test_strategy(self):
-        """Starts by cooperating."""
         self.first_play_test(C)
-
-    def test_effect_of_strategy(self):
-        """Repeats last action of opponent history."""
-        self.responses_test([C, C, C], [C, C, C], [C])
-        self.responses_test([C, C, C], [D, C, C], [D])
-        self.responses_test([C, C, C], [C, D, C], [D])
-        self.responses_test([C, C, C], [C, C, D], [D])
-        self.responses_test([C, C, C, C], [D, C, C, C], [C])
+        self.responses_test(C, [C, C, C], [C, C, C])
+        self.responses_test(D, [C, C, C], [D, C, C])
+        self.responses_test(D, [C, C, C], [C, D, C])
+        self.responses_test(D, [C, C, C], [C, C, D])
+        self.responses_test(C, [C, C, C, C], [D, C, C, C])
 
 
 class TestHardTitFor2Tats(TestPlayer):
@@ -225,18 +194,18 @@ class TestHardTitFor2Tats(TestPlayer):
 
     def test_effect_of_strategy(self):
         """Repeats last action of opponent history."""
-        self.responses_test([C, C, C], [C, C, C], [C])
-        self.responses_test([C, C, C], [D, C, C], [C])
-        self.responses_test([C, C, C], [C, D, C], [C])
-        self.responses_test([C, C, C], [C, C, D], [C])
+        self.responses_test(C, [C, C, C], [C, C, C])
+        self.responses_test(C, [C, C, C], [D, C, C])
+        self.responses_test(C, [C, C, C], [C, D, C])
+        self.responses_test(C, [C, C, C], [C, C, D])
 
-        self.responses_test([C, C, C], [D, C, D], [C])
-        self.responses_test([C, C, C], [D, D, C], [D])
-        self.responses_test([C, C, C], [C, D, D], [D])
+        self.responses_test(C, [C, C, C], [D, C, D])
+        self.responses_test(D, [C, C, C], [D, D, C])
+        self.responses_test(D, [C, C, C], [C, D, D])
 
-        self.responses_test([C, C, C, C], [D, C, C, C], [C])
-        self.responses_test([C, C, C, C], [D, D, C, C], [C])
-        self.responses_test([C, C, C, C], [C, D, D, C], [D])
+        self.responses_test(C, [C, C, C, C], [D, C, C, C])
+        self.responses_test(C, [C, C, C, C], [D, D, C, C])
+        self.responses_test(D, [C, C, C, C], [C, D, D, C])
 
 
 class OmegaTFT(TestPlayer):
@@ -257,12 +226,13 @@ class OmegaTFT(TestPlayer):
         """Starts by cooperating."""
         self.first_play_test(C)
         for i in range(10):
-            self.responses_test([C] * i, [C] * i, [C])
+            self.responses_test(C, C * i, C * i)
 
     def test_reset(self):
         player = self.player()
         opponent = axelrod.Defector()
-        [player.play(opponent) for _ in range(10)]
+        for _ in range(10):
+            player.play(opponent)
         player.reset()
         self.assertEqual(player.randomness_counter, 0)
         self.assertEqual(player.deadlock_counter, 0)
@@ -307,7 +277,7 @@ class TestGradual(TestPlayer):
         """Punishes defection with a growing number of defections and calms
         the opponent with two Cooperations in a row"""
         self.responses_test(
-            [C], [C], [C],
+            C, C, C,
             attrs={
                 "calming": False,
                 "punishing": False,
@@ -316,7 +286,7 @@ class TestGradual(TestPlayer):
             }
         )
         self.responses_test(
-            [C], [D], [D],
+            D, C, D,
             attrs={
                 "calming": False,
                 "punishing": True,
@@ -325,7 +295,7 @@ class TestGradual(TestPlayer):
             }
         )
         self.responses_test(
-            [C, D], [D, C], [C],
+            C, C + D, D + C,
             attrs={
                 "calming": True,
                 "punishing": False,
@@ -334,7 +304,7 @@ class TestGradual(TestPlayer):
             }
         )
         self.responses_test(
-            [C, D, C], [D, C, D], [C],
+            C, C + D + C, D + C + D,
             attrs={
                 "calming": False,
                 "punishing": False,
@@ -343,7 +313,7 @@ class TestGradual(TestPlayer):
             }
         )
         self.responses_test(
-            [C, D, C, C], [D, C, D, C], [C],
+            C, C + D + C + C, D + C + D + C,
             attrs={
                 "calming": False,
                 "punishing": False,
@@ -352,7 +322,7 @@ class TestGradual(TestPlayer):
             }
         )
         self.responses_test(
-            [C, D, C, D, C], [D, C, D, C, C], [C],
+            C, [C, D, C, D, C], [D, C, D, C, C],
             attrs={
                 "calming": False,
                 "punishing": False,
@@ -361,7 +331,7 @@ class TestGradual(TestPlayer):
             }
         )
         self.responses_test(
-            [C, D, C, D, C, C], [D, C, D, C, C, D], [D],
+            D, [C, D, C, D, C, C], [D, C, D, C, C, D],
             attrs={
                 "calming": False,
                 "punishing": True,
@@ -370,7 +340,7 @@ class TestGradual(TestPlayer):
             }
         )
         self.responses_test(
-            [C, D, C, D, D, C, D], [D, C, D, C, C, D, C], [D],
+            D, [C, D, C, D, D, C, D], [D, C, D, C, C, D, C],
             attrs={
                 "calming": False,
                 "punishing": True,
@@ -379,7 +349,7 @@ class TestGradual(TestPlayer):
             }
         )
         self.responses_test(
-            [C, D, C, D, D, C, D, D], [D, C, D, C, C, D, C, C], [C],
+            C, [C, D, C, D, D, C, D, D], [D, C, D, C, C, D, C, C],
             attrs={
                 "calming": True,
                 "punishing": False,
@@ -388,7 +358,7 @@ class TestGradual(TestPlayer):
             }
         )
         self.responses_test(
-            [C, D, C, D, D, C, D, D, C], [D, C, D, C, C, D, C, C, C], [C],
+            C, [C, D, C, D, D, C, D, D, C], [D, C, D, C, C, D, C, C, C],
             attrs={
                 "calming": False,
                 "punishing": False,
@@ -404,7 +374,6 @@ class TestGradual(TestPlayer):
         p.punishment_count = 1
         p.punishment_limit = 1
         p.reset()
-
         self.assertFalse(p.calming)
         self.assertFalse(p.punishing)
         self.assertEqual(p.punishment_count, 0)
@@ -465,15 +434,15 @@ class TestContriteTitForTat(TestPlayer):
         ctft = self.player()
         opponent = axelrod.Defector()
         self.assertEqual(ctft.strategy(opponent), C)
-        self.assertEqual(ctft._recorded_history, [C])
+        self.assertEqual(ctft._recorded_history, C)
         ctft.reset()  # Clear the recorded history
-        self.assertEqual(ctft._recorded_history, [])
+        self.assertEqual(len(ctft._recorded_history), 0)
 
         random.seed(0)
         ctft.play(opponent, noise=.9)
-        self.assertEqual(ctft.history, [D])
-        self.assertEqual(ctft._recorded_history, [C])
-        self.assertEqual(opponent.history, [C])
+        self.assertEqual(ctft.history, D)
+        self.assertEqual(ctft._recorded_history, C)
+        self.assertEqual(opponent.history, C)
 
         # After noise: is contrite
         ctft.play(opponent)
@@ -517,15 +486,12 @@ class TestSlowTitForTwoTats(TestPlayer):
     }
 
     def test_strategy(self):
-        """Starts by cooperating."""
         self.first_play_test(C)
-
-    def test_effect_of_strategy(self):
-        """If opponent plays the same move twice, repeats last action of
-        opponent history."""
-        self.responses_test([C] * 2, [C, C], [C])
-        self.responses_test([C] * 3, [C, D, C], [C])
-        self.responses_test([C] * 3, [C, D, D], [D])
+        #If opponent plays the same move twice, repeats last action of
+        # opponent history.
+        self.responses_test(C, C * 2, C * 2)
+        self.responses_test(C, C * 3, [C, D, C])
+        self.responses_test(D, C * 3, [C, D, D])
 
 
 class TestAdaptiveTitForTat(TestPlayer):
@@ -542,12 +508,8 @@ class TestAdaptiveTitForTat(TestPlayer):
     }
 
     def test_strategy(self):
-        """Start by cooperating."""
         self.first_play_test(C)
-
-    def test_effect_of_strategy(self):
-
-        self.markov_test(['C', 'D', 'C', 'D'])
+        self.second_play_test(C, D, C, D)
 
         p1, p2 = self.player(), self.player()
         p1.play(p2)
@@ -576,22 +538,16 @@ class TestSpitefulTitForTat(TestPlayer):
     }
 
     def test_strategy(self):
-        """Starts by cooperating."""
         self.first_play_test(C)
-
-    def test_effect_of_strategy(self):
-        """Repeats last action of opponent history until 2 consecutive
-        defections, then always defects"""
-        self.markov_test([C, D, C, D])
-        self.responses_test(
-            [C] * 4, [C, C, C, C], [C], attrs={"retaliating": False}
-        )
-        self.responses_test(
-            [C] * 5, [C, C, C, C, D], [D], attrs={"retaliating": False}
-        )
-        self.responses_test(
-            [C] * 5, [C, C, D, D, C], [D], attrs={"retaliating": True}
-        )
+        # Repeats last action of opponent history until 2 consecutive
+        # defections, then always defects.
+        self.second_play_test(C, D, C, D)
+        self.responses_test(C, C * 4, C * 4,
+                            attrs={"retaliating": False})
+        self.responses_test(D, C * 5, C * 4 + D,
+                            attrs={"retaliating": False})
+        self.responses_test(D, C * 5, C + C + D + D + C,
+                            attrs={"retaliating": True})
 
     def test_reset_retaliating(self):
         player = self.player()

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -4,25 +4,19 @@ import csv
 import logging
 from multiprocessing import Queue, cpu_count
 import unittest
+from unittest.mock import MagicMock
 import warnings
 
 from hypothesis import given, example, settings
 from hypothesis.strategies import integers, floats
-from axelrod.tests.property import (tournaments,
-                                    prob_end_tournaments,
-                                    spatial_tournaments,
-                                    strategy_lists)
 
 import axelrod
+from axelrod import Actions
+from axelrod.tests.property import (
+    tournaments, prob_end_tournaments, spatial_tournaments, strategy_lists)
 
 
-try:
-    # Python 3
-    from unittest.mock import MagicMock
-except ImportError:
-    # Python 2
-    from mock import MagicMock
-
+C, D = Actions.C, Actions.D
 test_strategies = [axelrod.Cooperator,
                    axelrod.TitForTat,
                    axelrod.Defector,
@@ -30,11 +24,8 @@ test_strategies = [axelrod.Cooperator,
                    axelrod.GoByMajority]
 test_repetitions = 5
 test_turns = 100
-
 test_prob_end = .5
-
 test_edges = [(0, 1), (1, 2), (3, 4)]
-
 deterministic_strategies = [s for s in axelrod.strategies
                             if not s().classifier['stochastic']]
 
@@ -76,7 +67,7 @@ class TestTournament(unittest.TestCase):
         self.assertIsInstance(
             tournament.players[0].match_attributes['game'], axelrod.Game
         )
-        self.assertEqual(tournament.game.score(('C', 'C')), (3, 3))
+        self.assertEqual(tournament.game.score((C, C)), (3, 3))
         self.assertEqual(tournament.turns, self.test_turns)
         self.assertEqual(tournament.repetitions, 10)
         self.assertEqual(tournament.name, 'test')
@@ -149,7 +140,6 @@ class TestTournament(unittest.TestCase):
             turns=200,
             repetitions=self.test_repetitions)
 
-
         # Test with build results
         results = tournament.play(progress_bar=False)
         self.assertIsInstance(results, axelrod.ResultSet)
@@ -221,7 +211,6 @@ class TestTournament(unittest.TestCase):
     @example(tournament=axelrod.Tournament(players=[s() for s in
         test_strategies], turns=test_turns, repetitions=test_repetitions)
         )
-
     # These two examples are to make sure #465 is fixed.
     # As explained there: https://github.com/Axelrod-Python/Axelrod/issues/465,
     # these two examples were identified by hypothesis.
@@ -503,36 +492,37 @@ class TestTournament(unittest.TestCase):
         tournament.play(filename=self.filename, progress_bar=False)
         with open(self.filename, 'r') as f:
             written_data = [[int(r[0]), int(r[1])] + r[2:] for r in csv.reader(f)]
-            expected_data = [[0, 1, 'Cooperator', 'Tit For Tat', 'CC', 'CC'],
-                             [0, 1, 'Cooperator', 'Tit For Tat', 'CC', 'CC'],
-                             [1, 2, 'Tit For Tat', 'Defector', 'CD', 'DD'],
-                             [1, 2, 'Tit For Tat', 'Defector', 'CD', 'DD'],
-                             [0, 0, 'Cooperator', 'Cooperator', 'CC', 'CC'],
-                             [0, 0, 'Cooperator', 'Cooperator', 'CC', 'CC'],
-                             [3, 3, 'Grudger', 'Grudger', 'CC', 'CC'],
-                             [3, 3, 'Grudger', 'Grudger', 'CC', 'CC'],
-                             [2, 2, 'Defector', 'Defector', 'DD', 'DD'],
-                             [2, 2, 'Defector', 'Defector', 'DD', 'DD'],
-                             [4, 4, 'Soft Go By Majority', 'Soft Go By Majority', 'CC', 'CC'],
-                             [4, 4, 'Soft Go By Majority', 'Soft Go By Majority', 'CC', 'CC'],
-                             [1, 4, 'Tit For Tat', 'Soft Go By Majority', 'CC', 'CC'],
-                             [1, 4, 'Tit For Tat', 'Soft Go By Majority', 'CC', 'CC'],
-                             [1, 1, 'Tit For Tat', 'Tit For Tat', 'CC', 'CC'],
-                             [1, 1, 'Tit For Tat', 'Tit For Tat', 'CC', 'CC'],
-                             [1, 3, 'Tit For Tat', 'Grudger', 'CC', 'CC'],
-                             [1, 3, 'Tit For Tat', 'Grudger', 'CC', 'CC'],
-                             [2, 3, 'Defector', 'Grudger', 'DD', 'CD'],
-                             [2, 3, 'Defector', 'Grudger', 'DD', 'CD'],
-                             [0, 4, 'Cooperator', 'Soft Go By Majority', 'CC', 'CC'],
-                             [0, 4, 'Cooperator', 'Soft Go By Majority', 'CC', 'CC'],
-                             [2, 4, 'Defector', 'Soft Go By Majority', 'DD', 'CD'],
-                             [2, 4, 'Defector', 'Soft Go By Majority', 'DD', 'CD'],
-                             [0, 3, 'Cooperator', 'Grudger', 'CC', 'CC'],
-                             [0, 3, 'Cooperator', 'Grudger', 'CC', 'CC'],
-                             [3, 4, 'Grudger', 'Soft Go By Majority', 'CC', 'CC'],
-                             [3, 4, 'Grudger', 'Soft Go By Majority', 'CC', 'CC'],
-                             [0, 2, 'Cooperator', 'Defector', 'CC', 'DD'],
-                             [0, 2, 'Cooperator', 'Defector', 'CC', 'DD']]
+            expected_data = [
+                [0, 1, 'Cooperator', 'Tit For Tat', C + C, C + C],
+                [0, 1, 'Cooperator', 'Tit For Tat', C + C, C + C],
+                [1, 2, 'Tit For Tat', 'Defector', C + D, D + D],
+                [1, 2, 'Tit For Tat', 'Defector', C + D, D + D],
+                [0, 0, 'Cooperator', 'Cooperator', C + C, C + C],
+                [0, 0, 'Cooperator', 'Cooperator', C + C, C + C],
+                [3, 3, 'Grudger', 'Grudger', C + C, C + C],
+                [3, 3, 'Grudger', 'Grudger', C + C, C + C],
+                [2, 2, 'Defector', 'Defector', D + D, D + D],
+                [2, 2, 'Defector', 'Defector', D + D, D + D],
+                [4, 4, 'Soft Go By Majority', 'Soft Go By Majority', C + C, C + C],
+                [4, 4, 'Soft Go By Majority', 'Soft Go By Majority', C + C, C + C],
+                [1, 4, 'Tit For Tat', 'Soft Go By Majority', C + C, C + C],
+                [1, 4, 'Tit For Tat', 'Soft Go By Majority', C + C, C + C],
+                [1, 1, 'Tit For Tat', 'Tit For Tat', C + C, C + C],
+                [1, 1, 'Tit For Tat', 'Tit For Tat', C + C, C + C],
+                [1, 3, 'Tit For Tat', 'Grudger', C + C, C + C],
+                [1, 3, 'Tit For Tat', 'Grudger', C + C, C + C],
+                [2, 3, 'Defector', 'Grudger', D + D, C + D],
+                [2, 3, 'Defector', 'Grudger', D + D, C + D],
+                [0, 4, 'Cooperator', 'Soft Go By Majority', C + C, C + C],
+                [0, 4, 'Cooperator', 'Soft Go By Majority', C + C, C + C],
+                [2, 4, 'Defector', 'Soft Go By Majority', D + D, C + D],
+                [2, 4, 'Defector', 'Soft Go By Majority', D + D, C + D],
+                [0, 3, 'Cooperator', 'Grudger', C + C, C + C],
+                [0, 3, 'Cooperator', 'Grudger', C + C, C + C],
+                [3, 4, 'Grudger', 'Soft Go By Majority', C + C, C + C],
+                [3, 4, 'Grudger', 'Soft Go By Majority', C + C, C + C],
+                [0, 2, 'Cooperator', 'Defector', C + C, D + D],
+                [0, 2, 'Cooperator', 'Defector', C + C, D + D]]
             self.assertEqual(sorted(written_data), sorted(expected_data))
 
 
@@ -555,7 +545,7 @@ class TestProbEndTournament(unittest.TestCase):
             noise=0.2)
         self.assertEqual(tournament.match_generator.prob_end, tournament.prob_end)
         self.assertEqual(len(tournament.players), len(test_strategies))
-        self.assertEqual(tournament.game.score(('C', 'C')), (3, 3))
+        self.assertEqual(tournament.game.score((C, C)), (3, 3))
         self.assertEqual(tournament.turns, float("inf"))
         self.assertEqual(tournament.repetitions, 10)
         self.assertEqual(tournament.name, 'test')
@@ -617,7 +607,7 @@ class TestSpatialTournament(unittest.TestCase):
             noise=0.2)
         self.assertEqual(tournament.match_generator.edges, tournament.edges)
         self.assertEqual(len(tournament.players), len(test_strategies))
-        self.assertEqual(tournament.game.score(('C', 'C')), (3, 3))
+        self.assertEqual(tournament.game.score((C, C)), (3, 3))
         self.assertEqual(tournament.turns, 100)
         self.assertEqual(tournament.repetitions, 10)
         self.assertEqual(tournament.name, 'test')
@@ -723,7 +713,7 @@ class TestProbEndingSpatialTournament(unittest.TestCase):
             noise=0.2)
         self.assertEqual(tournament.match_generator.edges, tournament.edges)
         self.assertEqual(len(tournament.players), len(test_strategies))
-        self.assertEqual(tournament.game.score(('C', 'C')), (3, 3))
+        self.assertEqual(tournament.game.score((C, C)), (3, 3))
         self.assertEqual(tournament.turns, float("inf"))
         self.assertEqual(tournament.repetitions, 10)
         self.assertEqual(tournament.name, 'test')
@@ -772,7 +762,6 @@ class TestProbEndingSpatialTournament(unittest.TestCase):
         self.assertEqual(results.scores, spatial_results.scores)
         self.assertEqual(results.cooperation,
                          spatial_results.cooperation)
-
 
     @given(tournament=spatial_tournaments(strategies=axelrod.basic_strategies,
                                           max_turns=1, max_noise=0,

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -117,7 +117,7 @@ class TestTournament(unittest.TestCase):
             turns=200,
             repetitions=self.test_repetitions)
         results = tournament.play(progress_bar=False)
-        self.assertEqual(tournament.num_interactions, 75)
+        self.assertIsInstance(results, axelrod.ResultSet)
 
     def test_serial_play_with_different_game(self):
         # Test that a non default game is passed to the result set
@@ -129,6 +129,7 @@ class TestTournament(unittest.TestCase):
             turns=1,
             repetitions=1)
         results = tournament.play(progress_bar=False)
+        self.assertIsInstance(results, axelrod.ResultSet)
         self.assertEqual(results.game.RPST(), (-1, -1, -1, -1))
 
     def test_no_progress_bar_play(self):
@@ -244,7 +245,6 @@ class TestTournament(unittest.TestCase):
             repetitions=self.test_repetitions)
         results = tournament.play(processes=2, progress_bar=False)
         self.assertIsInstance(results, axelrod.ResultSet)
-        self.assertEqual(tournament.num_interactions, 75)
 
         # The following relates to #516
         players = [axelrod.Cooperator(), axelrod.Defector(),

--- a/axelrod/tests/unit/test_version.py
+++ b/axelrod/tests/unit/test_version.py
@@ -1,8 +1,9 @@
 """
 Tests the version number
 """
-from axelrod import __version__
 import unittest
+from axelrod import __version__
+
 
 class TestVersion(unittest.TestCase):
     def test_version(self):

--- a/axelrod/tests/unit/test_windows_detection.py
+++ b/axelrod/tests/unit/test_windows_detection.py
@@ -2,6 +2,7 @@ import unittest
 import os
 import axelrod
 
+
 class TestWindowsDetection(unittest.TestCase):
 
     @unittest.skipIf(os.name == 'nt',

--- a/axelrod/tests/unit/test_worse_and_worse.py
+++ b/axelrod/tests/unit/test_worse_and_worse.py
@@ -1,10 +1,10 @@
-"""Test for the Worse and Worse strategies."""
+"""Tests for the Worse and Worse strategies."""
 
 import axelrod
-
-from .test_player import TestPlayer, TestHeadsUp
+from .test_player import TestPlayer
 
 C, D = axelrod.Actions.C, axelrod.Actions.D
+
 
 class TestWorseAndWorse(TestPlayer):
 
@@ -29,32 +29,32 @@ class TestWorseAndWorse(TestPlayer):
         opponent = axelrod.Cooperator()
         player = axelrod.WorseAndWorse()
         match = axelrod.Match((opponent, player), turns=10)
-        self.assertEqual(match.play(), [('C', 'C'),
-                                        ('C', 'C'),
-                                        ('C', 'C'),
-                                        ('C', 'C'),
-                                        ('C', 'C'),
-                                        ('C', 'C'),
-                                        ('C', 'D'),
-                                        ('C', 'C'),
-                                        ('C', 'C'),
-                                        ('C', 'C')])
+        self.assertEqual(match.play(), [(C, C),
+                                        (C, C),
+                                        (C, C),
+                                        (C, C),
+                                        (C, C),
+                                        (C, C),
+                                        (C, D),
+                                        (C, C),
+                                        (C, C),
+                                        (C, C)])
 
         # Test that behaviour does not depend on opponent
         opponent = axelrod.Defector()
         player = axelrod.WorseAndWorse()
         axelrod.seed(8)
         match = axelrod.Match((opponent, player), turns=10)
-        self.assertEqual(match.play(), [('D', 'C'),
-                                        ('D', 'C'),
-                                        ('D', 'C'),
-                                        ('D', 'C'),
-                                        ('D', 'C'),
-                                        ('D', 'C'),
-                                        ('D', 'D'),
-                                        ('D', 'C'),
-                                        ('D', 'C'),
-                                        ('D', 'C')])
+        self.assertEqual(match.play(), [(D, C),
+                                        (D, C),
+                                        (D, C),
+                                        (D, C),
+                                        (D, C),
+                                        (D, C),
+                                        (D, D),
+                                        (D, C),
+                                        (D, C),
+                                        (D, C)])
 
 
 class TestWorseAndWorseRandom(TestPlayer):
@@ -79,32 +79,32 @@ class TestWorseAndWorseRandom(TestPlayer):
         opponent = axelrod.Cooperator()
         player = axelrod.KnowledgeableWorseAndWorse()
         match = axelrod.Match((opponent, player), turns=5)
-        self.assertEqual(match.play(), [('C', 'C'),
-                                        ('C', 'D'),
-                                        ('C', 'D'),
-                                        ('C', 'D'),
-                                        ('C', 'D')])
+        self.assertEqual(match.play(), [(C, C),
+                                        (C, D),
+                                        (C, D),
+                                        (C, D),
+                                        (C, D)])
 
         # Test that behaviour does not depend on opponent
         opponent = axelrod.Defector()
         player = axelrod.KnowledgeableWorseAndWorse()
         axelrod.seed(1)
         match = axelrod.Match((opponent, player), turns=5)
-        self.assertEqual(match.play(), [('D', 'C'),
-                                        ('D', 'D'),
-                                        ('D', 'D'),
-                                        ('D', 'D'),
-                                        ('D', 'D')])
+        self.assertEqual(match.play(), [(D, C),
+                                        (D, D),
+                                        (D, D),
+                                        (D, D),
+                                        (D, D)])
 
         # Test that behaviour changes when does not know length.
         axelrod.seed(1)
         match = axelrod.Match((opponent, player), turns=5,
                               match_attributes={'length': float('inf')})
-        self.assertEqual(match.play(), [('D', 'C'),
-                                        ('D', 'C'),
-                                        ('D', 'C'),
-                                        ('D', 'C'),
-                                        ('D', 'C')])
+        self.assertEqual(match.play(), [(D, C),
+                                        (D, C),
+                                        (D, C),
+                                        (D, C),
+                                        (D, C)])
 
 
 class TestWorseAndWorse2(TestPlayer):
@@ -127,19 +127,19 @@ class TestWorseAndWorse2(TestPlayer):
         """
 
         # Test that first move is C
-        self.first_play_test('C')
+        self.first_play_test(C)
 
         # Test that given a history, next move matches opponent (round <= 20)
-        self.responses_test([C], [C], [C])
-        self.responses_test([C, C], [C, D], [D])
-        self.responses_test([C] * 19, [C] * 19, [C])
-        self.responses_test([C] * 19, [C] * 18 + [D], [D])
+        self.responses_test(C, C, C)
+        self.responses_test(D, C + C, C + D)
+        self.responses_test(C, C * 19, C * 19)
+        self.responses_test(D, C * 19, C * 18 + D)
 
         # Test that after round 20, strategy follows stochastic behaviour given
         # a seed
-        self.responses_test([C] * 20, [C] * 20, [C, D, C, C, C, C, D, C, C, C],
+        self.responses_test(C + D + C * 4 + D + C * 3, C * 20, C * 20,
                             random_seed=8)
-        self.responses_test([C] * 20, [C] * 20, [D, D, C, C, D, C, C, C, C, C],
+        self.responses_test(D * 2 + C * 2 + D + C * 5, C * 20, C * 20,
                             random_seed=2)
 
 
@@ -163,17 +163,16 @@ class TestWorseAndWorse3(TestPlayer):
         """
 
         # Test that first move is C
-        self.first_play_test('C')
+        self.first_play_test(C)
 
         # Test that if opponent only defects, strategy also defects
-        self.responses_test([D] * 5, [D] * 5, [D])
+        self.responses_test(D, D * 5, D * 5,)
 
         # Test that if opponent only cooperates, strategy also cooperates
-        self.responses_test([C] * 5, [C] * 5, [C])
+        self.responses_test(C, C * 5, C * 5)
 
         # Test that given a non 0/1 probability of defecting, strategy follows
         # stochastic behaviour, given a seed
-        self.responses_test([C] * 5, [C, D, C, D, C],
-                            [D, C, C, D, C, C, C, C, C, C], random_seed=8)
-        self.responses_test([C] * 5, [D] * 5, [D, D, D, C, C, D, D, D, C, C],
-                            random_seed=2)
+        self.responses_test(D + C + C + D + C * 6, C * 5, C + D + C + D + C,
+                            random_seed=8)
+        self.responses_test((D * 3 + C * 2) * 2, C * 5, D * 5, random_seed=2)

--- a/axelrod/tournament.py
+++ b/axelrod/tournament.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from collections import defaultdict
 from multiprocessing import Process, Queue, cpu_count
 from tempfile import NamedTemporaryFile
@@ -11,7 +9,9 @@ import warnings
 from axelrod import on_windows
 from .game import Game
 from .match import Match
-from .match_generator import RoundRobinMatches, ProbEndRoundRobinMatches, SpatialMatches, ProbEndSpatialMatches
+from .match_generator import (
+    RoundRobinMatches, ProbEndRoundRobinMatches, SpatialMatches,
+    ProbEndSpatialMatches)
 from .result_set import ResultSetFromFile, ResultSet
 
 
@@ -47,7 +47,6 @@ class Tournament(object):
         self.name = name
         self.turns = turns
         self.noise = noise
-        self.num_interactions = 0
         self.players = players
         self.repetitions = repetitions
         self.match_generator = match_generator(
@@ -75,7 +74,7 @@ class Tournament(object):
              processes=None, progress_bar=True,
              keep_interactions=False, in_memory=False):
         """
-        Plays the tournament and passes the results to the ResultSet class
+        Plays the tournament and passes the results to the ResultSet class.
 
         Parameters
         ----------
@@ -132,7 +131,7 @@ class Tournament(object):
     def _build_result_set(self, progress_bar=True, keep_interactions=False,
                           in_memory=False):
         """
-        Build the result set (used by the play method)
+        Build the result set (used by the play method).
 
         Returns
         -------
@@ -141,7 +140,6 @@ class Tournament(object):
         if not in_memory:
             result_set = ResultSetFromFile(filename=self.filename,
                                            progress_bar=progress_bar,
-                                           num_interactions=self.num_interactions,
                                            repetitions=self.repetitions,
                                            players=[str(p) for p in self.players],
                                            keep_interactions=keep_interactions,
@@ -150,7 +148,6 @@ class Tournament(object):
         else:
             result_set = ResultSet(players=[str(p) for p in self.players],
                                    interactions=self.interactions_dict,
-                                   num_interactions=self.num_interactions,
                                    repetitions=self.repetitions,
                                    progress_bar=progress_bar,
                                    game=self.game)
@@ -158,7 +155,7 @@ class Tournament(object):
 
     def _run_serial(self, progress_bar=False):
         """
-        Run all matches in serial
+        Run all matches in serial.
 
         Parameters
         ----------
@@ -196,7 +193,6 @@ class Tournament(object):
                 row.append(history1)
                 row.append(history2)
                 self.writer.writerow(row)
-                self.num_interactions += 1
 
     def _write_interactions_to_dict(self, results):
         """Write the interactions to memory"""
@@ -206,11 +202,10 @@ class Tournament(object):
                     self.interactions_dict[index_pair].append(interaction)
                 except KeyError:
                     self.interactions_dict[index_pair] = [interaction]
-                self.num_interactions += 1
 
     def _run_parallel(self, processes=2, progress_bar=False):
         """
-        Run all matches in parallel
+        Run all matches in parallel.
 
         Parameters
         ----------
@@ -270,7 +265,7 @@ class Tournament(object):
 
     def _process_done_queue(self, workers, done_queue, progress_bar=False):
         """
-        Retrieves the matches from the parallel sub-processes
+        Retrieves the matches from the parallel sub-processes.
 
         Parameters
         ----------
@@ -344,21 +339,18 @@ class Tournament(object):
 
 class ProbEndTournament(Tournament):
     """
-    A tournament in which the player don't know the length of a given match. The
-    length of a match is equivalent to randomly sampling after each round
+    A tournament in which the players don't know the length of a given match.
+    The length of a match is equivalent to randomly sampling after each round
     whether or not to continue.
     """
 
-    def __init__(self, players, match_generator=ProbEndRoundRobinMatches,
-                 name='axelrod', game=None, prob_end=.5, repetitions=10,
-                 noise=0, with_morality=True):
+    def __init__(self, players, name='axelrod', game=None, prob_end=.5,
+                 repetitions=10, noise=0, with_morality=True):
         """
         Parameters
         ----------
         players : list
             A list of axelrod.Player objects
-        match_generator : class
-            A class that must be descended from axelrod.MatchGenerator
         name : string
             A name for the tournament
         game : axelrod.Game
@@ -418,7 +410,7 @@ class SpatialTournament(Tournament):
 class ProbEndSpatialTournament(ProbEndTournament):
     """
     A tournament in which the players are allocated in a graph as nodes
-    and they players only play the others that are connected to with an edge.
+    and the players only play the others that are connected to with an edge.
     Players do not know the length of a given match (it is randomly sampled).
     """
     def __init__(self, players, edges, name='axelrod', game=None, prob_end=.5,

--- a/docs/reference/glossary.rst
+++ b/docs/reference/glossary.rst
@@ -48,7 +48,8 @@ used in the tournament is 200. Here is a single match between two players over
     >>> for turn in range(10):
     ...     p1.play(p2)
     >>> p1.history, p2.history
-    (['C', 'C', 'C', 'C', 'C', 'C', 'C', 'C', 'C', 'C'], ['D', 'D', 'D', 'D', 'D', 'D', 'D', 'D', 'D', 'D'])
+    (History: CCCCCCCCCC, History: DDDDDDDDDD)
+
 
 A win
 -----

--- a/docs/tutorials/contributing/strategy/writing_test_for_the_new_strategy.rst
+++ b/docs/tutorials/contributing/strategy/writing_test_for_the_new_strategy.rst
@@ -37,7 +37,7 @@ As an example, the tests for Tit-For-Tat are as follows::
 
         def test_effect_of_strategy(self):
             """Repeats last action of opponent history."""
-            self.markov_test([C, D, C, D])
+            self.second_play_test([C, D, C, D])
             self.responses_test([C] * 4, [C, C, C, C], [C])
             self.responses_test([C] * 5, [C, C, C, C, D], [D])
 
@@ -72,11 +72,11 @@ All three of these functions can take an optional keyword argument
         P2.history = []
         self.assertEqual(P1.strategy(P2), 'C')
 
-2. The member function :code:`markov_test` takes a list of four plays, each
+2. The member function :code:`second_play_test` takes a list of four plays, each
    following one round of CC, CD, DC, and DD respectively::
 
     def test_effect_of_strategy(self):
-        self.markov_test(['C', 'D', 'D', 'C'])
+        self.second_play_test(['C', 'D', 'D', 'C'])
 
    This is equivalent to::
 

--- a/docs/tutorials/getting_started/contributing.old
+++ b/docs/tutorials/getting_started/contributing.old
@@ -113,7 +113,7 @@ opponent has not played yet) will cooperate::
         except IndexError:
             return C
 
-The variables :code:`C` and :code:`D` represent the cooperate and defect actions respectively, and are importable from the main axelrod namespace.  
+The variables :code:`C` and :code:`D` represent the cooperate and defect actions respectively, and are importable from the main axelrod namespace.
 
 If your strategy creates any particular attribute along the way you need to make
 sure that there is a :code:`reset` method that takes account of it.  An example
@@ -313,10 +313,10 @@ This is equivalent to::
         P2.history = []
         self.assertEqual(P1.strategy(P2), 'C')
 
-2. The member function :code:`markov_test` takes a list of four plays, each following one round of CC, CD, DC, and DD respectively::
+2. The member function :code:`second_play_test` takes a list of four plays, each following one round of CC, CD, DC, and DD respectively::
 
     def test_effect_of_strategy(self):
-        self.markov_test(['C', 'D', 'D', 'C'])
+        self.second_play_test(['C', 'D', 'D', 'C'])
 
 This is equivalent to::
 


### PR DESCRIPTION
I've implemented two versions of a history class, with the underlying data structure being a list or a string. Both have similar performance, and there is definitely some overhead for using a history class rather than just a list -- the tests take a bit longer (about 25%) due to (1) more copying of lists and (2) overhead from additional function calls. I think the impact on tournaments will be less (testing now and will update).

Nevertheless there are advantages (as I mentioned at #806):
* We can treat history as a list or a string in all cases, e.g as `[C, C, D]`, "CCD", and even `C + C + D` and `(C * 2 + D * 3) * 2` for `[C, C, D, D, D, C, C, D, D, D]`
* The latter has some advantages since `"C" == C` and also acts as a container like `['C']`, so you can do thinks like `history[-1:] == C` and `history[-2:] == C + C` rather than `history[-1:] == [C]` and `history[-2:] == [C, C]` 
* No risk of failing to properly copy a history list, we can overload various methods (like the comparison to a list, str, etc.)
* We can add features and other boolean tests to the history class beyond what we have not with just cooperations and defections

I rewrote many tests to use the additive notation instead and made sure all the tests work with either the list or string implementations. Whether a bit vector or similar is ultimately better is an experiment for the future. However this notation is great because we can just refer to `C` and `D` universally, and if we decide to use `enum` or some other definition of the actions we should be able to handle it more easily.

Also in this PR (which could be separated):
* `markov_test([C, D, D, C])` is now `second_play_test(C, D, D, C)`. See #726
* `responses_test` got some upgrades -- you can pass `init_args` and `init_kwargs` so there's no need to construct players manually and use `test_responses`
* I changed the argument order to be `responses_test(responses, history1=None, history2=None, ...)` so you can test the first X actions with e.g. `responses_test(C + D + D + ...)`
* Some bugs around testing and I fixed some tests that were not actually testing anything or were not quite correct. For example `responses_test` was incorrect if `random_seed was 0`. In general we should avoid manually setting the history of a player for most testing purposes.
* Lots of PEP8 violations and typos were fixed, some tests consolidated
* Some Python 2 stuff (but I didn't go out of my way to look for specifics)
* `@init_args` now saves `kwargs` as well, which hopefully helps with #706 

What this PR still needs:
* documentation of the history class
* `JointHistory` is still WIP and can be moved out

If you are on board with these changes then I'll write up some docs and consolidate the remaining tests.