### PR TITLE
Dropping support for Python 2

### DIFF
--- a/axelrod/__init__.py
+++ b/axelrod/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import os
 
 on_windows = os.name == 'nt'

--- a/axelrod/deterministic_cache.py
+++ b/axelrod/deterministic_cache.py
@@ -1,9 +1,4 @@
-try:
-    # Python 2.x
-    from UserDict import UserDict
-except ImportError:
-    # Python 3.x
-    from collections import UserDict
+from collections import UserDict
 import pickle
 
 from axelrod import Player

--- a/axelrod/deterministic_cache.py
+++ b/axelrod/deterministic_cache.py
@@ -36,7 +36,7 @@ class DeterministicCache(UserDict):
         file_name : string
             Path to a previously saved cache file
         """
-        UserDict.__init__(self)
+        super().__init__()
         self.mutable = True
         if file_name is not None:
             self.load(file_name)
@@ -51,13 +51,13 @@ class DeterministicCache(UserDict):
         return key[0].name, key[1].name, key[2]
 
     def __delitem__(self, key):
-        return UserDict.__delitem__(self, self._key_transform(key))
+        return super().__delitem__(self._key_transform(key))
 
     def __getitem__(self, key):
-        return UserDict.__getitem__(self, self._key_transform(key))
+        return super().__getitem__(self._key_transform(key))
 
     def __contains__(self, key):
-        return UserDict.__contains__(self, self._key_transform(key))
+        return super().__contains__(self._key_transform(key))
 
     def __setitem__(self, key, value):
         """Overrides the UserDict.__setitem__ method in order to validate
@@ -73,7 +73,7 @@ class DeterministicCache(UserDict):
             raise ValueError(
                 'Value must be a list with length equal to turns attribute')
 
-        UserDict.__setitem__(self, self._key_transform(key), value)
+        super().__setitem__(self._key_transform(key), value)
 
     def _is_valid_key(self, key):
         """Validate a proposed dictionary key

--- a/axelrod/ecosystem.py
+++ b/axelrod/ecosystem.py
@@ -27,7 +27,7 @@ class Ecosystem(object):
                 norm = float(sum(population))
                 self.population_sizes = [[p / norm for p in population]]
         else:
-            self.population_sizes = [[1.0 / self.nplayers for i in range(self.nplayers)]]
+            self.population_sizes = [[1 / self.nplayers for i in range(self.nplayers)]]
 
         # This function is quite arbitrary and probably only influences the
         # kinetics for the current code.

--- a/axelrod/ecosystem.py
+++ b/axelrod/ecosystem.py
@@ -24,7 +24,7 @@ class Ecosystem(object):
             elif len(population) != self.nplayers:
                 raise TypeError("Population vector must be same size as number of players")
             else:
-                norm = float(sum(population))
+                norm = sum(population)
                 self.population_sizes = [[p / norm for p in population]]
         else:
             self.population_sizes = [[1 / self.nplayers for i in range(self.nplayers)]]

--- a/axelrod/interaction_utils.py
+++ b/axelrod/interaction_utils.py
@@ -136,12 +136,12 @@ def compute_normalised_state_distribution(interactions):
     return normalized_count
 
 
-def sparkline(actions, c_symbol=u'█', d_symbol=u' '):
-    return u''.join([
+def sparkline(actions, c_symbol='█', d_symbol=' '):
+    return ''.join([
         c_symbol if play == 'C' else d_symbol for play in actions])
 
 
-def compute_sparklines(interactions, c_symbol=u'█', d_symbol=u' '):
+def compute_sparklines(interactions, c_symbol='█', d_symbol=' '):
     """Returns the sparklines for a set of interactions"""
     if len(interactions) == 0:
         return None
@@ -149,7 +149,7 @@ def compute_sparklines(interactions, c_symbol=u'█', d_symbol=u' '):
     histories = list(zip(*interactions))
     return (
         sparkline(histories[0], c_symbol, d_symbol) +
-        u'\n' +
+        '\n' +
         sparkline(histories[1], c_symbol, d_symbol))
 
 

--- a/axelrod/interaction_utils.py
+++ b/axelrod/interaction_utils.py
@@ -46,7 +46,7 @@ def compute_final_score_per_turn(interactions, game=None):
         return None
 
     final_score_per_turn = tuple(
-        sum([score[player_index] for score in scores]) / (float(num_turns))
+        sum([score[player_index] for score in scores]) / num_turns
         for player_index in [0, 1])
     return final_score_per_turn
 

--- a/axelrod/interaction_utils.py
+++ b/axelrod/interaction_utils.py
@@ -129,10 +129,7 @@ def compute_normalised_state_distribution(interactions):
         return None
 
     interactions_count = Counter(interactions)
-    total = sum(interactions_count.values(), 0.0)
-    # By starting the sum with 0.0 we make sure total is a floating point value,
-    # avoiding the Python 2 floor division behaviour of / with integer operands
-    # (Stack Overflow)
+    total = sum(interactions_count.values(), 0)
 
     normalized_count = Counter({key: value / total for key, value in
                                 interactions_count.items()})

--- a/axelrod/interaction_utils.py
+++ b/axelrod/interaction_utils.py
@@ -83,7 +83,7 @@ def compute_normalised_cooperation(interactions):
     num_turns = len(interactions)
     cooperation = compute_cooperations(interactions)
 
-    normalised_cooperation = tuple([c / float(num_turns) for c in cooperation])
+    normalised_cooperation = tuple([c / num_turns for c in cooperation])
 
     return normalised_cooperation
 

--- a/axelrod/match.py
+++ b/axelrod/match.py
@@ -171,7 +171,7 @@ class Match(object):
         """
         return iu.compute_normalised_state_distribution(self.result)
 
-    def sparklines(self, c_symbol=u'█', d_symbol=u' '):
+    def sparklines(self, c_symbol='█', d_symbol=' '):
         return iu.compute_sparklines(self.result, c_symbol, d_symbol)
 
     def __len__(self):

--- a/axelrod/match_generator.py
+++ b/axelrod/match_generator.py
@@ -1,4 +1,3 @@
-from __future__ import division
 from math import ceil, log
 import random
 
@@ -165,7 +164,7 @@ class ProbEndRoundRobinMatches(RoundRobinMatches):
 
     def estimated_size(self):
         """Rough estimate of the number of matches that will be generated."""
-        size = self.__len__() * (1. / self.prob_end) * self.repetitions
+        size = self.__len__() * (1 / self.prob_end) * self.repetitions
         return size
 
 

--- a/axelrod/match_generator.py
+++ b/axelrod/match_generator.py
@@ -112,7 +112,7 @@ class ProbEndRoundRobinMatches(RoundRobinMatches):
         noise : float, 0
             The probability that a player's intended action should be flipped
         """
-        super(ProbEndRoundRobinMatches, self).__init__(
+        super().__init__(
             players, turns=float("inf"), game=game, repetitions=repetitions,
             noise=noise)
         self.prob_end = prob_end
@@ -220,8 +220,7 @@ class SpatialMatches(RoundRobinMatches):
         if not graph_is_connected(edges, players):
             raise ValueError("The graph edges do not include all players.")
         self.edges = edges
-        super(SpatialMatches, self).__init__(players, turns, game, repetitions,
-                                             noise)
+        super().__init__(players, turns, game, repetitions, noise)
 
     def build_match_chunks(self):
         for edge in self.edges:

--- a/axelrod/mock_player.py
+++ b/axelrod/mock_player.py
@@ -12,7 +12,7 @@ class MockPlayer(Player):
     def __init__(self, player, move):
         # Need to retain history for opponents that examine opponents history
         # Do a deep copy just to be safe
-        Player.__init__(self)
+        super().__init__()
         self.history = copy.deepcopy(player.history)
         self.cooperations = player.cooperations
         self.defections = player.defections

--- a/axelrod/moran.py
+++ b/axelrod/moran.py
@@ -304,7 +304,7 @@ class MoranProcessGraph(MoranProcess):
         match_class: subclass of Match
             The match type to use for scoring
         """
-        MoranProcess.__init__(self, players, turns=turns, noise=noise,
+        super().__init__(players, turns=turns, noise=noise,
                               deterministic_cache=deterministic_cache,
                               mutation_rate=mutation_rate, mode=mode)
         if not reproduction_graph:

--- a/axelrod/plot.py
+++ b/axelrod/plot.py
@@ -233,7 +233,7 @@ class Plot(object):
         ticks = []
         for i, n in enumerate(self.result_set.ranked_names):
             x = -0.01
-            y = (i + 0.5) * 1.0 / self.result_set.nplayers
+            y = (i + 0.5) * 1 / self.result_set.nplayers
             ax.annotate(n, xy=(x, y), xycoords=trans, clip_on=False,
                              va='center', ha='right', fontsize=5)
             ticks.append(y)

--- a/axelrod/result_set.py
+++ b/axelrod/result_set.py
@@ -200,7 +200,7 @@ class ResultSet(object):
                    enumerate(total_length_v_opponent)]
 
         # Max is to deal with edge cases of matches that have no turns
