### PR TITLE
Fix Type Annotations and add type test shell script

### DIFF
--- a/axelrod/actions.py
+++ b/axelrod/actions.py
@@ -1,6 +1,6 @@
-from typing import NewType
 
-Action = NewType('Action', str)
+# Type alias for actions.
+Action = str
 
 
 class Actions(object):

--- a/axelrod/deterministic_cache.py
+++ b/axelrod/deterministic_cache.py
@@ -1,8 +1,9 @@
 from collections import UserDict
 import pickle
-from typing import Tuple
+from typing import List, Tuple
 
-from axelrod import Action, Player
+from .actions import Action
+from .player import Player
 
 
 CachePlayerKey = Tuple[Player, Player, int]

--- a/axelrod/deterministic_cache.py
+++ b/axelrod/deterministic_cache.py
@@ -2,7 +2,11 @@ from collections import UserDict
 import pickle
 from typing import Tuple
 
-from axelrod import Player
+from axelrod import Action, Player
+
+
+CachePlayerKey = Tuple[Player, Player, int]
+CacheKey = Tuple[str, str, int]
 
 
 class DeterministicCache(UserDict):
@@ -30,7 +34,7 @@ class DeterministicCache(UserDict):
     methods to save/load the cache to/from a file.
     """
 
-    def __init__(self, file_name: str=None):
+    def __init__(self, file_name: str=None) -> None:
         """
         Parameters
         ----------
@@ -43,7 +47,7 @@ class DeterministicCache(UserDict):
             self.load(file_name)
 
     @staticmethod
-    def _key_transform(key: Tuple[str, str, int]):
+    def _key_transform(key: CachePlayerKey) -> CacheKey:
         """
         Parameters
         ----------
@@ -52,16 +56,16 @@ class DeterministicCache(UserDict):
         """
         return key[0].name, key[1].name, key[2]
 
-    def __delitem__(self, key: Tuple[str, str, int]):
+    def __delitem__(self, key: CachePlayerKey):
         return super().__delitem__(self._key_transform(key))
 
-    def __getitem__(self, key: Tuple[str, str, int]):
+    def __getitem__(self, key: CachePlayerKey) -> List[Tuple[Action, Action]]:
         return super().__getitem__(self._key_transform(key))
 
-    def __contains__(self, key: Tuple[str, str, int]):
+    def __contains__(self, key):
         return super().__contains__(self._key_transform(key))
 
-    def __setitem__(self, key: Tuple[str, str, int], value):
+    def __setitem__(self, key: CachePlayerKey, value):
         """Overrides the UserDict.__setitem__ method in order to validate
         the key/value and also to set the turns attribute"""
         if not self.mutable:
@@ -79,7 +83,7 @@ class DeterministicCache(UserDict):
         super().__setitem__(self._key_transform(key), value)
 
     @staticmethod
-    def _is_valid_key(key: Tuple[str, str, int]) -> bool:
+    def _is_valid_key(key: CachePlayerKey) -> bool:
         """Validate a proposed dictionary key.
 
         Parameters
@@ -117,7 +121,7 @@ class DeterministicCache(UserDict):
         return True
 
     @staticmethod
-    def _is_valid_value(value) -> bool:
+    def _is_valid_value(value: List) -> bool:
         """Validate a proposed dictionary value.
 
         Parameters
@@ -134,7 +138,7 @@ class DeterministicCache(UserDict):
 
         return True
 
-    def save(self, file_name: str):
+    def save(self, file_name: str) -> bool:
         """Serialise the cache dictionary to a file.
 
         Parameters

--- a/axelrod/game.py
+++ b/axelrod/game.py
@@ -1,4 +1,4 @@
-from axelrod import Action, Actions
+from .actions import Action, Actions
 from typing import Tuple
 
 C, D = Actions.C, Actions.D

--- a/axelrod/game.py
+++ b/axelrod/game.py
@@ -1,13 +1,15 @@
 from .actions import Action, Actions
-from typing import Tuple
+from typing import Tuple, Union
 
 C, D = Actions.C, Actions.D
+
+Score = Union[int, float]
 
 
 class Game(object):
     """A class to hold the game matrix and to score a game accordingly."""
 
-    def __init__(self, r: int=3, s: int=0, t: int=5, p: int=1) -> None:
+    def __init__(self, r: Score=3, s: Score=0, t: Score=5, p: Score=1) -> None:
         self.scores = {
             (C, C): (r, r),
             (D, D): (p, p),
@@ -15,7 +17,7 @@ class Game(object):
             (D, C): (t, s),
         }
 
-    def RPST(self) -> Tuple[int, int, int, int]:
+    def RPST(self) -> Tuple[Score, Score, Score, Score]:
         """Return the values in the game matrix in the Press and Dyson
         notation."""
         R = self.scores[(C, C)][0]
@@ -24,7 +26,7 @@ class Game(object):
         T = self.scores[(D, C)][0]
         return (R, P, S, T)
 
-    def score(self, pair: Tuple[Action, Action]) -> Tuple[int, int]:
+    def score(self, pair: Tuple[Action, Action]) -> Tuple[Score, Score]:
         """Return the appropriate score for decision pair.
 
         Returns the appropriate score (as a tuple) from the scores dictionary

--- a/axelrod/game.py
+++ b/axelrod/game.py
@@ -1,4 +1,4 @@
-from axelrod import Actions
+from axelrod import Action, Actions
 from typing import Tuple
 
 C, D = Actions.C, Actions.D
@@ -7,7 +7,7 @@ C, D = Actions.C, Actions.D
 class Game(object):
     """A class to hold the game matrix and to score a game accordingly."""
 
-    def __init__(self, r: int =3, s: int=0, t: int=5, p:int=1):
+    def __init__(self, r: int=3, s: int=0, t: int=5, p: int=1) -> None:
         self.scores = {
             (C, C): (r, r),
             (D, D): (p, p),
@@ -15,7 +15,7 @@ class Game(object):
             (D, C): (t, s),
         }
 
-    def RPST(self):
+    def RPST(self) -> Tuple[int, int, int, int]:
         """Return the values in the game matrix in the Press and Dyson
         notation."""
         R = self.scores[(C, C)][0]
@@ -24,7 +24,7 @@ class Game(object):
         T = self.scores[(D, C)][0]
         return (R, P, S, T)
 
-    def score(self, pair) -> Tuple[int, int]:
+    def score(self, pair: Tuple[Action, Action]) -> Tuple[int, int]:
         """Return the appropriate score for decision pair.
 
         Returns the appropriate score (as a tuple) from the scores dictionary
@@ -33,7 +33,8 @@ class Game(object):
         """
         return self.scores[pair]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "Axelrod game: (R,P,S,T) = {}".format(self.RPST())
+
 
 DefaultGame = Game()

--- a/type_tests.sh
+++ b/type_tests.sh
@@ -1,0 +1,4 @@
+mypy --ignore-missing-imports --follow-imports skip axelrod/actions.py
+mypy --ignore-missing-imports --follow-imports skip axelrod/deterministic_cache.py
+mypy --ignore-missing-imports --follow-imports skip axelrod/game.py
+


### PR DESCRIPTION
Some of the type annotations already merged are not correct. Please be sure to run mypy on any new files with type annotations (see the included shell script). You will need to `pip install mypy`.

I was not able to get `mypy -m axelrod` to work -- it doesn't like our dynamically generated classes and I didn't track down a fix yet. (I've asked the mypy authors for advice in their gitter room.)