### PR TITLE
Add shortmem to autodoc

### DIFF
--- a/docs/reference/all_strategies.rst
+++ b/docs/reference/all_strategies.rst
@@ -132,6 +132,9 @@ Here are the docstrings of all the strategies in the library.
 .. automodule:: axelrod.strategies.sequence_player
    :members:
    :undoc-members:
+.. automodule:: axelrod.strategies.shortmem
+   :members:
+   :undoc-members:
 .. automodule:: axelrod.strategies.titfortat
    :members:
    :undoc-members:


### PR DESCRIPTION
This was missed in #857. 

Minor, arguably a bug.