-        return [sum(cs) / max(1, float(sum(ls))) for cs, ls
+        return [sum(cs) / max(1, sum(ls)) for cs, ls
                 in zip(self.cooperation, lengths)]
 
     @update_progress_bar
@@ -622,7 +622,7 @@ class ResultSet(object):
         attribute
         """
         return [sum(self.good_partner_matrix[player]) /
-                max(1, float(self.total_interactions[player]))
+                max(1, self.total_interactions[player])
                 for player in range(self.nplayers)]
 
     @update_progress_bar
@@ -632,7 +632,7 @@ class ResultSet(object):
         cooperation rate attribute
         """
         return [self.initial_cooperation_count[player] /
-                max(1, float(self.total_interactions[player]))
+                max(1, self.total_interactions[player])
                 for player in range(self.nplayers)]
 
     def _build_score_related_metrics(self, progress_bar=False,
@@ -783,7 +783,7 @@ class ResultSet(object):
                 p = sum([opp[state] for j, opp in enumerate(player) if i != j])
                 counts.append(p)
             try:
-                counts = [float(c) / sum(counts) for c in counts]
+                counts = [c / sum(counts) for c in counts]
             except ZeroDivisionError:
                 counts = [0 for c in counts]
             state_prob.append(counts)

--- a/axelrod/result_set.py
+++ b/axelrod/result_set.py
@@ -354,7 +354,7 @@ class ResultSet(object):
             counters = []
             for counter in player:
                 total = sum(counter.values())
-                counters.append(Counter({key: float(value) / total for
+                counters.append(Counter({key: value / total for
                                          key, value in counter.items()}))
             norm.append(counters)
         return norm

--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from .alternator import Alternator
 from .adaptive import Adaptive
 from .ann import EvolvedANN, EvolvedANN5, EvolvedANNNoise05

--- a/axelrod/strategies/adaptive.py
+++ b/axelrod/strategies/adaptive.py
@@ -26,7 +26,7 @@ class Adaptive(Player):
 
     @init_args
     def __init__(self, initial_plays=None):
-        Player.__init__(self)
+        super().__init__()
         if not initial_plays:
             initial_plays = [C] * 6 + [D] * 5
         self.initial_plays = initial_plays
@@ -53,5 +53,5 @@ class Adaptive(Player):
         return D
 
     def reset(self):
-        Player.reset(self)
+        super().reset()
         self.scores = {C: 0, D: 0}

--- a/axelrod/strategies/ann.py
+++ b/axelrod/strategies/ann.py
@@ -64,7 +64,7 @@ class ANN(Player):
 
     @init_args
     def __init__(self, weights, num_features, num_hidden):
-        Player.__init__(self)
+        super().__init__()
         (i2h, h2o, bias) = split_weights(weights, num_features, num_hidden)
         self.input_to_hidden_layer_weights = i2h
         self.hidden_to_output_layer_weights = h2o
@@ -192,7 +192,7 @@ class EvolvedANN(ANN):
     @init_args
     def __init__(self):
         num_features, num_hidden, weights = nn_weights["Evolved ANN"]
-        ANN.__init__(self, weights, num_features, num_hidden)
+        super().__init__(weights, num_features, num_hidden)
 
 
 class EvolvedANN5(ANN):
@@ -210,7 +210,7 @@ class EvolvedANN5(ANN):
     @init_args
     def __init__(self):
         num_features, num_hidden, weights = nn_weights["Evolved ANN 5"]
-        ANN.__init__(self, weights, num_features, num_hidden)
+        super().__init__(weights, num_features, num_hidden)
 
 
 class EvolvedANNNoise05(ANN):
@@ -228,4 +228,4 @@ class EvolvedANNNoise05(ANN):
     @init_args
     def __init__(self):
         num_features, num_hidden, weights = nn_weights["Evolved ANN 5 Noise 05"]
-        ANN.__init__(self, weights, num_features, num_hidden)
+        super().__init__(weights, num_features, num_hidden)

--- a/axelrod/strategies/apavlov.py
+++ b/axelrod/strategies/apavlov.py
@@ -26,7 +26,7 @@ class APavlov2006(Player):
     }
 
     def __init__(self):
-        Player.__init__(self)
+        super().__init__()
         self.opponent_class = None
 
     def strategy(self, opponent):
@@ -66,7 +66,7 @@ class APavlov2006(Player):
         return C
 
     def reset(self):
-        Player.reset(self)
+        super().reset()
         self.opponent_class = None
 
 
@@ -93,7 +93,7 @@ class APavlov2011(Player):
     }
 
     def __init__(self):
-        Player.__init__(self)
+        super().__init__()
         self.opponent_class = None
 
     def strategy(self, opponent):
@@ -121,5 +121,5 @@ class APavlov2011(Player):
             return D if opponent.history[-1:] == [D] else C
 
     def reset(self):
-        Player.reset(self)
+        super().reset()
         self.opponent_class = None

--- a/axelrod/strategies/axelrod_first.py
+++ b/axelrod/strategies/axelrod_first.py
@@ -42,7 +42,7 @@ class Davis(Player):
         rounds_to_cooperate: int, 10
            The number of rounds to cooperate initially
         """
-        Player.__init__(self)
+        super().__init__()
         self._rounds_to_cooperate = rounds_to_cooperate
 
     def strategy(self, opponent):
@@ -78,7 +78,7 @@ class RevisedDowning(Player):
 
     @init_args
     def __init__(self, revised=True):
-        Player.__init__(self)
+        super().__init__()
         self.revised = revised
         self.good = 1.0
         self.bad = 0.0
@@ -127,7 +127,7 @@ class RevisedDowning(Player):
         return self.move
 
     def reset(self):
-        Player.reset(self)
+        super().reset()
         self.good = 1.0
         self.bad = 0.0
         self.nice1 = 0
@@ -173,7 +173,7 @@ class Feld(Player):
             The number of rounds to linearly decrease from start_coop_prob
             to end_coop_prob
         """
-        Player.__init__(self)
+        super().__init__()
         self._start_coop_prob = start_coop_prob
         self._end_coop_prob = end_coop_prob
         self._rounds_of_decay = rounds_of_decay
@@ -259,7 +259,7 @@ class Joss(MemoryOnePlayer):
         """
         four_vector = (p, 0, p, 0)
         self.p = p
-        super(Joss, self).__init__(four_vector)
+        super().__init__(four_vector)
 
     def __repr__(self):
         return "%s: %s" % (self.name, round(self.p, 2))
@@ -299,7 +299,7 @@ class Nydegger(Player):
                           (C, D): 2,
                           (D, C): 1,
                           (D, D): 3}
-        super(Nydegger, self).__init__()
+        super().__init__()
 
     @staticmethod
     def score_history(my_history, opponent_history, score_map):
@@ -354,7 +354,7 @@ class Shubik(Player):
     }
 
     def __init__(self):
-        Player.__init__(self)
+        super().__init__()
         self.is_retaliating = False
         self.retaliation_length = 0
         self.retaliation_remaining = 0
@@ -391,7 +391,7 @@ class Shubik(Player):
         return C
 
     def reset(self):
-        Player.reset(self)
+        super().reset()
         self.is_retaliating = False
         self.retaliation_length = 0
         self.retaliation_remaining = 0
@@ -428,7 +428,7 @@ class Tullock(Player):
         rounds_to_cooperate: int, 10
            The number of rounds to cooperate initially
         """
-        Player.__init__(self)
+        super().__init__()
         self._rounds_to_cooperate = rounds_to_cooperate
         self.__class__.memory_depth = rounds_to_cooperate
 

--- a/axelrod/strategies/axelrod_first.py
+++ b/axelrod/strategies/axelrod_first.py
@@ -109,12 +109,12 @@ class RevisedDowning(Player):
                 if opponent.history[-1] == C:
                     self.nice2 += 1
                 self.total_D += 1
-                self.bad = float(self.nice2) / self.total_D
+                self.bad = self.nice2 / self.total_D
             else:
                 if opponent.history[-1] == C:
                     self.nice1 += 1
                 self.total_C += 1
-                self.good = float(self.nice1) / self.total_C
+                self.good = self.nice1 / self.total_C
         # Make a decision based on the accrued counts
         c = 6.0 * self.good - 8.0 * self.bad - 2
         alt = 4.0 * self.good - 5.0 * self.bad - 1
@@ -183,7 +183,7 @@ class Feld(Player):
         something simple that decreases monotonically from 1.0 to 0.5 over
         200 rounds."""
         diff = (self._end_coop_prob - self._start_coop_prob)
-        slope = diff / float(self._rounds_of_decay)
+        slope = diff / self._rounds_of_decay
         rounds = len(self.history)
         return max(self._start_coop_prob + slope * rounds,
                    self._end_coop_prob)
@@ -229,7 +229,7 @@ class Grofman(Player):
             return opponent.history[-1]
         if self.history[-1] == opponent.history[-1]:
             return C
-        return random_choice(2./ 7)
+        return random_choice(2 / 7)
 
 
 
@@ -437,7 +437,7 @@ class Tullock(Player):
         if len(self.history) < rounds:
             return C
         cooperate_count = opponent.history[-rounds:].count(C)
-        prop_cooperate = cooperate_count / float(rounds)
+        prop_cooperate = cooperate_count / rounds
         prob_cooperate = max(0, prop_cooperate - 0.10)
         return random_choice(prob_cooperate)
 
@@ -480,5 +480,5 @@ class UnnamedStrategy(Player):
 
     @staticmethod
     def strategy(opponent):
-        r = random.uniform(3, 7) / float(10)
+        r = random.uniform(3, 7) / 10
         return random_choice(r)

--- a/axelrod/strategies/axelrod_second.py
+++ b/axelrod/strategies/axelrod_second.py
@@ -37,13 +37,13 @@ class Champion(Player):
         # Cooperate for the first 1/20-th of the game
         if current_round == 0:
             return C
-        if current_round < expected_length / 20.:
+        if current_round < expected_length / 20:
             return C
         # Mirror partner for the next phase
-        if current_round < expected_length * 5 / 40.:
+        if current_round < expected_length * 5 / 40:
             return opponent.history[-1]
         # Now cooperate unless all of the necessary conditions are true
-        defection_prop = float(opponent.defections) / len(opponent.history)
+        defection_prop = opponent.defections / len(opponent.history)
         if opponent.history[-1] == D:
             r = random.random()
             if defection_prop > max(0.4, r):
@@ -83,7 +83,7 @@ class Eatherley(Player):
             return C
         # Respond to defections with probability equal to opponent's total
         # proportion of defections
-        defection_prop = float(opponent.defections) / len(opponent.history)
+        defection_prop = opponent.defections / len(opponent.history)
         return random_choice(1 - defection_prop)
 
 

--- a/axelrod/strategies/axelrod_second.py
+++ b/axelrod/strategies/axelrod_second.py
@@ -110,7 +110,7 @@ class Tester(Player):
     }
 
     def __init__(self):
-        Player.__init__(self)
+        super().__init__()
         self.is_TFT = False
 
     def strategy(self, opponent):
@@ -131,5 +131,5 @@ class Tester(Player):
             return flip_action(self.history[-1])
 
     def reset(self):
-        Player.reset(self)
+        super().reset()
         self.is_TFT = False

--- a/axelrod/strategies/calculator.py
+++ b/axelrod/strategies/calculator.py
@@ -21,7 +21,7 @@ class Calculator(Player):
     }
 
     def __init__(self):
-        Player.__init__(self)
+        super().__init__()
         self.joss_instance = Joss()
 
     def strategy(self, opponent):
@@ -44,5 +44,5 @@ class Calculator(Player):
             return Actions.D if opponent.history[-1:] == [Actions.D] else Actions.C
 
     def reset(self):
-        Player.reset(self)
+        super().reset()
         self.joss_instance = Joss()

--- a/axelrod/strategies/cycler.py
+++ b/axelrod/strategies/cycler.py
@@ -21,7 +21,7 @@ class AntiCycler(Player):
     }
 
     def __init__(self):
-        Player.__init__(self)
+        super().__init__()
         self.cycle_length = 1
         self.cycle_counter = 0
 
@@ -35,7 +35,7 @@ class AntiCycler(Player):
             return Actions.D
 
     def reset(self):
-        Player.reset(self)
+        super().reset()
         self.cycle_length = 1
         self.cycle_counter = 0
 
@@ -66,7 +66,7 @@ class Cycler(Player):
         Alternator is equivalent to Cycler("CD")
 
         """
-        Player.__init__(self)
+        super().__init__()
         self.cycle = cycle
         self.name = "Cycler {}".format(cycle)
         self.classifier['memory_depth'] = len(cycle) - 1
@@ -85,7 +85,7 @@ class CyclerDC(Cycler):
 
     @init_args
     def __init__(self, cycle="DC"):
-        Cycler.__init__(self, cycle=cycle)
+        super().__init__(cycle=cycle)
 
 
 class CyclerCCD(Cycler):
@@ -96,7 +96,7 @@ class CyclerCCD(Cycler):
 
     @init_args
     def __init__(self, cycle="CCD"):
-        Cycler.__init__(self, cycle=cycle)
+        super().__init__(cycle=cycle)
 
 
 class CyclerDDC(Cycler):
@@ -107,7 +107,7 @@ class CyclerDDC(Cycler):
 
     @init_args
     def __init__(self, cycle="DDC"):
-        Cycler.__init__(self, cycle=cycle)
+        super().__init__(cycle=cycle)
 
 
 class CyclerCCCD(Cycler):
@@ -118,7 +118,7 @@ class CyclerCCCD(Cycler):
 
     @init_args
     def __init__(self, cycle="CCCD"):
-        Cycler.__init__(self, cycle=cycle)
+        super().__init__(cycle=cycle)
 
 
 class CyclerCCCCCD(Cycler):
@@ -129,7 +129,7 @@ class CyclerCCCCCD(Cycler):
 
     @init_args
     def __init__(self, cycle="CCCCCD"):
-        Cycler.__init__(self, cycle=cycle)
+        super().__init__(cycle=cycle)
 
 
 class CyclerCCCDCD(Cycler):
@@ -140,4 +140,4 @@ class CyclerCCCDCD(Cycler):
 
     @init_args
     def __init__(self, cycle="CCCDCD"):
-        Cycler.__init__(self, cycle=cycle)
+        super().__init__(cycle=cycle)

--- a/axelrod/strategies/darwin.py
+++ b/axelrod/strategies/darwin.py
@@ -36,7 +36,7 @@ class Darwin(Player):
     valid_callers = ["play"]    # What functions may invoke our strategy.
 
     def __init__(self):
-        super(Darwin, self).__init__()
+        super().__init__()
         self.response = Darwin.genome[0]
 
     def receive_match_attributes(self):
@@ -68,7 +68,7 @@ class Darwin(Player):
 
     def reset(self):
         """ Reset instance properties. """
-        Player.reset(self)
+        super().reset()
         Darwin.genome[0] = C # Ensure initial Cooperate
 
     def mutate(self, outcome, trial):

--- a/axelrod/strategies/finite_state_machines.py
+++ b/axelrod/strategies/finite_state_machines.py
@@ -55,7 +55,7 @@ class FSMPlayer(Player):
             transitions = [(1, C, 1, C), (1, D, 1, D)]
             initial_state = 1
             initial_action = C
-        Player.__init__(self)
+        super().__init__()
         self.initial_state = initial_state
         self.initial_action = initial_action
         self.fsm = SimpleFSM(transitions, initial_state)
@@ -71,7 +71,7 @@ class FSMPlayer(Player):
             return action
 
     def reset(self):
-        Player.reset(self)
+        super().reset()
         self.fsm.state = self.initial_state
 
 
@@ -102,7 +102,7 @@ class Fortress3(FSMPlayer):
             (3, D, 1, D)
         )
 
-        FSMPlayer.__init__(self, transitions, initial_state=1, initial_action=D)
+        super().__init__(transitions, initial_state=1, initial_action=D)
 
 
 class Fortress4(FSMPlayer):
@@ -134,7 +134,7 @@ class Fortress4(FSMPlayer):
             (4, D, 1, D)
         )
 
-        FSMPlayer.__init__(self, transitions, initial_state=1, initial_action=D)
+        super().__init__(transitions, initial_state=1, initial_action=D)
 
 
 class Predator(FSMPlayer):
@@ -174,7 +174,7 @@ class Predator(FSMPlayer):
             (8, D, 6, D)
         )
 
