### PR TITLE
Add py3 constraint to setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,4 +26,5 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3 :: Only',
         ],
+    python_requires='>=3.0',
 )


### PR DESCRIPTION
Closes #859 

Note that if you pip install with py2 you now get:


```
(py2.7) Desktop: pip install ~/src/Axelrod
Processing /home/vince/src/Axelrod
Axelrod requires Python '>=3.0' but the running Python is 2.7.12
```
