### PR TITLE
Add state to action analysis.

### DIFF
--- a/axelrod/interaction_utils.py
+++ b/axelrod/interaction_utils.py
@@ -175,10 +175,7 @@ def compute_state_to_action_distribution(interactions):
 
 def compute_normalised_state_to_action_distribution(interactions):
     """
-    Returns the normalised count of each state to action
-    for a set of interactions.
-
-    Returns a list (for each player) of normlised counts of each state to action
+    Returns a list (for each player) of normalised counts of each state to action
     pair for a set of interactions. A state to action pair is of the form:
 
     ((C, D), C)

--- a/axelrod/interaction_utils.py
+++ b/axelrod/interaction_utils.py
@@ -2,7 +2,7 @@
 Functions to calculate results from interactions. Interactions are lists of the
 form:
 
-    [('C', 'D'), ('D', 'C'),...]
+    [(C, D), (D, C),...]
 
 This is used by both the Match class and the ResultSet class which analyse
 interactions.
@@ -145,7 +145,7 @@ def compute_state_to_action_distribution(interactions):
     Implying that from a state of (C, D) (the first player having played C and
     the second playing D) the player in question then played C.
 
-    The following counter object, implies that the player in question was in
+    The following counter object implies that the player in question was in
     state (C, D) for a total of 12 times, subsequently cooperating 4 times and
     defecting 8 times.
 
@@ -167,8 +167,8 @@ def compute_state_to_action_distribution(interactions):
     if not interactions:
         return None
 
-    distributions = [Counter([(state, outcome[j]) for state, outcome in zip(interactions,
-                                                              interactions[1:])])
+    distributions = [Counter([(state, outcome[j])
+                     for state, outcome in zip(interactions, interactions[1:])])
                      for j in range(2)]
     return distributions
 
@@ -180,13 +180,12 @@ def compute_normalised_state_to_action_distribution(interactions):
 
     ((C, D), C)
 
-    Implying that from a state of (C, D) (the first player having played C and
+    implying that from a state of (C, D) (the first player having played C and
     the second playing D) the player in question then played C.
 
     The following counter object, implies that the player in question was only
-    ever in
-    state (C, D), subsequently cooperating 1/3 of the time and
-    defecting 2/3 times.
+    ever in state (C, D), subsequently cooperating 1/3 of the time and defecting
+    2/3 times.
 
     Counter({((C, D), C): 0.333333, ((C, D), D): 0.66666667})
 
@@ -197,11 +196,11 @@ def compute_normalised_state_to_action_distribution(interactions):
         this file.
 
     Returns
-    ----------
+    -------
     normalised_state_to_C_distributions : List of Counter Object
         List of Counter objects where the keys are the states and actions and
-        the values the normalized counts.. The
-        first/second Counter corresponds to the first/second player.
+        the values the normalized counts. The first/second Counter corresponds
+        to the first/second player.
     """
     if not interactions:
         return None
@@ -210,22 +209,22 @@ def compute_normalised_state_to_action_distribution(interactions):
     normalized_distribution = []
     for player in range(2):
         counter = {}
-        for state in [('C', 'C'), ('C', 'D'), ('D', 'C'), ('D', 'D')]:
-            C_count = distribution[player].get((state, 'C'), 0)
-            D_count = distribution[player].get((state, 'D'), 0)
+        for state in [(C, C), (C, D), (D, C), (D, D)]:
+            C_count = distribution[player].get((state, C), 0)
+            D_count = distribution[player].get((state, D), 0)
             total = C_count + D_count
             if total > 0:
                 if C_count > 0:
-                    counter[(state, 'C')] = C_count / (C_count + D_count)
+                    counter[(state, C)] = C_count / (C_count + D_count)
                 if D_count > 0:
-                    counter[(state, 'D')] = D_count / (C_count + D_count)
+                    counter[(state, D)] = D_count / (C_count + D_count)
         normalized_distribution.append(Counter(counter))
     return normalized_distribution
 
 
 def sparkline(actions, c_symbol='█', d_symbol=' '):
     return ''.join([
-        c_symbol if play == 'C' else d_symbol for play in actions])
+        c_symbol if play == C else d_symbol for play in actions])
 
 
 def compute_sparklines(interactions, c_symbol='█', d_symbol=' '):