-        FSMPlayer.__init__(self, transitions, initial_state=1, initial_action=C)
+        super().__init__(transitions, initial_state=1, initial_action=C)
 
 
 class Pun1(FSMPlayer):
@@ -204,7 +204,7 @@ class Pun1(FSMPlayer):
             (2, D, 1, D)
         )
 
-        FSMPlayer.__init__(self, transitions, initial_state=1, initial_action=D)
+        super().__init__(transitions, initial_state=1, initial_action=D)
 
 
 class Raider(FSMPlayer):
@@ -234,7 +234,7 @@ class Raider(FSMPlayer):
             (3, D, 1, C)
         )
 
-        FSMPlayer.__init__(self, transitions, initial_state=0, initial_action=D)
+        super().__init__(transitions, initial_state=0, initial_action=D)
 
 
 class Ripoff(FSMPlayer):
@@ -262,7 +262,7 @@ class Ripoff(FSMPlayer):
             (3, D, 3, D)
         )
 
-        FSMPlayer.__init__(self, transitions, initial_state=1, initial_action=D)
+        super().__init__(transitions, initial_state=1, initial_action=D)
 
 
 class SolutionB1(FSMPlayer):
@@ -290,7 +290,7 @@ class SolutionB1(FSMPlayer):
             (3, D, 3, C)
         )
 
-        FSMPlayer.__init__(self, transitions, initial_state=1, initial_action=D)
+        super().__init__(transitions, initial_state=1, initial_action=D)
 
 
 class SolutionB5(FSMPlayer):
@@ -324,7 +324,7 @@ class SolutionB5(FSMPlayer):
             (6, D, 5, D)
         )
 
-        FSMPlayer.__init__(self, transitions, initial_state=1, initial_action=D)
+        super().__init__(transitions, initial_state=1, initial_action=D)
 
 
 class Thumper(FSMPlayer):
@@ -350,7 +350,7 @@ class Thumper(FSMPlayer):
             (2, D, 1, D)
         )
 
-        FSMPlayer.__init__(self, transitions, initial_state=1, initial_action=C)
+        super().__init__(transitions, initial_state=1, initial_action=C)
 
 
 class EvolvedFSM4(FSMPlayer):
@@ -386,7 +386,7 @@ class EvolvedFSM4(FSMPlayer):
             (3, D, 1, D)
         )
 
-        FSMPlayer.__init__(self, transitions, initial_state=0, initial_action=C)
+        super().__init__(transitions, initial_state=0, initial_action=C)
 
 
 class EvolvedFSM16(FSMPlayer):
@@ -447,7 +447,7 @@ class EvolvedFSM16(FSMPlayer):
             (15, D, 2, C)
         )
 
-        FSMPlayer.__init__(self, transitions, initial_state=0, initial_action=C)
+        super().__init__(transitions, initial_state=0, initial_action=C)
 
 
 class EvolvedFSM16Noise05(FSMPlayer):
@@ -508,4 +508,4 @@ class EvolvedFSM16Noise05(FSMPlayer):
             (15, D, 11, C)
         )
 
-        FSMPlayer.__init__(self, transitions, initial_state=0, initial_action=C)
+        super().__init__(transitions, initial_state=0, initial_action=C)

--- a/axelrod/strategies/forgiver.py
+++ b/axelrod/strategies/forgiver.py
@@ -24,7 +24,7 @@ class Forgiver(Player):
         """
         Begins by playing C, then plays D if the opponent has defected more than 10 percent of the time
         """
-        if opponent.defections > len(opponent.history) / 10.:
+        if opponent.defections > len(opponent.history) / 10:
             return D
         return C
 
@@ -54,6 +54,6 @@ class ForgivingTitForTat(Player):
         the opponent has defected more than 10 percent of the time,
         and their most recent decision was defect.
         """
-        if opponent.defections > len(opponent.history) / 10.:
+        if opponent.defections > len(opponent.history) / 10:
             return opponent.history[-1]
         return C

--- a/axelrod/strategies/gambler.py
+++ b/axelrod/strategies/gambler.py
@@ -55,7 +55,7 @@ class PSOGamblerMem1(Gambler):
         lookup_table = create_lookup_table_from_pattern(
             plays=1, op_plays=1, op_start_plays=0,
             pattern=pattern)
-        Gambler.__init__(self, lookup_table=lookup_table)
+        super().__init__(lookup_table=lookup_table)
         self.classifier['memory_depth'] = 1
 
 
@@ -74,7 +74,7 @@ class PSOGambler1_1_1(Gambler):
         lookup_table = create_lookup_table_from_pattern(
             plays=1, op_plays=1, op_start_plays=1,
             pattern=pattern)
-        Gambler.__init__(self, lookup_table=lookup_table)
+        super().__init__(lookup_table=lookup_table)
 
 
 class PSOGambler2_2_2(Gambler):
@@ -92,7 +92,7 @@ class PSOGambler2_2_2(Gambler):
         lookup_table = create_lookup_table_from_pattern(
             plays=2, op_plays=2, op_start_plays=2,
             pattern=pattern)
-        Gambler.__init__(self, lookup_table=lookup_table)
+        super().__init__(lookup_table=lookup_table)
 
 
 class PSOGambler2_2_2_Noise05(Gambler):
@@ -111,4 +111,4 @@ class PSOGambler2_2_2_Noise05(Gambler):
         lookup_table = create_lookup_table_from_pattern(
             plays=2, op_plays=2, op_start_plays=2,
             pattern=pattern)
-        Gambler.__init__(self, lookup_table=lookup_table)
+        super().__init__(lookup_table=lookup_table)

--- a/axelrod/strategies/gobymajority.py
+++ b/axelrod/strategies/gobymajority.py
@@ -42,7 +42,7 @@ class GoByMajority(Player):
             cooperation and defection probabilities are equal.
         """
 
-        Player.__init__(self)
+        super().__init__()
         self.soft = soft
         self.classifier['memory_depth'] = memory_depth
         if self.classifier['memory_depth'] < float('inf'):
@@ -88,8 +88,7 @@ class GoByMajority40(GoByMajority):
 
     @init_args
     def __init__(self, memory_depth=40, soft=True):
-        super(GoByMajority40, self).__init__(memory_depth=memory_depth,
-                                             soft=soft)
+        super().__init__(memory_depth=memory_depth, soft=soft)
 
 
 class GoByMajority20(GoByMajority):
@@ -102,8 +101,7 @@ class GoByMajority20(GoByMajority):
 
     @init_args
     def __init__(self, memory_depth=20, soft=True):
-        super(GoByMajority20, self).__init__(memory_depth=memory_depth,
-                                                 soft=soft)
+        super().__init__(memory_depth=memory_depth, soft=soft)
 
 
 class GoByMajority10(GoByMajority):
@@ -116,8 +114,7 @@ class GoByMajority10(GoByMajority):
 
     @init_args
     def __init__(self, memory_depth=10, soft=True):
-        super(GoByMajority10, self).__init__(memory_depth=memory_depth,
-                                                 soft=soft)
+        super().__init__(memory_depth=memory_depth, soft=soft)
 
 
 class GoByMajority5(GoByMajority):
@@ -130,8 +127,7 @@ class GoByMajority5(GoByMajority):
 
     @init_args
     def __init__(self, memory_depth=5, soft=True):
-        super(GoByMajority5, self).__init__(memory_depth=memory_depth,
-                                                soft=soft)
+        super().__init__(memory_depth=memory_depth, soft=soft)
 
 
 class HardGoByMajority(GoByMajority):
@@ -146,8 +142,7 @@ class HardGoByMajority(GoByMajority):
 
     @init_args
     def __init__(self, memory_depth=float('inf'), soft=False):
-        super(HardGoByMajority, self).__init__(memory_depth=memory_depth,
-                                               soft=soft)
+        super().__init__(memory_depth=memory_depth, soft=soft)
 
 
 class HardGoByMajority40(HardGoByMajority):
@@ -160,8 +155,7 @@ class HardGoByMajority40(HardGoByMajority):
 
     @init_args
     def __init__(self, memory_depth=40, soft=False):
-        super(HardGoByMajority40, self).__init__(memory_depth=memory_depth,
-                                                 soft=soft)
+        super().__init__(memory_depth=memory_depth, soft=soft)
 
 
 class HardGoByMajority20(HardGoByMajority):
@@ -174,8 +168,7 @@ class HardGoByMajority20(HardGoByMajority):
 
     @init_args
     def __init__(self, memory_depth=20, soft=False):
-        super(HardGoByMajority20, self).__init__(memory_depth=memory_depth,
-                                                 soft=soft)
+        super().__init__(memory_depth=memory_depth, soft=soft)
 
 
 class HardGoByMajority10(HardGoByMajority):
@@ -188,8 +181,7 @@ class HardGoByMajority10(HardGoByMajority):
 
     @init_args
     def __init__(self, memory_depth=10, soft=False):
-        super(HardGoByMajority10, self).__init__(memory_depth=memory_depth,
-                                                 soft=soft)
+        super().__init__(memory_depth=memory_depth, soft=soft)
 
 
 class HardGoByMajority5(HardGoByMajority):
@@ -202,5 +194,4 @@ class HardGoByMajority5(HardGoByMajority):
 
     @init_args
     def __init__(self, memory_depth=5, soft=False):
-        super(HardGoByMajority5, self).__init__(memory_depth=memory_depth,
-                                                soft=soft)
+        super().__init__(memory_depth=memory_depth, soft=soft)

--- a/axelrod/strategies/grudger.py
+++ b/axelrod/strategies/grudger.py
@@ -52,7 +52,7 @@ class ForgetfulGrudger(Player):
 
     def __init__(self):
         """Initialised the player."""
-        super(ForgetfulGrudger, self).__init__()
+        super().__init__()
         self.mem_length = 10
         self.grudged = False
         self.grudge_memory = 0
@@ -74,7 +74,7 @@ class ForgetfulGrudger(Player):
 
     def reset(self):
         """Resets scores and history."""
-        Player.reset(self)
+        super().reset()
         self.grudged = False
         self.grudge_memory = 0
 
@@ -151,7 +151,7 @@ class SoftGrudger(Player):
 
     def __init__(self):
         """Initialised the player."""
-        super(SoftGrudger, self).__init__()
+        super().__init__()
         self.grudged = False
         self.grudge_memory = 0
 
@@ -172,7 +172,7 @@ class SoftGrudger(Player):
 
     def reset(self):
         """Resets scores and history."""
-        Player.reset(self)
+        super().reset()
         self.grudged = False
         self.grudge_memory = 0
 

