### PR TITLE
Add type hints to geller, hunter, memorytwo

### DIFF
--- a/axelrod/strategies/geller.py
+++ b/axelrod/strategies/geller.py
@@ -1,6 +1,6 @@
 import inspect
 
-from axelrod.actions import Actions
+from axelrod.actions import Actions, Action
 from axelrod.player import Player
 from axelrod.random_ import random_choice
 
@@ -42,7 +42,7 @@ class Geller(Player):
         'manipulates_state': False
     }
 
-    def strategy(self, opponent):
+    def strategy(self, opponent: Player) -> Action:
         """
         Look at what the opponent will play in the next round and choose a strategy
         that gives the least jail time, which is is equivalent to playing the same

--- a/axelrod/strategies/hunter.py
+++ b/axelrod/strategies/hunter.py
@@ -1,6 +1,8 @@
-from axelrod.actions import Actions
+from axelrod.actions import Actions, Action
 from axelrod.player import Player
 from axelrod._strategy_utils import detect_cycle
+
+from typing import List
 
 C, D = Actions.C, Actions.D
 
@@ -19,7 +21,7 @@ class DefectorHunter(Player):
         'manipulates_state': False
     }
 
-    def strategy(self, opponent):
+    def strategy(self, opponent: Player) -> Action:
         if len(self.history) >= 4 and len(opponent.history) == opponent.defections:
             return D
         return C
@@ -39,13 +41,13 @@ class CooperatorHunter(Player):
         'manipulates_state': False
     }
 
-    def strategy(self, opponent):
+    def strategy(self, opponent: Player) -> Action:
         if len(self.history) >= 4 and len(opponent.history) == opponent.cooperations:
             return D
         return C
 
 
-def is_alternator(history):
+def is_alternator(history: List[Action]) -> bool:
     for i in range(len(history) - 1):
         if history[i] == history[i + 1]:
             return False
@@ -66,11 +68,11 @@ class AlternatorHunter(Player):
         'manipulates_state': False
     }
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.is_alt = False
 
-    def strategy(self, opponent):
+    def strategy(self, opponent: Player) -> Action:
         if len(opponent.history) < 6:
             return C
         if len(self.history) == 6:
@@ -100,11 +102,11 @@ class CycleHunter(Player):
         'manipulates_state': False
     }
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.cycle = None
 
-    def strategy(self, opponent):
+    def strategy(self, opponent: Player) -> Action:
         if self.cycle:
             return D
         cycle = detect_cycle(opponent.history, min_size=3)
@@ -124,7 +126,7 @@ class EventualCycleHunter(CycleHunter):
 
     name = 'Eventual Cycle Hunter'
 
-    def strategy(self, opponent):
+    def strategy(self, opponent: Player) -> None:
         if len(opponent.history) < 10:
             return C
         if len(opponent.history) == opponent.cooperations:
@@ -153,7 +155,7 @@ class MathConstantHunter(Player):
         'manipulates_state': False
     }
 
-    def strategy(self, opponent):
+    def strategy(self, opponent: Player) -> Action:
         """
         Check whether the number of cooperations in the first and second halves
         of the history are close. The variance of the uniform distribution (1/4)
@@ -191,12 +193,12 @@ class RandomHunter(Player):
         'manipulates_state': False
     }
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.countCC = 0
         self.countDD = 0
         super().__init__()
 
-    def strategy(self, opponent):
+    def strategy(self, opponent: Player) -> Action:
         """
         A random player is unpredictable, which means the conditional frequency
         of cooperation after cooperation, and defection after defections, should

--- a/axelrod/strategies/hunter.py
+++ b/axelrod/strategies/hunter.py
@@ -2,7 +2,7 @@ from axelrod.actions import Actions, Action
 from axelrod.player import Player
 from axelrod._strategy_utils import detect_cycle
 
-from typing import List
+from typing import List, Tuple
 
 C, D = Actions.C, Actions.D
 
@@ -104,7 +104,7 @@ class CycleHunter(Player):
 
     def __init__(self) -> None:
         super().__init__()
-        self.cycle = None
+        self.cycle = None # type: Tuple[Action]
 
     def strategy(self, opponent: Player) -> Action:
         if self.cycle:

--- a/axelrod/strategies/memorytwo.py
+++ b/axelrod/strategies/memorytwo.py
@@ -1,4 +1,4 @@
-from axelrod.actions import Actions
+from axelrod.actions import Actions, Action
 from axelrod.player import Player
 from .titfortat import TitForTat, TitFor2Tats
 from .defector import Defector
@@ -30,7 +30,7 @@ class MEM2(Player):
         'manipulates_state': False
     }
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.players = {
             "TFT" : TitForTat(),
@@ -41,7 +41,7 @@ class MEM2(Player):
         self.shift_counter = 3
         self.alld_counter = 0
 
-    def strategy(self, opponent):
+    def strategy(self, opponent: Player) -> Action:
         # Update Histories
         # Note that this assumes that TFT and TFTT do not use internal counters,
         # Rather that they examine the actual history of play

--- a/type_tests.sh
+++ b/type_tests.sh
@@ -27,3 +27,6 @@ mypy --ignore-missing-imports --follow-imports skip axelrod/strategies/grumpy.py
 mypy --ignore-missing-imports --follow-imports skip axelrod/strategies/handshake.py
 mypy --ignore-missing-imports --follow-imports skip axelrod/strategies/inverse.py
 mypy --ignore-missing-imports --follow-imports skip axelrod/strategies/mathematicalconstants.py
+mypy --ignore-missing-imports --follow-imports skip axelrod/strategies/hunter.py
+mypy --ignore-missing-imports --follow-imports skip axelrod/strategies/geller.py
+mypy --ignore-missing-imports --follow-imports skip axelrod/strategies/memorytwo.py


### PR DESCRIPTION
#808
Only one error on mypy for `hunter.py`.
`axelrod/strategies/hunter.py:107: error: Need type annotation for variable`
I think this is an error with mypy where it can't infer type for empty containers. See [here](https://github.com/python/mypy/issues/1534).