--- a/axelrod/interaction_utils.py
+++ b/axelrod/interaction_utils.py
@@ -135,6 +135,71 @@ def compute_normalised_state_distribution(interactions):
     return normalized_count
 
 
+def compute_state_to_action_distribution(interactions):
+    """
+    Returns the count of each state to action
+    for a set of interactions.
+
+    Parameters
+    ----------
+    interactions : list of tuples
+        A list containing the interactions of the match as shown at the top of
+        this file.
+
+    Returns
+    ----------
+    state_to_C_distributions : List of Counter Object
+        List of Dictionaries where the keys are the states and actions
+    """
+    if not interactions:
+        return None
+
+    distributions = [Counter([(state, outcome[j]) for state, outcome in zip(interactions,
+                                                              interactions[1:])])
+                     for j in range(2)]
+    return distributions
+
+
+def compute_normalised_state_to_action_distribution(interactions):
+    """
+    Returns the normalised count of each state to action
+    for a set of interactions.
+
+    Parameters
+    ----------
+    interactions : list of tuples
+        A list containing the interactions of the match as shown at the top of
+        this file.
+
+    Returns
+    ----------
+    normalised_state_to_C_distributions : List of Counter Object
+        List of Dictionaries where the keys are the states and actions and the
+        values
+        the proportion of times that state resulted in a cooperation.
+    """
+    if not interactions:
+        return None
+
+    distribution = compute_state_to_action_distribution(interactions)
+    normalized_distribution = []
+    for player in range(2):
+        counter = {}
+        for state in [('C', 'C'), ('C', 'D'), ('D', 'C'), ('D', 'D')]:
+            C_count = distribution[player].get((state, 'C'), 0)
+            D_count = distribution[player].get((state, 'D'), 0)
+            total = C_count + D_count
+            if total > 0:
+                if C_count > 0:
+                    counter[(state, 'C')] = C_count / (C_count + D_count)
+                if D_count > 0:
+                    counter[(state, 'D')] = D_count / (C_count + D_count)
+        normalized_distribution.append(Counter(counter))
+    return normalized_distribution
+
+
+
+
 def sparkline(actions, c_symbol='█', d_symbol=' '):
     return ''.join([
         c_symbol if play == 'C' else d_symbol for play in actions])

--- a/axelrod/interaction_utils.py
+++ b/axelrod/interaction_utils.py
@@ -137,8 +137,19 @@ def compute_normalised_state_distribution(interactions):
 
 def compute_state_to_action_distribution(interactions):
     """
-    Returns the count of each state to action
-    for a set of interactions.
+    Returns a list (for each player) of counts of each state to action pair
+    for a set of interactions. A state to action pair is of the form:
+
+    ((C, D), C)
+
+    Implying that from a state of (C, D) (the first player having played C and
+    the second playing D) the player in question then played C.
+
+    The following counter object, implies that the player in question was in
+    state (C, D) for a total of 12 times, subsequently cooperating 4 times and
+    defecting 8 times.
+
+    Counter({((C, D), C): 4, ((C, D), D): 8})
 
     Parameters
     ----------
@@ -149,7 +160,9 @@ def compute_state_to_action_distribution(interactions):
     Returns
     ----------
     state_to_C_distributions : List of Counter Object
-        List of Dictionaries where the keys are the states and actions
+        List of Counter objects where the keys are the states and actions and
+        the values the counts. The
+        first/second Counter corresponds to the first/second player.
     """
     if not interactions:
         return None
@@ -165,6 +178,21 @@ def compute_normalised_state_to_action_distribution(interactions):
     Returns the normalised count of each state to action
     for a set of interactions.
 
+    Returns a list (for each player) of normlised counts of each state to action
+    pair for a set of interactions. A state to action pair is of the form:
+
+    ((C, D), C)
+
+    Implying that from a state of (C, D) (the first player having played C and
+    the second playing D) the player in question then played C.
+
+    The following counter object, implies that the player in question was only
+    ever in
+    state (C, D), subsequently cooperating 1/3 of the time and
+    defecting 2/3 times.
+
+    Counter({((C, D), C): 0.333333, ((C, D), D): 0.66666667})
+
     Parameters
     ----------
     interactions : list of tuples