--- a/axelrod/strategies/grumpy.py
+++ b/axelrod/strategies/grumpy.py
@@ -33,7 +33,7 @@ class Grumpy(Player):
             The threshold of opponent defections - cooperations to become
             nice
         """
-        super(Grumpy, self).__init__()
+        super().__init__()
         self.history = []
         self.state = starting_state
         self.starting_state = starting_state
@@ -64,5 +64,5 @@ class Grumpy(Player):
 
     def reset(self):
         """Resets score, history and state for the next round of the tournement."""
-        Player.reset(self)
+        super().reset()
         self.state = self.starting_state

--- a/axelrod/strategies/handshake.py
+++ b/axelrod/strategies/handshake.py
@@ -25,7 +25,7 @@ class Handshake(Player):
 
     @init_args
     def __init__(self, initial_plays=None):
-        Player.__init__(self)
+        super().__init__()
         if not initial_plays:
             initial_plays = [C, D]
         self.initial_plays = initial_plays

--- a/axelrod/strategies/hmm.py
+++ b/axelrod/strategies/hmm.py
@@ -102,7 +102,7 @@ class HMMPlayer(Player):
     def __init__(self, transitions_C=None, transitions_D=None,
                  emission_probabilities=None, initial_state=0,
                  initial_action=C):
-        Player.__init__(self)
+        super().__init__()
         if not transitions_C:
             transitions_C = [[1]]
             transitions_D = [[1]]
@@ -138,7 +138,7 @@ class HMMPlayer(Player):
             return action
 
     def reset(self):
-        Player.reset(self)
+        super().reset()
         self.hmm.state = self.initial_state
 
 
@@ -181,6 +181,6 @@ class EvolvedHMM5(HMMPlayer):
                [0, 0.287, 0.456, 0.146, 0.111]]
 
         emissions = [1, 0, 0, 1, 0.111]
-        HMMPlayer.__init__(self, t_C, t_D, emissions, initial_state,
+        super().__init__(t_C, t_D, emissions, initial_state,
                            initial_action)
 

--- a/axelrod/strategies/human.py
+++ b/axelrod/strategies/human.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from os import linesep
 from axelrod import Actions, Player, init_args
 from prompt_toolkit import prompt

--- a/axelrod/strategies/human.py
+++ b/axelrod/strategies/human.py
@@ -64,7 +64,7 @@ class Human(Player):
             A symbol to denote defection within the history toolbar
             and prompt
         """
-        Player.__init__(self)
+        super().__init__()
         self.name = name
         self.symbols = {
             C: c_symbol,

--- a/axelrod/strategies/hunter.py
+++ b/axelrod/strategies/hunter.py
@@ -189,9 +189,9 @@ class RandomHunter(Player):
         if n > 10:
             probabilities = []
             if self.cooperations > 5:
-                probabilities.append(1.0 * self.countCC / self.cooperations)
+                probabilities.append(self.countCC / self.cooperations)
             if self.defections > 5:
-                probabilities.append(1.0 * self.countDD / self.defections)
+                probabilities.append(self.countDD / self.defections)
             if probabilities and all([abs(p - 0.5) < 0.25 for p in probabilities]):
                 return D
         return C

--- a/axelrod/strategies/hunter.py
+++ b/axelrod/strategies/hunter.py
@@ -170,7 +170,7 @@ class RandomHunter(Player):
     def __init__(self):
         self.countCC = 0
         self.countDD = 0
-        Player.__init__(self)
+        super().__init__()
 
     def strategy(self, opponent):
         """
@@ -199,4 +199,4 @@ class RandomHunter(Player):
     def reset(self):
         self.countCC = 0
         self.countDD = 0
-        Player.reset(self)
+        super().reset()

--- a/axelrod/strategies/hunter.py
+++ b/axelrod/strategies/hunter.py
@@ -66,7 +66,7 @@ class AlternatorHunter(Player):
     }
 
     def __init__(self):
-        Player.__init__(self)
+        super().__init__()
         self.is_alt = False
 
     def strategy(self, opponent):
@@ -80,7 +80,7 @@ class AlternatorHunter(Player):
         return C
 
     def reset(self):
-        Player.reset(self)
+        super().reset()
         self.is_alt = False
 
 
@@ -100,7 +100,7 @@ class CycleHunter(Player):
     }
 
     def __init__(self):
-        Player.__init__(self)
+        super().__init__()
         self.cycle = None
 
     def strategy(self, opponent):
@@ -114,7 +114,7 @@ class CycleHunter(Player):
         return C
 
     def reset(self):
-        Player.reset(self)
+        super().reset()
         self.cycle = None
 
 

--- a/axelrod/strategies/inverse.py
+++ b/axelrod/strategies/inverse.py
@@ -30,4 +30,4 @@ class Inverse(Player):
         if index is None:
             return C
 
-        return random_choice(1 - 1 / float(abs(index)))
+        return random_choice(1 - 1 / abs(index))

--- a/axelrod/strategies/lookerup.py
+++ b/axelrod/strategies/lookerup.py
@@ -104,7 +104,7 @@ class LookerUp(Player):
         """
         If no lookup table is provided to the constructor, then use the TFT one.
         """
-        Player.__init__(self)
+        super().__init__()
 
         if not lookup_table:
             lookup_table = {
@@ -201,7 +201,7 @@ class Winner12(LookerUp):
         pattern = 'CDCDDCDD'
         # Zip together the keys and the action pattern to get the lookup table.
         lookup_table = dict(zip(lookup_table_keys, pattern))
-        LookerUp.__init__(self, lookup_table=lookup_table,
+        super().__init__(lookup_table=lookup_table,
                           initial_actions=(C, C))
 
 
@@ -221,5 +221,5 @@ class Winner21(LookerUp):
         pattern = 'CDCDCDDD'
         # Zip together the keys and the action pattern to get the lookup table.
         lookup_table = dict(zip(lookup_table_keys, pattern))
-        LookerUp.__init__(self, lookup_table=lookup_table,
+        super().__init__(lookup_table=lookup_table,
                           initial_actions=(D, C))

--- a/axelrod/strategies/mathematicalconstants.py
+++ b/axelrod/strategies/mathematicalconstants.py
@@ -26,7 +26,7 @@ class CotoDeRatio(Player):
             return Actions.D
         # Otherwise compare ratio to golden mean
         cooperations = opponent.cooperations + self.cooperations
-        defections = float(opponent.defections + self.defections)
+        defections = opponent.defections + self.defections
         if cooperations / defections > self.ratio:
             return Actions.D
         return Actions.C

--- a/axelrod/strategies/memoryone.py
+++ b/axelrod/strategies/memoryone.py
@@ -161,7 +161,7 @@ class GTFT(MemoryOnePlayer):
     def receive_match_attributes(self):
         (R, P, S, T) = self.match_attributes["game"].RPST()
         if self.p is None:
-            self.p = min(1 - float(T - R) / (R - S), float(R - P) / (T - P))
+            self.p = min(1 - (T - R) / (R - S), (R - P) / (T - P))
         four_vector = [1, self.p, 1, self.p]
         self.set_four_vector(four_vector)
 
@@ -181,7 +181,7 @@ class FirmButFair(MemoryOnePlayer):
 
     @init_args
     def __init__(self):
-        four_vector = (1, 0, 1, 2./3)
+        four_vector = (1, 0, 1, 2/3)
         super().__init__(four_vector)
         self.set_four_vector(four_vector)
 
@@ -282,7 +282,7 @@ class ZDExtort2(LRPlayer):
     name = 'ZD-Extort-2'
 
     @init_args
-    def __init__(self, phi=1./9, s=0.5):
+    def __init__(self, phi=1/9, s=0.5):
         """
         Parameters
 
@@ -307,7 +307,7 @@ class ZDExtort2v2(LRPlayer):
     name = 'ZD-Extort-2 v2'
 
     @init_args
-    def __init__(self, phi=1./8, s=0.5, l=1):
+    def __init__(self, phi=1/8, s=0.5, l=1):
         """
         Parameters
 
@@ -332,7 +332,7 @@ class ZDExtort4(LRPlayer):
     name = 'ZD-Extort-4'
 
     @init_args
-    def __init__(self, phi=4./17, s=0.25, l=1):
+    def __init__(self, phi=4/17, s=0.25, l=1):
         """
         Parameters
 
@@ -356,7 +356,7 @@ class ZDGen2(LRPlayer):
     name = 'ZD-GEN-2'
 
     @init_args
-    def __init__(self, phi=1./8, s=0.5, l=3):
+    def __init__(self, phi=1/8, s=0.5, l=3):
         """
         Parameters
 
@@ -405,7 +405,7 @@ class ZDSet2(LRPlayer):
     name = 'ZD-SET-2'
 
     @init_args
-    def __init__(self, phi=1./4, s=0., l=2):
+    def __init__(self, phi=1/4, s=0., l=2):
         """
         Parameters
 

--- a/axelrod/strategies/memoryone.py
+++ b/axelrod/strategies/memoryone.py
@@ -44,7 +44,7 @@ class MemoryOnePlayer(Player):
                   Multiple strategies in titfortat.py
                   Grofman, Joss in axelrod_tournaments.py
         """
-        Player.__init__(self)
+        super().__init__()
         self._initial = initial
         if four_vector is not None:
             self.set_four_vector(four_vector)
@@ -93,7 +93,7 @@ class WinStayLoseShift(MemoryOnePlayer):
 
     @init_args
     def __init__(self, initial=C):
-        Player.__init__(self)
+        super().__init__()
         self.set_four_vector([1, 0, 0, 1])
         self._initial = initial
 
@@ -119,7 +119,7 @@ class WinShiftLoseStay(MemoryOnePlayer):
 
     @init_args
     def __init__(self, initial=D):
-        Player.__init__(self)
+        super().__init__()
         self.set_four_vector([0, 1, 1, 0])
         self._initial = initial
 
@@ -155,7 +155,7 @@ class GTFT(MemoryOnePlayer):
         TitForTat is equivalent to GTFT(0)
         """
         self.p = p
-        super(GTFT, self).__init__()
+        super().__init__()
         self.init_args = (p,)
 
     def receive_match_attributes(self):
@@ -182,7 +182,7 @@ class FirmButFair(MemoryOnePlayer):
     @init_args
     def __init__(self):
         four_vector = (1, 0, 1, 2./3)
-        super(FirmButFair, self).__init__(four_vector)
+        super().__init__(four_vector)
         self.set_four_vector(four_vector)
 
 
@@ -194,7 +194,7 @@ class StochasticCooperator(MemoryOnePlayer):
     @init_args
     def __init__(self):
         four_vector = (0.935, 0.229, 0.266, 0.42)
-        super(StochasticCooperator, self).__init__(four_vector)
+        super().__init__(four_vector)
         self.set_four_vector(four_vector)
 
 
@@ -219,7 +219,7 @@ class StochasticWSLS(MemoryOnePlayer):
 
         self.ep = ep
         four_vector = (1.-ep, ep, ep, 1.-ep)
-        super(StochasticWSLS, self).__init__(four_vector)
+        super().__init__(four_vector)
         self.set_four_vector(four_vector)
 
 
@@ -292,12 +292,12 @@ class ZDExtort2(LRPlayer):
         """
         self.phi = phi
         self.s = s
-        super(ZDExtort2, self).__init__()
+        super().__init__()
 
     def receive_match_attributes(self):
         (R, P, S, T) = self.match_attributes["game"].RPST()
         self.l = P
-        super(ZDExtort2, self).receive_match_attributes(
+        super().receive_match_attributes(
             self.phi, self.s, self.l)
 
 
@@ -318,10 +318,10 @@ class ZDExtort2v2(LRPlayer):
         self.phi = phi
         self.s = s
         self.l = l
-        super(ZDExtort2v2, self).__init__()
+        super().__init__()
 
     def receive_match_attributes(self):
-        super(ZDExtort2v2, self).receive_match_attributes(
+        super().receive_match_attributes(
             self.phi, self.s, self.l)
 
 
@@ -343,10 +343,10 @@ class ZDExtort4(LRPlayer):
         self.phi = phi
         self.s = s
         self.l = l
-        super(ZDExtort4, self).__init__()
+        super().__init__()
 
     def receive_match_attributes(self):
-        super(ZDExtort4, self).receive_match_attributes(
+        super().receive_match_attributes(
             self.phi, self.s, self.l)
 
 
@@ -367,10 +367,10 @@ class ZDGen2(LRPlayer):
         self.phi = phi
         self.s = s
         self.l = l
-        super(ZDGen2, self).__init__()
+        super().__init__()
 
     def receive_match_attributes(self):
-        super(ZDGen2, self).receive_match_attributes(
+        super().receive_match_attributes(
             self.phi, self.s, self.l)
 
 
@@ -390,12 +390,12 @@ class ZDGTFT2(LRPlayer):
         """
         self.phi = phi
         self.s = s
-        super(ZDGTFT2, self).__init__()
+        super().__init__()
 
     def receive_match_attributes(self):
         (R, P, S, T) = self.match_attributes["game"].RPST()
         self.l = R
-        super(ZDGTFT2, self).receive_match_attributes(
+        super().receive_match_attributes(
             self.phi, self.s, self.l)
 
 
@@ -416,10 +416,10 @@ class ZDSet2(LRPlayer):
         self.phi = phi
         self.s = s
         self.l = l
-        super(ZDSet2, self).__init__()
+        super().__init__()
 
     def receive_match_attributes(self):
-        super(ZDSet2, self).receive_match_attributes(
+        super().receive_match_attributes(
             self.phi, self.s, self.l)
 
 
@@ -449,7 +449,7 @@ class SoftJoss(MemoryOnePlayer):
         """
         self.q = q
         four_vector = (1., 1 - q, 1, 1 - q)
-        super(SoftJoss, self).__init__(four_vector)
+        super().__init__(four_vector)
 
     def __repr__(self):
         return "%s: %s" % (self.name, round(self.q, 2))

--- a/axelrod/strategies/memorytwo.py
+++ b/axelrod/strategies/memorytwo.py
@@ -30,7 +30,7 @@ class MEM2(Player):
     }
 
     def __init__(self):
-        Player.__init__(self)
+        super().__init__()
         self.players = {
             "TFT" : TitForTat(),
             "TFTT": TitFor2Tats(),
@@ -62,7 +62,7 @@ class MEM2(Player):
         return self.players[self.play_as].strategy(opponent)
 
     def reset(self):
-        Player.reset(self)
+        super().reset()
         for v in self.players.values():
             v.reset()
         self.play_as = "TFT"

--- a/axelrod/strategies/meta.py
+++ b/axelrod/strategies/meta.py
@@ -28,7 +28,7 @@ class MetaPlayer(Player):
 
     @init_args
     def __init__(self, team=None):
-        super(MetaPlayer, self).__init__()
+        super().__init__()
         # The default is to use all strategies available, but we need to import
         # the list at runtime, since _strategies import also _this_ module
         # before defining the list.
@@ -74,7 +74,7 @@ class MetaPlayer(Player):
         return 'C'
 
     def reset(self):
-        Player.reset(self)
+        super().reset()
         # Reset each player as well
         for player in self.team:
             player.reset()
@@ -87,7 +87,7 @@ class MetaMajority(MetaPlayer):
 
     @init_args
     def __init__(self, team=None):
-        super(MetaMajority, self).__init__(team=team)
+        super().__init__(team=team)
 
     @staticmethod
     def meta_strategy(results, opponent):
@@ -103,7 +103,7 @@ class MetaMinority(MetaPlayer):
 
     @init_args
     def __init__(self, team=None):
-        super(MetaMinority, self).__init__(team=team)
+        super().__init__(team=team)
 
     @staticmethod
     def meta_strategy(results, opponent):
@@ -119,7 +119,7 @@ class MetaWinner(MetaPlayer):
 
     @init_args
     def __init__(self, team=None):
-        super(MetaWinner, self).__init__(team=team)
+        super().__init__(team=team)
         # For each player, we will keep the history of proposed moves and
         # a running score since the beginning of the game.
         self.scores = [0] * len(self.team)
@@ -146,7 +146,7 @@ class MetaWinner(MetaPlayer):
         return bestresult
 
     def reset(self):
-        MetaPlayer.reset(self)
+        super().reset()
         self.scores = [0] * len(self.team)
 
 
@@ -206,7 +206,7 @@ class MetaHunter(MetaPlayer):
         team = [DefectorHunter, AlternatorHunter, RandomHunter,
                 MathConstantHunter, CycleHunter, EventualCycleHunter]
 
-        super(MetaHunter, self).__init__(team=team)
+        super().__init__(team=team)
 
     @staticmethod
     def meta_strategy(results, opponent):
@@ -244,7 +244,7 @@ class MetaHunterAggressive(MetaPlayer):
                 MathConstantHunter, CycleHunter, EventualCycleHunter,
                 CooperatorHunter]
 
-        super(MetaHunterAggressive, self).__init__(team=team)
+        super().__init__(team=team)
 
     @staticmethod
     def meta_strategy(results, opponent):
@@ -270,7 +270,7 @@ class MetaMajorityMemoryOne(MetaMajority):
     @init_args
     def __init__(self):
         team = [s for s in ordinary_strategies if s().classifier['memory_depth'] <= 1]
-        super(MetaMajorityMemoryOne, self).__init__(team=team)
+        super().__init__(team=team)
         self.classifier["long_run_time"] = False
 
 
@@ -283,7 +283,7 @@ class MetaMajorityFiniteMemory(MetaMajority):
     def __init__(self):
         team = [s for s in ordinary_strategies if s().classifier['memory_depth']
                 < float('inf')]
-        super(MetaMajorityFiniteMemory, self).__init__(team=team)
+        super().__init__(team=team)
 
 
 class MetaMajorityLongMemory(MetaMajority):
@@ -295,7 +295,7 @@ class MetaMajorityLongMemory(MetaMajority):
     def __init__(self):
         team = [s for s in ordinary_strategies if s().classifier['memory_depth']
                 == float('inf')]
-        super(MetaMajorityLongMemory, self).__init__(team=team)
+        super().__init__(team=team)
 
 
 class MetaWinnerMemoryOne(MetaWinner):
@@ -306,7 +306,7 @@ class MetaWinnerMemoryOne(MetaWinner):
     @init_args
     def __init__(self):
         team = [s for s in ordinary_strategies if s().classifier['memory_depth'] <= 1]
-        super(MetaWinnerMemoryOne, self).__init__(team=team)
+        super().__init__(team=team)
         self.classifier["long_run_time"] = False
 
 
@@ -319,7 +319,7 @@ class MetaWinnerFiniteMemory(MetaWinner):
     def __init__(self):
         team = [s for s in ordinary_strategies if s().classifier['memory_depth']
                 < float('inf')]
-        super(MetaWinnerFiniteMemory, self).__init__(team=team)
+        super().__init__(team=team)
 
 
 class MetaWinnerLongMemory(MetaWinner):
@@ -331,7 +331,7 @@ class MetaWinnerLongMemory(MetaWinner):
     def __init__(self):
         team = [s for s in ordinary_strategies if s().classifier['memory_depth']
                 == float('inf')]
-        super(MetaWinnerLongMemory, self).__init__(team=team)
+        super().__init__(team=team)
 
 
 class MetaWinnerDeterministic(MetaWinner):
@@ -343,7 +343,7 @@ class MetaWinnerDeterministic(MetaWinner):
     def __init__(self):
         team = [s for s in ordinary_strategies if
                 not s().classifier['stochastic']]
-        super(MetaWinnerDeterministic, self).__init__(team=team)
+        super().__init__(team=team)
         self.classifier['stochastic'] = False
 
 
@@ -356,7 +356,7 @@ class MetaWinnerStochastic(MetaWinner):
     def __init__(self):
         team = [s for s in ordinary_strategies if
                 s().classifier['stochastic']]
-        super(MetaWinnerStochastic, self).__init__(team=team)
+        super().__init__(team=team)
 
 
 class MetaMixer(MetaPlayer):
@@ -390,7 +390,7 @@ class MetaMixer(MetaPlayer):
     @init_args
     def __init__(self, team=None, distribution=None):
         self.distribution = distribution
-        super(MetaMixer, self).__init__(team=team)
+        super().__init__(team=team)
 
     def meta_strategy(self, results, opponent):
         """Using the numpy.random choice function to sample with weights"""
@@ -406,7 +406,7 @@ class NMWEDeterministic(NiceMetaWinnerEnsemble):
     def __init__(self):
         team = [s for s in ordinary_strategies if
                 not s().classifier['stochastic']]
-        super(NMWEDeterministic, self).__init__(team=team)
+        super().__init__(team=team)
         self.classifier["stochastic"] = True
 
 
@@ -419,7 +419,7 @@ class NMWEStochastic(NiceMetaWinnerEnsemble):
     def __init__(self):
         team = [s for s in ordinary_strategies if
                 s().classifier['stochastic']]
-        super(NMWEStochastic, self).__init__(team=team)
+        super().__init__(team=team)
 
 
 class NMWEFiniteMemory(NiceMetaWinnerEnsemble):
@@ -431,7 +431,7 @@ class NMWEFiniteMemory(NiceMetaWinnerEnsemble):
     def __init__(self):
         team = [s for s in ordinary_strategies if s().classifier['memory_depth']
                 < float('inf')]
-        super(NMWEFiniteMemory, self).__init__(team=team)
+        super().__init__(team=team)
 
 
 class NMWELongMemory(NiceMetaWinnerEnsemble):
@@ -443,7 +443,7 @@ class NMWELongMemory(NiceMetaWinnerEnsemble):
     def __init__(self):
         team = [s for s in ordinary_strategies if s().classifier['memory_depth']
                 == float('inf')]
-        super(NMWELongMemory, self).__init__(team=team)
+        super().__init__(team=team)
 
 
 class NMWEMemoryOne(NiceMetaWinnerEnsemble):
@@ -455,5 +455,5 @@ class NMWEMemoryOne(NiceMetaWinnerEnsemble):
     def __init__(self):
         team = [s for s in ordinary_strategies if s().classifier['memory_depth']
                 <= 1]
-        super(NMWEMemoryOne, self).__init__(team=team)
+        super().__init__(team=team)
         self.classifier["long_run_time"] = False

--- a/axelrod/strategies/oncebitten.py
+++ b/axelrod/strategies/oncebitten.py
@@ -20,7 +20,7 @@ class OnceBitten(Player):
     }
 
     def __init__(self):
-        super(OnceBitten, self).__init__()
+        super().__init__()
         self.mem_length = 10
         self.grudged = False
         self.grudge_memory = 0
@@ -47,7 +47,7 @@ class OnceBitten(Player):
 
     def reset(self):
         """Resets grudge memory and history."""
-        Player.reset(self)
+        super().reset()
         self.grudged = False
         self.grudge_memory = 0
 
@@ -103,7 +103,7 @@ class ForgetfulFoolMeOnce(Player):
         forget_probability, float
             The probability of forgetting the count of opponent defections.
         """
-        Player.__init__(self)
+        super().__init__()
         self.D_count = 0
         self._initial = C
         self.forget_probability = forget_probability
@@ -121,7 +121,7 @@ class ForgetfulFoolMeOnce(Player):
         return C
 
     def reset(self):
-        Player.reset(self)
+        super().reset()
         self.D_count = 0
 
 

--- a/axelrod/strategies/prober.py
+++ b/axelrod/strategies/prober.py
@@ -164,7 +164,7 @@ class Prober4(Player):
     }
 
     def __init__(self):
-        Player.__init__(self)
+        super().__init__()
         self.init_sequence = [
             C, C, D, C, D, D, D, C, C, D, C, D, C, C, D, C, D, D, C, D
         ]
@@ -194,7 +194,7 @@ class Prober4(Player):
             return D if opponent.history[-1] == D else C
 
     def reset(self):
-        Player.reset(self)
+        super().reset()
         self.just_Ds = 0
         self.unjust_Ds = 0
         self.turned_defector = False
@@ -264,7 +264,7 @@ class NaiveProber(Player):
         p, float
             The probability to defect randomly
         """
-        Player.__init__(self)
+        super().__init__()
         self.p = p
         if (self.p == 0) or (self.p == 1):
             self.classifier['stochastic'] = False
@@ -315,7 +315,7 @@ class RemorsefulProber(NaiveProber):
 
     @init_args
     def __init__(self, p=0.1):
-        NaiveProber.__init__(self, p)
+        super().__init__(p)
         self.probing = False
 
     def strategy(self, opponent):
@@ -338,5 +338,5 @@ class RemorsefulProber(NaiveProber):
         return D
 
     def reset(self):
-        Player.reset(self)
+        super().reset()
         self.probing = False

--- a/axelrod/strategies/punisher.py
+++ b/axelrod/strategies/punisher.py
@@ -29,7 +29,7 @@ class Punisher(Player):
         """
         Initialised the player
         """
-        super(Punisher, self).__init__()
+        super().__init__()
         self.mem_length = 1
         self.grudged = False
         self.grudge_memory = 1
@@ -58,7 +58,7 @@ class Punisher(Player):
         """
         Resets scores and history
         """
-        Player.reset(self)
+        super().reset()
         self.grudged = False
         self.grudge_memory = 0
         self.mem_length = 1
@@ -87,7 +87,7 @@ class InversePunisher(Player):
     }
 
     def __init__(self):
-        super(InversePunisher, self).__init__()
+        super().__init__()
         self.history = []
         self.mem_length = 1
         self.grudged = False
@@ -115,7 +115,7 @@ class InversePunisher(Player):
 
     def reset(self):
         """Resets internal variables and history"""
-        Player.reset(self)
+        super().reset()
         self.grudged = False
         self.grudge_memory = 0
         self.mem_length = 1

--- a/axelrod/strategies/qlearner.py
+++ b/axelrod/strategies/qlearner.py
@@ -36,7 +36,7 @@ class RiskyQLearner(Player):
     def __init__(self):
         """Initialises the player by picking a random strategy."""
 
-        super(RiskyQLearner, self).__init__()
+        super().__init__()
 
         # Set this explicitely, since the constructor of super will not pick it up
         # for any subclasses that do not override methods using random calls.
@@ -106,7 +106,7 @@ class RiskyQLearner(Player):
         """
         Resets scores and history
         """
-        Player.reset(self)
+        super().reset()
 
         self.Qs = {'': {C: 0, D: 0}}
         self.Vs = {'': 0}

--- a/axelrod/strategies/rand.py
+++ b/axelrod/strategies/rand.py
@@ -34,7 +34,7 @@ class Random(Player):
         Random(0) is equivalent to Defector
         Random(1) is equivalent to Cooperator
         """
-        Player.__init__(self)
+        super().__init__()
         self.p = p
         if p in [0, 1]:
             self.classifier['stochastic'] = False

--- a/axelrod/strategies/retaliate.py
+++ b/axelrod/strategies/retaliate.py
@@ -32,7 +32,7 @@ class Retaliate(Player):
         Uses the basic init from the Player class, but also set the name to
         include the retaliation setting.
         """
-        Player.__init__(self)
+        super().__init__()
         self.retaliation_threshold = retaliation_threshold
         self.name = (
             'Retaliate (' +
@@ -55,7 +55,7 @@ class Retaliate(Player):
         return C
 
     def reset(self):
-        Player.reset(self)
+        super().reset()
         self.play_counts = defaultdict(int)
 
 
@@ -71,8 +71,7 @@ class Retaliate2(Retaliate):
     name = 'Retaliate 2'
 
     def __init__(self, retaliation_threshold=0.08):
-        super(Retaliate2, self).__init__(
-            retaliation_threshold=retaliation_threshold)
+        super().__init__(retaliation_threshold=retaliation_threshold)
 
 
 class Retaliate3(Retaliate):
@@ -87,8 +86,7 @@ class Retaliate3(Retaliate):
     name = 'Retaliate 3'
 
     def __init__(self, retaliation_threshold=0.05):
-        super(Retaliate3, self).__init__(
-            retaliation_threshold=retaliation_threshold)
+        super().__init__(retaliation_threshold=retaliation_threshold)
 
 
 class LimitedRetaliate(Player):
@@ -126,7 +124,7 @@ class LimitedRetaliate(Player):
             The maximum number of retaliations until the strategy returns to
             cooperation
         """
-        Player.__init__(self)
+        super().__init__()
         self.retaliating = False
         self.retaliation_count = 0
         self.retaliation_threshold = retaliation_threshold
@@ -167,7 +165,7 @@ class LimitedRetaliate(Player):
         return C
 
     def reset(self):
-        Player.reset(self)
+        super().reset()
         self.play_counts = defaultdict(int)
         self.retaliating = False
         self.retaliation_count = 0
@@ -186,7 +184,7 @@ class LimitedRetaliate2(LimitedRetaliate):
     name = 'Limited Retaliate 2'
 
     def __init__(self, retaliation_threshold=0.08, retaliation_limit=15):
-        super(LimitedRetaliate2, self).__init__(
+        super().__init__(
             retaliation_threshold=retaliation_threshold,
             retaliation_limit=retaliation_limit)
 
@@ -204,6 +202,6 @@ class LimitedRetaliate3(LimitedRetaliate):
     name = 'Limited Retaliate 3'
 
     def __init__(self, retaliation_threshold=0.05, retaliation_limit=20):
-        super(LimitedRetaliate3, self).__init__(
+        super().__init__(
             retaliation_threshold=retaliation_threshold,
             retaliation_limit=retaliation_limit)

--- a/axelrod/strategies/sequence_player.py
+++ b/axelrod/strategies/sequence_player.py
@@ -9,7 +9,7 @@ class SequencePlayer(Player):
 
     @init_args
     def __init__(self, generator_function, generator_args=()):
-        Player.__init__(self)
+        super().__init__()
         # Initialize the sequence generator
         self.generator_function = generator_function
         self.generator_args = generator_args
@@ -31,7 +31,7 @@ class SequencePlayer(Player):
 
     def reset(self):
         # Be sure to reset the sequence generator
-        Player.reset(self)
+        super().reset()
         self.sequence_generator = self.generator_function(*self.generator_args)
 
 
@@ -61,7 +61,7 @@ class ThueMorse(SequencePlayer):
 
     @init_args
     def __init__(self):
-        SequencePlayer.__init__(self, thue_morse_generator, (0,))
+        super().__init__(thue_morse_generator, (0,))
 
 
 class ThueMorseInverse(ThueMorse):
@@ -85,7 +85,7 @@ class ThueMorseInverse(ThueMorse):
 
     @init_args
     def __init__(self):
-        SequencePlayer.__init__(self, thue_morse_generator, (0,))
+        super(ThueMorse, self).__init__(thue_morse_generator, (0,))
 
     def meta_strategy(self, value):
         # Switch the default cooperate and defect action on 0 or 1

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -288,7 +288,7 @@ class OmegaTFT(Player):
 
     @init_args
     def __init__(self, deadlock_threshold=3, randomness_threshold=8):
-        Player.__init__(self)
+        super().__init__()
         self.deadlock_threshold = deadlock_threshold
         self.randomness_threshold = randomness_threshold
         self.randomness_counter = 0
@@ -335,7 +335,7 @@ class OmegaTFT(Player):
         return self.move
 
     def reset(self):
-        Player.reset(self)
+        super().reset()
         self.randomness_counter = 0
         self.deadlock_counter = 0
 
@@ -364,7 +364,7 @@ class Gradual(Player):
 
     def __init__(self):
 
-        Player.__init__(self)
+        super().__init__()
         self.calming = False
         self.punishing = False
         self.punishment_count = 0
@@ -395,7 +395,7 @@ class Gradual(Player):
         return C
 
     def reset(self):
-        Player.reset(self)
+        super().reset()
         self.calming = False
         self.punishing = False
         self.punishment_count = 0
@@ -445,7 +445,7 @@ class ContriteTitForTat(Player):
         return opponent.history[-1]
 
     def reset(self):
-        Player.reset(self)
+        super().reset()
         self.contrite = False
         self._recorded_history = []
 
@@ -529,7 +529,7 @@ class AdaptiveTitForTat(Player):
 
     @init_args
     def __init__(self, rate=0.5):
-        Player.__init__(self)
+        super().__init__()
         self.rate, self.starting_rate = rate, rate
 
     def strategy(self, opponent):
@@ -549,7 +549,7 @@ class AdaptiveTitForTat(Player):
 
     def reset(self):
 
-        Player.reset(self)
+        super().reset()
         self.world = 0.5
         self.rate = self.starting_rate
 
@@ -581,7 +581,7 @@ class SpitefulTitForTat(Player):
     }
 
     def __init__(self):
-        Player.__init__(self)
+        super().__init__()
         self.retaliating = False
 
     def strategy(self, opponent):
@@ -601,5 +601,5 @@ class SpitefulTitForTat(Player):
             return C
 
     def reset(self):
-        Player.reset(self)
+        super().reset()
         self.retaliating = False

--- a/axelrod/strategy_transformers.py
+++ b/axelrod/strategy_transformers.py
@@ -361,7 +361,7 @@ def mixed_wrapper(player, opponent, action, probability, m_player):
         mutate_prob = sum(probability)  # Prob of mutation
         if mutate_prob > 0:
             # Distribution of choice of mutation:
-            normalised_prob = [prob / float(mutate_prob)
+            normalised_prob = [prob / mutate_prob
                                for prob in probability]
             if random.random() < mutate_prob:
                 p = choice(list(m_player), p=normalised_prob)()

--- a/axelrod/tests/unit/test_interaction_utils.py
+++ b/axelrod/tests/unit/test_interaction_utils.py
@@ -26,7 +26,7 @@ class TestMatch(unittest.TestCase):
                                      Counter({('D', 'C'): 1.0}),
                                      Counter({('C', 'C'): 0.5, ('C', 'D'): 0.5}),
                                      None]
-    sparklines = [ u'█ \n █', u'  \n██', u'██\n█ ', None ]
+    sparklines = [ '█ \n █', '  \n██', '██\n█ ', None ]
 
 
     def test_compute_scores(self):

--- a/axelrod/tests/unit/test_match.py
+++ b/axelrod/tests/unit/test_match.py
@@ -201,7 +201,7 @@ class TestMatch(unittest.TestCase):
         players = (axelrod.Cooperator(), axelrod.Alternator())
         match = axelrod.Match(players, 4)
         match.play()
-        expected_sparklines = u'████\n█ █ '
+        expected_sparklines = '████\n█ █ '
         self.assertEqual(match.sparklines(), expected_sparklines)
-        expected_sparklines = u'XXXX\nXYXY'
+        expected_sparklines = 'XXXX\nXYXY'
         self.assertEqual(match.sparklines('X', 'Y'), expected_sparklines)

--- a/axelrod/tests/unit/test_match.py
+++ b/axelrod/tests/unit/test_match.py
@@ -134,12 +134,12 @@ class TestMatch(unittest.TestCase):
         match = axelrod.Match((player1, player2), turns)
         self.assertEqual(match.final_score_per_turn(), None)
         match.play()
-        self.assertEqual(match.final_score_per_turn(), (2/float(turns), 7/float(turns)))
+        self.assertEqual(match.final_score_per_turn(), (2/turns, 7/turns))
 
         match = axelrod.Match((player2, player1), turns)
         self.assertEqual(match.final_score_per_turn(), None)
         match.play()
-        self.assertEqual(match.final_score_per_turn(), (7/float(turns), 2/float(turns)))
+        self.assertEqual(match.final_score_per_turn(), (7/turns, 2/turns))
 
     def test_winner(self):
         player1 = axelrod.TitForTat()
@@ -187,7 +187,7 @@ class TestMatch(unittest.TestCase):
         match = axelrod.Match((player1, player2), turns)
         self.assertEqual(match.normalised_cooperation(), None)
         match.play()
-        self.assertEqual(match.normalised_cooperation(), (3/float(turns), 2/float(turns)))
+        self.assertEqual(match.normalised_cooperation(), (3/turns, 2/turns))
 
         player1 = axelrod.Alternator()
         player2 = axelrod.Defector()
@@ -195,7 +195,7 @@ class TestMatch(unittest.TestCase):
         match = axelrod.Match((player1, player2), turns)
         self.assertEqual(match.normalised_cooperation(), None)
         match.play()
-        self.assertEqual(match.normalised_cooperation(), (2/float(turns), 0/float(turns)))
+        self.assertEqual(match.normalised_cooperation(), (2/turns, 0/turns))
 
     def test_sparklines(self):
         players = (axelrod.Cooperator(), axelrod.Alternator())

--- a/axelrod/tests/unit/test_match_generator.py
+++ b/axelrod/tests/unit/test_match_generator.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import unittest
 
 from hypothesis import given, example

--- a/axelrod/tests/unit/test_memoryone.py
+++ b/axelrod/tests/unit/test_memoryone.py
@@ -99,7 +99,7 @@ class TestGTFT(TestPlayer):
 
     def test_four_vector(self):
         (R, P, S, T) = Game().RPST()
-        p = min(1 - float(T - R) / (R - S), float(R - P) / (T - P))
+        p = min(1 - (T - R) / (R - S), (R - P) / (T - P))
         expected_dictionary = {(C, C): 1., (C, D): p, (D, C): 1., (D, D): p}
         test_four_vector(self, expected_dictionary)
 
@@ -124,7 +124,7 @@ class TestFirmButFair(TestPlayer):
     }
 
     def test_four_vector(self):
-        expected_dictionary = {(C, C): 1, (C, D): 0, (D, C): 1, (D, D): 2./3}
+        expected_dictionary = {(C, C): 1, (C, D): 0, (D, C): 1, (D, D): 2/3}
         test_four_vector(self, expected_dictionary)
 
     def test_strategy(self):
@@ -239,7 +239,7 @@ class TestZDExtort2(TestPlayer):
     }
 
     def test_four_vector(self):
-        expected_dictionary = {(C, C): 8./9, (C, D): 0.5, (D, C): 1./3,
+        expected_dictionary = {(C, C): 8/9, (C, D): 0.5, (D, C): 1/3,
                                (D, D): 0.}
         test_four_vector(self, expected_dictionary)
 
@@ -268,7 +268,7 @@ class TestZDExtort2v2(TestPlayer):
     }
 
     def test_four_vector(self):
-        expected_dictionary = {(C, C): 7./8, (C, D): 7./16, (D, C): 3./8,
+        expected_dictionary = {(C, C): 7/8, (C, D): 7/16, (D, C): 3/8,
                                (D, D): 0.}
         test_four_vector(self, expected_dictionary)
 
@@ -291,7 +291,7 @@ class TestZDExtort4(TestPlayer):
     }
 
     def test_four_vector(self):
-        expected_dictionary = {(C, C): 11./17, (C, D): 0, (D, C): 8./17,
+        expected_dictionary = {(C, C): 11/17, (C, D): 0, (D, C): 8/17,
                                (D, D): 0.}
         test_four_vector(self, expected_dictionary)
 
@@ -314,8 +314,8 @@ class TestZDGen2(TestPlayer):
     }
 
     def test_four_vector(self):
-        expected_dictionary = {(C, C): 1, (C, D): 9./16, (D, C): 1./2,
-                               (D, D): 1./8}
+        expected_dictionary = {(C, C): 1, (C, D): 9/16, (D, C): 1/2,
+                               (D, D): 1/8}
         test_four_vector(self, expected_dictionary)
 
     def test_strategy(self):
@@ -336,7 +336,7 @@ class TestZDGTFT2(TestPlayer):
     }
 
     def test_four_vector(self):