@@ -174,9 +202,9 @@ def compute_normalised_state_to_action_distribution(interactions):
     Returns
     ----------
     normalised_state_to_C_distributions : List of Counter Object
-        List of Dictionaries where the keys are the states and actions and the
-        values
-        the proportion of times that state resulted in a cooperation.
+        List of Counter objects where the keys are the states and actions and
+        the values the normalized counts.. The
+        first/second Counter corresponds to the first/second player.
     """
     if not interactions:
         return None
@@ -196,8 +224,6 @@ def compute_normalised_state_to_action_distribution(interactions):
                     counter[(state, 'D')] = D_count / (C_count + D_count)
         normalized_distribution.append(Counter(counter))
     return normalized_distribution
-
-
 
 
 def sparkline(actions, c_symbol='█', d_symbol=' '):

--- a/axelrod/result_set.py
+++ b/axelrod/result_set.py
@@ -340,8 +340,9 @@ class ResultSet(object):
     @update_progress_bar
     def _build_normalised_state_distribution(self):
         """
-        Returns
-        ----------
+        Returns:
+        --------
+            norm : list
 
             Normalised state distribution. A list of lists of counter objects:
 
@@ -361,10 +362,11 @@ class ResultSet(object):
     @update_progress_bar
     def _build_normalised_state_to_action_distribution(self):
         """
-        Returns
-        ----------
+        Returns:
+        --------
+            norm : list
 
-            Normalised state distribution. A list of lists of counter objects:
+            A list of lists of counter objects.
 
             Dictionary where the keys are the states and the values are a
             normalized counts of the number of times that state goes to a given

--- a/axelrod/tests/unit/test_interaction_utils.py
+++ b/axelrod/tests/unit/test_interaction_utils.py
@@ -22,11 +22,27 @@ class TestMatch(unittest.TestCase):
                           Counter({('D', 'C'): 2}),
                           Counter({('C', 'C'): 1, ('C', 'D'): 1}),
                           None]
+    state_to_action_distribution = [[Counter({(('C', 'D'), 'D'): 1}),
+                                     Counter({(('C', 'D'), 'C'): 1})],
+                                    [Counter({(('D', 'C'), 'D'): 1}),
+                                     Counter({(('D', 'C'), 'C'): 1})],
+                                    [Counter({(('C', 'C'), 'C'): 1}),
+                                     Counter({(('C', 'C'), 'D'): 1})],
+                                    None]
+
     normalised_state_distribution = [
         Counter({('C', 'D'): 0.5, ('D', 'C'): 0.5}),
         Counter({('D', 'C'): 1.0}),
         Counter({('C', 'C'): 0.5, ('C', 'D'): 0.5}),
         None]
+    normalised_state_to_action_distribution = [[Counter({(('C', 'D'), 'D'): 1}),
+                                                Counter({(('C', 'D'), 'C'): 1})],
+                                               [Counter({(('D', 'C'), 'D'): 1}),
+                                                Counter({(('D', 'C'), 'C'): 1})],
+                                               [Counter({(('C', 'C'), 'C'): 1}),
+                                                Counter({(('C', 'C'), 'D'): 1})],
+                                               None]
+
     sparklines = [ '█ \n █', '  \n██', '██\n█ ', None ]
 
     def test_compute_scores(self):
@@ -62,6 +78,37 @@ class TestMatch(unittest.TestCase):
     def test_compute_normalised_state_distribution(self):
         for inter, dist in zip(self.interactions, self.normalised_state_distribution):
             self.assertEqual(dist, iu.compute_normalised_state_distribution(inter))
+
+    def test_compute_state_to_action_distribution(self):
+        for inter, dist in zip(self.interactions,
+                               self.state_to_action_distribution):
+            self.assertEqual(dist,
+                             iu.compute_state_to_action_distribution(inter))
+        inter = [(C, D), (D, C), (C, D), (D, C), (D, D), (C, C), (C, D)]
+        expected_dist =[Counter({(('C', 'C'), 'C'): 1, (('D', 'C'), 'C'): 1,
+                                 (('C', 'D'), 'D'): 2, (('D', 'C'), 'D'): 1,
+                                 (('D', 'D'), 'C'): 1}),
+                        Counter({(('C', 'C'), 'D'): 1,
+                                 (('C', 'D'), 'C'): 2, (('D', 'C'), 'D'): 2,
+                                 (('D', 'D'), 'C'): 1})]
+
+        self.assertEqual(expected_dist,
+                         iu.compute_state_to_action_distribution(inter))
+
+    def test_compute_normalised_state_to_action_distribution(self):
+        for inter, dist in zip(self.interactions,
+                               self.normalised_state_to_action_distribution):
+            self.assertEqual(dist,
+                             iu.compute_normalised_state_to_action_distribution(inter))
+        inter = [(C, D), (D, C), (C, D), (D, C), (D, D), (C, C), (C, D)]
+        expected_dist =[Counter({(('C', 'C'), 'C'): 1, (('D', 'C'), 'C'): 1 / 2,
+                                 (('C', 'D'), 'D'): 1, (('D', 'C'), 'D'): 1 / 2,
+                                 (('D', 'D'), 'C'): 1}),
+                        Counter({(('C', 'C'), 'D'): 1,
+                                 (('C', 'D'), 'C'): 1, (('D', 'C'), 'D'): 1,
+                                 (('D', 'D'), 'C'): 1})]
+        self.assertEqual(expected_dist,
+                         iu.compute_normalised_state_to_action_distribution(inter))
 
     def test_compute_sparklines(self):
         for inter, spark in zip(self.interactions, self.sparklines):

--- a/docs/tutorials/getting_started/tournament_results.rst
+++ b/docs/tutorials/getting_started/tournament_results.rst
@@ -24,6 +24,10 @@ This tutorial will show you how to access the various results of a tournament:
 - State distribution: the count of each type of state of a match
 - Normalised state distribution: the normalised count of each type of state of a
   match
+- State to action distribution: the count of each type of state to action pair
+  of a match
+- Normalised state distribution: the normalised count of each type of state to
+  action pair of a match
 - Initial cooperation count: the count of initial cooperation by each player.
 - Initial cooperation rate: the rate of initial cooperation by each player.
 - Cooperation rating: cooperation rating of each player
@@ -269,6 +273,58 @@ the second the action of the opponent::
       Counter({('C', 'C'): 1.0}),
       Counter()]]
 
+State to action distribution counts
+-----------------------------------
+
+This gives a total state action pair count against each opponent. A state
+corresponds to 1 turn of a match and can be one of :code:`('C', 'C'), ('C',
+'D'), ('D', 'C'), ('D', 'D')` where the first element is the action of the
+player in question and the second the action of the opponent::
+
+    >>> pprint.pprint(results.state_to_action_distribution)  # doctest: +SKIP
+    [[Counter(),
+      Counter({(('C', 'D'), 'C'): 27}),
+      Counter({(('C', 'C'), 'C'): 27}),
+      Counter({(('C', 'C'), 'C'): 27})],
+     [Counter({(('D', 'C'), 'D'): 27}),
+      Counter(),
+      Counter({(('D', 'D'), 'D'): 24, (('D', 'C'), 'D'): 3}),
+      Counter({(('D', 'D'), 'D'): 24, (('D', 'C'), 'D'): 3})],
+     [Counter({(('C', 'C'), 'C'): 27}),
+      Counter({(('D', 'D'), 'D'): 24, (('C', 'D'), 'D'): 3}),
+      Counter(),
+      Counter({(('C', 'C'), 'C'): 27})],
+     [Counter({(('C', 'C'), 'C'): 27}),
+      Counter({(('D', 'D'), 'D'): 24, (('C', 'D'), 'D'): 3}),
+      Counter({(('C', 'C'), 'C'): 27}),
+      Counter()]]
+
+Normalised state to action distribution
+---------------------------------------
+
+This gives the average rate state to action pair distribution against each
+opponent.  A state corresponds to 1 turn of a match and can be one of
+:code:`('C', 'C'), ('C', 'D'), ('D', 'C'), ('D', 'D')` where the first element
+is the action of the player in question and the second the action of the
+opponent::
+
+    >>> pprint.pprint(results.normalised_state_to_action_distribution) # doctest: +SKIP
+    [[Counter(),
+      Counter({(('C', 'D'), 'C'): 1.0}),
+      Counter({(('C', 'C'), 'C'): 1.0}),
+      Counter({(('C', 'C'), 'C'): 1.0})],
+     [Counter({(('D', 'C'), 'D'): 1.0}),
+      Counter(),
+      Counter({(('D', 'C'), 'D'): 1.0, (('D', 'D'), 'D'): 1.0}),
+      Counter({(('D', 'C'), 'D'): 1.0, (('D', 'D'), 'D'): 1.0})],
+     [Counter({(('C', 'C'), 'C'): 1.0}),
+      Counter({(('C', 'D'), 'D'): 1.0, (('D', 'D'), 'D'): 1.0}),
+      Counter(),
+      Counter({(('C', 'C'), 'C'): 1.0})],
+     [Counter({(('C', 'C'), 'C'): 1.0}),
+      Counter({(('C', 'D'), 'D'): 1.0, (('D', 'D'), 'D'): 1.0}),
+      Counter({(('C', 'C'), 'C'): 1.0}),
+      Counter()]]
 
 Initial cooperation counts
 --------------------------
@@ -337,8 +393,8 @@ It is also possible to write this data directly to a csv file using the
     ...     csvreader = csv.reader(outfile)
     ...     for row in csvreader:
     ...         print(row)
-    ['Rank', 'Name', 'Median_score', 'Cooperation_rating', 'Wins', 'Initial_C_rate', 'CC_rate', 'CD_rate', 'DC_rate', 'DD_rate']
-    ['0', 'Defector', '2.6...', '0.0', '3.0', '0.0', '0.0', '0.0', '0.4...', '0.6...']
-    ['1', 'Tit For Tat', '2.3...', '0.7', '0.0', '1.0', '0.66...', '0.03...', '0.0', '0.3...']
-    ['2', 'Grudger', '2.3...', '0.7', '0.0', '1.0', '0.66...', '0.03...', '0.0', '0.3...']
-    ['3', 'Cooperator', '2.0...', '1.0', '0.0', '1.0', '0.66...', '0.33...', '0.0', '0.0']
+    ['Rank', 'Name', 'Median_score', 'Cooperation_rating', 'Wins', 'Initial_C_rate', 'CC_rate', 'CD_rate', 'DC_rate', 'DD_rate', 'CC_to_C_rate', 'CD_to_C_rate', 'DC_to_C_rate', 'DD_to_C_rate']
+    ['0', 'Defector', '2.6...', '0.0', '3.0', '0.0', '0.0', '0.0', '0.4...', '0.6...', '0', '0', '0', '0']
+    ['1', 'Tit For Tat', '2.3...', '0.7', '0.0', '1.0', '0.66...', '0.03...', '0.0', '0.3...', '1.0', '0', '0', '0']
+    ['2', 'Grudger', '2.3...', '0.7', '0.0', '1.0', '0.66...', '0.03...', '0.0', '0.3...', '1.0', '0', '0', '0']
+    ['3', 'Cooperator', '2.0...', '1.0', '0.0', '1.0', '0.66...', '0.33...', '0.0', '0.0', '1.0', '1.0', '0', '0']


### PR DESCRIPTION
Add two functions to interaction_utils:

- `interaction_utils.compute_state_to_action_distribution`: computes
  list of counter objects of mapping a `(state, action)` to a count.
- `interaction_utils.compute_normalised_state_to_action_distribution`: computes
  list of counter objects of mapping a `(state, action)` to a normalised
  count (for a given state).

There have then been incorporated in `axelrod.result_set` and in particular in
the `result_set.summarise()` output. Which now includes the average
rates for each strategy in a tournament. So for memory 1 strategies this
means we can measure their parameters and for non memory 1 strategies we
can infer what the parameters correspond to the data.