-        expected_dictionary = {(C, C): 1., (C, D): 1./8, (D, C): 1.,
+        expected_dictionary = {(C, C): 1., (C, D): 1/8, (D, C): 1.,
                                (D, D): 0.25}
         test_four_vector(self, expected_dictionary)
 
@@ -365,8 +365,8 @@ class TestZDSet2(TestPlayer):
     }
 
     def test_four_vector(self):
-        expected_dictionary = {(C, C): 3./4, (C, D): 1./4, (D, C): 1./2,
-                               (D, D): 1./4}
+        expected_dictionary = {(C, C): 3/4, (C, D): 1/4, (D, C): 1/2,
+                               (D, D): 1/4}
         test_four_vector(self, expected_dictionary)
 
     def test_strategy(self):

--- a/axelrod/tests/unit/test_plot.py
+++ b/axelrod/tests/unit/test_plot.py
@@ -39,9 +39,9 @@ class TestPlot(unittest.TestCase):
 
         cls.test_result_set = axelrod.ResultSet(cls.players, cls.interactions)
         cls.expected_boxplot_dataset = [
-               [(17.0 / 5 + 9.0 / 5) / 2 for _ in range(3)],
-               [(13.0 / 5 + 4.0 / 5) / 2 for _ in range(3)],
-               [3.0 / 2 for _ in range(3)]
+               [(17 / 5 + 9 / 5) / 2 for _ in range(3)],
+               [(13 / 5 + 4 / 5) / 2 for _ in range(3)],
+               [3 / 2 for _ in range(3)]
                ]
         cls.expected_boxplot_xticks_locations = [1, 2, 3, 4]
         cls.expected_boxplot_xticks_labels = ['Defector', 'Tit For Tat', 'Alternator']
@@ -53,9 +53,9 @@ class TestPlot(unittest.TestCase):
                ]
 
         cls.expected_payoff_dataset = [
-            [0, mean([9/5.0 for _ in range(3)]), mean([17/5.0 for _ in range(3)])],
-            [mean([4/5.0 for _ in range(3)]), 0, mean([13/5.0 for _ in range(3)])],
-            [mean([2/5.0 for _ in range(3)]), mean([13/5.0 for _ in range(3)]), 0]
+            [0, mean([9/5 for _ in range(3)]), mean([17/5 for _ in range(3)])],
+            [mean([4/5 for _ in range(3)]), 0, mean([13/5 for _ in range(3)])],
+            [mean([2/5 for _ in range(3)]), mean([13/5 for _ in range(3)]), 0]
         ]
         cls.expected_winplot_dataset = ([[2, 2, 2], [0, 0, 0], [0, 0, 0]],
                                         ['Defector', 'Tit For Tat', 'Alternator'])

--- a/axelrod/tests/unit/test_property.py
+++ b/axelrod/tests/unit/test_property.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import unittest
 import axelrod
 from axelrod.tests.property import (strategy_lists,

--- a/axelrod/tests/unit/test_resultset.py
+++ b/axelrod/tests/unit/test_resultset.py
@@ -62,9 +62,9 @@ class TestResultSet(unittest.TestCase):
                 ]
 
         cls.expected_normalised_scores =[
-               [3.0 / 2 for _ in range(3)],
-               [(13.0 / 5 + 4.0 / 5) / 2 for _ in range(3)],
-               [(17.0 / 5 + 9.0 / 5) / 2 for _ in range(3)],
+               [3 / 2 for _ in range(3)],
+               [(13 / 5 + 4 / 5) / 2 for _ in range(3)],
+               [(17 / 5 + 9 / 5) / 2 for _ in range(3)],
                 ]
 
         cls.expected_ranking = [2, 1, 0]
@@ -78,9 +78,9 @@ class TestResultSet(unittest.TestCase):
         ]
 
         cls.expected_payoffs = [
-            [[], [13/5.0 for _ in range(3)], [2/5.0 for _ in range(3)]],
-            [[13/5.0 for _ in range(3)], [], [4/5.0 for _ in range(3)]],
-            [[17/5.0 for _ in range(3)], [9/5.0 for _ in range(3)], []]
+            [[], [13/5 for _ in range(3)], [2/5 for _ in range(3)]],
+            [[13/5 for _ in range(3)], [], [4/5 for _ in range(3)]],
+            [[17/5 for _ in range(3)], [9/5 for _ in range(3)], []]
         ]
 
         cls.expected_score_diffs = [
@@ -103,15 +103,15 @@ class TestResultSet(unittest.TestCase):
 
         # Recalculating to deal with numeric imprecision
         cls.expected_payoff_matrix = [
-            [0, mean([13/5.0 for _ in range(3)]), mean([2/5.0 for _ in range(3)])],
-            [mean([13/5.0 for _ in range(3)]), 0, mean([4/5.0 for _ in range(3)])],
-            [mean([17/5.0 for _ in range(3)]), mean([9/5.0 for _ in range(3)]), 0]
+            [0, mean([13/5 for _ in range(3)]), mean([2/5 for _ in range(3)])],
+            [mean([13/5 for _ in range(3)]), 0, mean([4/5 for _ in range(3)])],
+            [mean([17/5 for _ in range(3)]), mean([9/5 for _ in range(3)]), 0]
         ]
 
         cls.expected_payoff_stddevs = [
-            [0, std([13/5.0 for _ in range(3)]), std([2/5.0 for _ in range(3)])],
-            [std([13/5.0 for _ in range(3)]), 0, std([4/5.0 for _ in range(3)])],
-            [std([17/5.0 for _ in range(3)]), std([9/5.0 for _ in range(3)]), 0]
+            [0, std([13/5 for _ in range(3)]), std([2/5 for _ in range(3)])],
+            [std([13/5 for _ in range(3)]), 0, std([4/5 for _ in range(3)])],
+            [std([17/5 for _ in range(3)]), std([9/5 for _ in range(3)]), 0]
         ]
 
         cls.expected_cooperation = [
@@ -128,8 +128,8 @@ class TestResultSet(unittest.TestCase):
             ]
 
         cls.expected_normalised_cooperation = [
-                [0, mean([3 / 5.0 for _ in range(3)]), mean([3 / 5.0 for _ in range(3)])],
-                [mean([3 / 5.0 for _ in range(3)]), 0, mean([1 / 5.0 for _ in range(3)])],
+                [0, mean([3 / 5 for _ in range(3)]), mean([3 / 5 for _ in range(3)])],
+                [mean([3 / 5 for _ in range(3)]), 0, mean([1 / 5 for _ in range(3)])],
                 [0, 0, 0],
             ]
 
@@ -161,8 +161,8 @@ class TestResultSet(unittest.TestCase):
                                    for row in cls.expected_normalised_cooperation]
 
         cls.expected_cooperating_rating = [
-                18.0 / 30,
-                12.0 / 30,
+                18 / 30,
+                12 / 30,
                 0
             ]
 
@@ -770,9 +770,9 @@ class TestResultSetSpatialStructure(TestResultSet):
                 ]
 
         cls.expected_normalised_scores =[
-               [3.0 / 2 for _ in range(3)],
-               [(13.0 / 5 )  for _ in range(3)],
-               [(17.0 / 5 )  for _ in range(3)],
+               [3 / 2 for _ in range(3)],
+               [(13 / 5 )  for _ in range(3)],
+               [(17 / 5 )  for _ in range(3)],
                 ]
 
         cls.expected_ranking = [2, 1, 0]
@@ -786,9 +786,9 @@ class TestResultSetSpatialStructure(TestResultSet):
         ]
 
         cls.expected_payoffs = [
-            [[], [13/5.0 for _ in range(3)], [2/5.0 for _ in range(3)]],
-            [[13/5.0 for _ in range(3)], [], []],
-            [[17/5.0 for _ in range(3)], [], []]
+            [[], [13/5 for _ in range(3)], [2/5 for _ in range(3)]],
+            [[13/5 for _ in range(3)], [], []],
+            [[17/5 for _ in range(3)], [], []]
         ]
 
         cls.expected_score_diffs = [
@@ -811,15 +811,15 @@ class TestResultSetSpatialStructure(TestResultSet):
 
         # Recalculating to deal with numeric imprecision
         cls.expected_payoff_matrix = [
-            [0, mean([13/5.0 for _ in range(3)]), mean([2/5.0 for _ in range(3)])],
-            [mean([13/5.0 for _ in range(3)]), 0, 0 ],
-            [mean([17/5.0 for _ in range(3)]), 0 , 0]
+            [0, mean([13/5 for _ in range(3)]), mean([2/5 for _ in range(3)])],
+            [mean([13/5 for _ in range(3)]), 0, 0 ],
+            [mean([17/5 for _ in range(3)]), 0 , 0]
         ]
 
         cls.expected_payoff_stddevs = [
-            [0, std([13/5.0 for _ in range(3)]), std([2/5.0 for _ in range(3)])],
-            [std([13/5.0 for _ in range(3)]), 0, 0 ],
-            [std([17/5.0 for _ in range(3)]), 0, 0 ]
+            [0, std([13/5 for _ in range(3)]), std([2/5 for _ in range(3)])],
+            [std([13/5 for _ in range(3)]), 0, 0 ],
+            [std([17/5 for _ in range(3)]), 0, 0 ]
         ]
 
         cls.expected_cooperation = [
@@ -829,8 +829,8 @@ class TestResultSetSpatialStructure(TestResultSet):
             ]
 
         cls.expected_normalised_cooperation = [
-            [0, mean([3 / 5.0 for _ in range(3)]), mean([3 / 5.0 for _ in range(3)])],
-            [mean([3 / 5.0 for _ in range(3)]), 0, 0 ],
+            [0, mean([3 / 5 for _ in range(3)]), mean([3 / 5 for _ in range(3)])],
+            [mean([3 / 5 for _ in range(3)]), 0, 0 ],
             [0, 0, 0],
             ]
 
@@ -841,8 +841,8 @@ class TestResultSetSpatialStructure(TestResultSet):
                                    for row in cls.expected_normalised_cooperation]
 
         cls.expected_cooperating_rating = [
-                18.0 / 30,
-                9.0 / 15,
+                18 / 30,
+                9 / 15,
                 0
             ]
 
@@ -975,9 +975,9 @@ class TestResultSetSpatialStructureTwo(TestResultSetSpatialStructure):
                 ]
 
         cls.expected_normalised_scores =[
-               [(13.0 / 5 )  for _ in range(3)],
-               [(13.0 / 5 )  for _ in range(3)],
-               [(25.0 / 5 )  for _ in range(3)],
+               [(13 / 5 )  for _ in range(3)],
+               [(13 / 5 )  for _ in range(3)],
+               [(25 / 5 )  for _ in range(3)],
                [0  for _ in range(3)]
                 ]
 
@@ -993,9 +993,9 @@ class TestResultSetSpatialStructureTwo(TestResultSetSpatialStructure):
         ]
 
         cls.expected_payoffs = [
-             [[], [13/5.0 for _ in range(3)], [], []],
-             [[13/5.0 for _ in range(3)], [], [], []],
-             [[], [], [], [25/5.0 for _ in range(3)]],
+             [[], [13/5 for _ in range(3)], [], []],
+             [[13/5 for _ in range(3)], [], [], []],
+             [[], [], [], [25/5 for _ in range(3)]],
              [[], [], [0 for _ in range(3)], []]
         ]
 
@@ -1027,16 +1027,16 @@ class TestResultSetSpatialStructureTwo(TestResultSetSpatialStructure):
 
         # Recalculating to deal with numeric imprecision
         cls.expected_payoff_matrix = [
-            [0, mean([13/5.0 for _ in range(3)]), 0, 0],
-            [mean([13/5.0 for _ in range(3)]), 0, 0, 0],
-            [0, 0, 0, mean([25/5.0 for _ in range(3)])],
+            [0, mean([13/5 for _ in range(3)]), 0, 0],
+            [mean([13/5 for _ in range(3)]), 0, 0, 0],
+            [0, 0, 0, mean([25/5 for _ in range(3)])],
             [0, 0, 0, 0]
         ]
 
         cls.expected_payoff_stddevs = [
-            [0, std([13/5.0 for _ in range(3)]), 0, 0],
-            [std([13/5.0 for _ in range(3)]), 0, 0, 0],
-            [0, 0, 0, std([25/5.0 for _ in range(3)])],
+            [0, std([13/5 for _ in range(3)]), 0, 0],
+            [std([13/5 for _ in range(3)]), 0, 0, 0],
+            [0, 0, 0, std([25/5 for _ in range(3)])],
             [0, 0, 0, 0]
         ]
 
@@ -1048,10 +1048,10 @@ class TestResultSetSpatialStructureTwo(TestResultSetSpatialStructure):
             ]
 
         cls.expected_normalised_cooperation = [
-                [0.0, mean([3 / 5.0 for _ in range(3)]), 0.0, 0.0],
-                [mean([3 / 5.0 for _ in range(3)]), 0.0, 0.0, 0.0],
+                [0.0, mean([3 / 5 for _ in range(3)]), 0.0, 0.0],
+                [mean([3 / 5 for _ in range(3)]), 0.0, 0.0, 0.0],
                 [0.0, 0.0, 0.0, 0.0],
-                [0.0, 0.0, mean([5 / 5.0 for _ in range(3)]), 0.0]
+                [0.0, 0.0, mean([5 / 5 for _ in range(3)]), 0.0]
                 ]
 
         cls.expected_initial_cooperation_count = [3.0, 3.0, 0, 3.0]
@@ -1061,8 +1061,8 @@ class TestResultSetSpatialStructureTwo(TestResultSetSpatialStructure):
                                    for row in cls.expected_normalised_cooperation]
 
         cls.expected_cooperating_rating = [
-                18.0 / 30,
-                18.0 / 30,
+                18 / 30,
+                18 / 30,
                 0.0,
                 30 / 30
             ]
@@ -1179,10 +1179,10 @@ class TestResultSetSpatialStructureThree(TestResultSetSpatialStructure):
         ]
 
         cls.expected_payoffs = [
-             [[11 /5.0 for _ in range(3)], [], [], []],
-             [[], [15 /5.0 for _ in range(3)], [], []],
-             [[], [], [5 /5.0 for _ in range(3)], []],
-             [[], [], [], [15 /5.0 for _ in range(3)]]
+             [[11 /5 for _ in range(3)], [], [], []],
+             [[], [15 /5 for _ in range(3)], [], []],
+             [[], [], [5 /5 for _ in range(3)], []],
+             [[], [], [], [15 /5 for _ in range(3)]]
         ]
 
         cls.expected_score_diffs = [
@@ -1195,17 +1195,17 @@ class TestResultSetSpatialStructureThree(TestResultSetSpatialStructure):
 
         # Recalculating to deal with numeric imprecision
         cls.expected_payoff_matrix = [
-            [mean([11/5.0 for _ in range(3)]),0, 0, 0],
-            [0, mean([15/5.0 for _ in range(3)]), 0, 0],
-            [0, 0, mean([5/5.0 for _ in range(3)]), 0],
-            [0, 0, 0, mean([15/5.0 for _ in range(3)])]
+            [mean([11/5 for _ in range(3)]),0, 0, 0],
+            [0, mean([15/5 for _ in range(3)]), 0, 0],
+            [0, 0, mean([5/5 for _ in range(3)]), 0],
+            [0, 0, 0, mean([15/5 for _ in range(3)])]
         ]
 
         cls.expected_payoff_stddevs = [
-            [std([11/5.0 for _ in range(3)]),0, 0, 0],
-            [0, std([15/5.0 for _ in range(3)]), 0, 0],
-            [0, 0, std([5/5.0 for _ in range(3)]), 0],
-            [0, 0, 0, std([15/5.0 for _ in range(3)])]
+            [std([11/5 for _ in range(3)]),0, 0, 0],
+            [0, std([15/5 for _ in range(3)]), 0, 0],
+            [0, 0, std([5/5 for _ in range(3)]), 0],
+            [0, 0, 0, std([15/5 for _ in range(3)])]
         ]
 
         cls.expected_cooperation = [
@@ -1213,10 +1213,10 @@ class TestResultSetSpatialStructureThree(TestResultSetSpatialStructure):
             ]
 
         cls.expected_normalised_cooperation = [
-                [mean([3 / 5.0 for _ in range(3)]), 0.0, 0.0, 0.0],
-                [0.0, mean([5 / 5.0 for _ in range(3)]), 0.0, 0.0],
+                [mean([3 / 5 for _ in range(3)]), 0.0, 0.0, 0.0],
+                [0.0, mean([5 / 5 for _ in range(3)]), 0.0, 0.0],
                 [0.0, 0.0, 0.0, 0.0],
-                [0.0, 0.0, 0.0, mean([5 / 5.0 for _ in range(3)])]
+                [0.0, 0.0, 0.0, mean([5 / 5 for _ in range(3)])]
                 ]
 
         cls.expected_initial_cooperation_count = [0, 0, 0, 0]

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -4,6 +4,7 @@ import csv
 import logging
 from multiprocessing import Queue, cpu_count
 import unittest
+from unittest.mock import MagicMock
 import warnings
 
 from hypothesis import given, example, settings
@@ -15,13 +16,6 @@ from axelrod.tests.property import (tournaments,
 
 import axelrod
 
-
-try:
-    # Python 3
-    from unittest.mock import MagicMock
-except ImportError:
-    # Python 2
-    from mock import MagicMock
 
 test_strategies = [axelrod.Cooperator,
                    axelrod.TitForTat,

--- a/axelrod/tournament.py
+++ b/axelrod/tournament.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from collections import defaultdict
 from multiprocessing import Process, Queue, cpu_count
 from tempfile import NamedTemporaryFile
@@ -372,7 +370,7 @@ class ProbEndTournament(Tournament):
         with_morality : boolean
             Whether morality metrics should be calculated
         """
-        super(ProbEndTournament, self).__init__(
+        super().__init__(
             players, name=name, game=game, turns=float("inf"),
             repetitions=repetitions, noise=noise, with_morality=with_morality)
 
@@ -406,7 +404,7 @@ class SpatialTournament(Tournament):
         with_morality : boolean
             Whether morality metrics should be calculated
         """
-        super(SpatialTournament, self).__init__(
+        super().__init__(
             players, name=name, game=game, turns=turns,
             repetitions=repetitions, noise=noise, with_morality=with_morality)
 
@@ -443,7 +441,7 @@ class ProbEndSpatialTournament(ProbEndTournament):
         with_morality : boolean
             Whether morality metrics should be calculated
         """
-        super(ProbEndSpatialTournament, self).__init__(
+        super().__init__(
             players, name=name, game=game, prob_end=prob_end,
             repetitions=repetitions, noise=noise, with_morality=with_morality)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,8 +58,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Axelrod'
-copyright = u'2015, Vincent Knight'
+project = 'Axelrod'
+copyright = '2015, Vincent Knight'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -216,8 +216,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('index', 'Axelrod.tex', u'Axelrod Documentation',
-   u'Vincent Knight', 'manual'),
+  ('index', 'Axelrod.tex', 'Axelrod Documentation',
+   'Vincent Knight', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -246,8 +246,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'axelrod', u'Axelrod Documentation',
-     [u'Vincent Knight'], 1)
+    ('index', 'axelrod', 'Axelrod Documentation',
+     ['Vincent Knight'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -260,8 +260,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'Axelrod', u'Axelrod Documentation',
-   u'Vincent Knight', 'Axelrod', 'One line description of project.',
+  ('index', 'Axelrod', 'Axelrod Documentation',
+   'Vincent Knight', 'Axelrod', 'One line description of project.',
    'Miscellaneous'),
 ]
 


### PR DESCRIPTION
This PR addresses [#801](https://github.com/Axelrod-Python/Axelrod/issues/801). I have gone through all of the files and removed any support for Python 2 that I could find.

Overview of the changes I made:

- Changed all floating point divisions that used a `float()` cast or had one of the operands as a float (e.g. `1.0/...` or `1./...`.
- Unicode strings are no longer prefixed as such: `u''`
- Changed all references to superclasses to use the preferred zero-argument format `super()`.
- Removed all imports from the `__future__` module.
- Removed some import logic to check if Python's version was 2 or 3.

Some things I could not change:

- Dropping the use of `random_choice()` and `randrange()` in [https://github.com/Axelrod-Python/Axelrod/blob/master/axelrod/random_.py](https://github.com/Axelrod-Python/Axelrod/blob/master/axelrod/random_.py) as noted in [#801](https://github.com/Axelrod-Python/Axelrod/issues/801#issuecomment-272677267).
- Due to Multiple Inheritance, it is preferred to use the old-style superclass/direct reference in [https://github.com/Axelrod-Python/Axelrod/blob/master/axelrod/match_generator.py#L263](https://github.com/Axelrod-Python/Axelrod/blob/master/axelrod/match_generator.py#L263).

Overall I think I have caught most of the differences between Python 2 and Python 3. Please let me know if I have missed anything or if I need to add anything else to this PR.