### PR TITLE
Add a versus_test method to TestPlayer

### DIFF
--- a/axelrod/mock_player.py
+++ b/axelrod/mock_player.py
@@ -2,6 +2,7 @@ import warnings
 from axelrod.actions import Actions, Action
 from axelrod.player import Player, update_history, update_state_distribution
 from collections import defaultdict
+from itertools import cycle
 
 from typing import List, Tuple
 
@@ -28,16 +29,16 @@ class MockPlayer(Player):
         if state_dist:
             self.state_distribution = dict(state_dist)
         if actions:
-            self.actions = list(actions)
+            self.actions = cycle(actions)
         else:
             self.actions = []
 
     def strategy(self, opponent: Player) -> Action:
         # Return the next saved action, if present.
         try:
-            action = self.actions.pop(0)
+            action = self.actions.__next__()
             return action
-        except IndexError:
+        except AttributeError:
             return C
 
 

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -1,7 +1,9 @@
 from collections import defaultdict
 from functools import wraps
+import types
 import random
 import copy
+import numpy as np
 
 from axelrod.actions import Actions, flip_action, Action
 from .game import DefaultGame
@@ -189,3 +191,21 @@ class Player(object):
         self.cooperations = 0
         self.defections = 0
         self.state_distribution = defaultdict(int)
+
+    def __eq__(self, other):
+        """
+        Test if two players are equal.
+        """
+        check = self.__repr__() == other.__repr__()
+        for attribute, value in self.__dict__.items():
+            other_value = getattr(other, attribute)
+
+            if isinstance(value, np.ndarray):
+                check = check and np.array_equal(value, other_value)
+
+            elif isinstance(value, types.GeneratorType):
+                check = check and all(next(value) == next(other_value)
+                                      for _ in range(10))
+            else:
+                check = check and value == other_value
+        return check

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -1,9 +1,7 @@
 from collections import defaultdict
 from functools import wraps
-import types
 import random
 import copy
-import numpy as np
 
 from axelrod.actions import Actions, flip_action, Action
 from .game import DefaultGame
@@ -191,21 +189,3 @@ class Player(object):
         self.cooperations = 0
         self.defections = 0
         self.state_distribution = defaultdict(int)
-
-    def __eq__(self, other):
-        """
-        Test if two players are equal.
-        """
-        check = self.__repr__() == other.__repr__()
-        for attribute, value in self.__dict__.items():
-            other_value = getattr(other, attribute)
-
-            if isinstance(value, np.ndarray):
-                check = check and np.array_equal(value, other_value)
-
-            elif isinstance(value, types.GeneratorType):
-                check = check and all(next(value) == next(other_value)
-                                      for _ in range(10))
-            else:
-                check = check and value == other_value
-        return check

--- a/axelrod/strategies/apavlov.py
+++ b/axelrod/strategies/apavlov.py
@@ -29,7 +29,7 @@ class APavlov2006(Player):
 
     def __init__(self) -> None:
         super().__init__()
-        self.opponent_class = ""
+        self.opponent_class = None
 
     def strategy(self, opponent: Player) -> Action:
         # TFT for six rounds
@@ -96,7 +96,7 @@ class APavlov2011(Player):
 
     def __init__(self) -> None:
         super().__init__()
-        self.opponent_class = ""
+        self.opponent_class = None
 
     def strategy(self, opponent: Player) -> Action:
         # TFT for six rounds

--- a/axelrod/strategies/appeaser.py
+++ b/axelrod/strategies/appeaser.py
@@ -24,11 +24,11 @@ class Appeaser(Player):
 
     def strategy(self, opponent: Player) -> Action:
         if not len(opponent.history):
-            self.move = C
+            return C
         else:
             if opponent.history[-1] == D:
-                if self.move == C:
-                    self.move = D
+                if self.history[-1] == C:
+                    return D
                 else:
-                    self.move = C
-        return self.move
+                    return C
+        return self.history[-1]

--- a/axelrod/strategies/axelrod_first.py
+++ b/axelrod/strategies/axelrod_first.py
@@ -98,12 +98,10 @@ class RevisedDowning(Player):
 
         if self.revised:
             if round_number == 1:
-                self.move = C
-                return self.move
+                return C
         elif not self.revised:
             if round_number <= 2:
-                self.move = D
-                return self.move
+                return D
 
         # Update various counts
         if round_number > 2:
@@ -121,12 +119,12 @@ class RevisedDowning(Player):
         c = 6.0 * self.good - 8.0 * self.bad - 2
         alt = 4.0 * self.good - 5.0 * self.bad - 1
         if (c >= 0 and c >= alt):
-            self.move = C
+            move = C
         elif (c >= 0 and c < alt) or (alt >= 0):
-            self.move = flip_action(self.move)
+            move = flip_action(self.history[-1])
         else:
-            self.move = D
-        return self.move
+            move = D
+        return move
 
     def reset(self):
         super().reset()

--- a/axelrod/strategies/finite_state_machines.py
+++ b/axelrod/strategies/finite_state_machines.py
@@ -35,8 +35,8 @@ class SimpleFSM(object):
     def __eq__(self, other):
         """Equality of two FSMs"""
         check = True
-        check += self.state == other.state
-        check += self.state_transitions == other.state_transitions
+        for attr in ["state", "state_transitions"]:
+            check = check and getattr(self, attr) == getattr(other, attr)
         return check
 
 

--- a/axelrod/strategies/finite_state_machines.py
+++ b/axelrod/strategies/finite_state_machines.py
@@ -32,6 +32,13 @@ class SimpleFSM(object):
         self.state = next_state
         return next_action
 
+    def __eq__(self, other):
+        """Equality of two FSMs"""
+        check = True
+        check += self.state == other.state
+        check += self.state_transitions == other.state_transitions
+        return check
+
 
 class FSMPlayer(Player):
     """Abstract base class for finite state machine players."""
@@ -57,6 +64,7 @@ class FSMPlayer(Player):
             initial_action = C
         super().__init__()
         self.initial_state = initial_state
+        self.state = initial_state
         self.initial_action = initial_action
         self.fsm = SimpleFSM(transitions, initial_state)
 
@@ -73,6 +81,7 @@ class FSMPlayer(Player):
     def reset(self):
         super().reset()
         self.fsm.state = self.initial_state
+        self.state = self.initial_state
 
 
 class Fortress3(FSMPlayer):

--- a/axelrod/strategies/hmm.py
+++ b/axelrod/strategies/hmm.py
@@ -64,10 +64,9 @@ class SimpleHMM(object):
     def __eq__(self, other):
         """Equality of two HMMs"""
         check = True
-        check += self.transitions_C == other.transitions_C
-        check += self.transitions_D == other.transitions_D
-        check += self.emission_probabilities == other.emission_probabilities
-        check += self.state == other.state
+        for attr in ["transitions_C", "transitions_D",
+                     "emission_probabilities", "state"]:
+            check = check and getattr(self, attr) == getattr(other, attr)
         return check
 
 

--- a/axelrod/strategies/hmm.py
+++ b/axelrod/strategies/hmm.py
@@ -61,6 +61,16 @@ class SimpleHMM(object):
             return False
         return True
 
+    def __eq__(self, other):
+        """Equality of two HMMs"""
+        check = True
+        check += self.transitions_C == other.transitions_C
+        check += self.transitions_D == other.transitions_D
+        check += self.emission_probabilities == other.emission_probabilities
+        check += self.state == other.state
+        return check
+
+
     def move(self, opponent_action):
         """Changes state and computes the response action.
 
@@ -114,6 +124,7 @@ class HMMPlayer(Player):
         self.hmm = SimpleHMM(transitions_C, transitions_D,
                              emission_probabilities, initial_state)
         assert self.hmm.is_well_formed()
+        self.state = self.hmm.state
         self.classifier['stochastic'] = self.is_stochastic()
 
     def is_stochastic(self):
@@ -141,6 +152,7 @@ class HMMPlayer(Player):
     def reset(self):
         super().reset()
         self.hmm.state = self.initial_state
+        self.state = self.hmm.state
 
 
 class EvolvedHMM5(HMMPlayer):

--- a/axelrod/strategies/punisher.py
+++ b/axelrod/strategies/punisher.py
@@ -62,7 +62,7 @@ class Punisher(Player):
         """
         super().reset()
         self.grudged = False
-        self.grudge_memory = 0
+        self.grudge_memory = 1
         self.mem_length = 1
 
 
@@ -122,15 +122,15 @@ class InversePunisher(Player):
         """Resets internal variables and history"""
         super().reset()
         self.grudged = False
-        self.grudge_memory = 0
+        self.grudge_memory = 1
         self.mem_length = 1
 
 class LevelPunisher(Player):
     """
-    A player starts by cooperating however, after 10 rounds 
-    will defect if at any point the number of defections 
+    A player starts by cooperating however, after 10 rounds
+    will defect if at any point the number of defections
     by an opponent is greater than 20%.
-    
+
     Names:
 
     - Level Punisher: Name from CoopSim https://github.com/jecki/CoopSim

--- a/axelrod/strategies/qlearner.py
+++ b/axelrod/strategies/qlearner.py
@@ -49,6 +49,7 @@ class RiskyQLearner(Player):
         self.classifier['stochastic'] = True
 
         self.prev_action = random_choice()
+        self.original_prev_action = self.prev_action
         self.history = [] # type: List[Action]
         self.score = 0
         self.Qs = OrderedDict({'':  OrderedDict(zip([C, D], [0, 0]))})
@@ -117,7 +118,7 @@ class RiskyQLearner(Player):
         self.Qs = {'': {C: 0, D: 0}}
         self.Vs = {'': 0}
         self.prev_state = ''
-        self.prev_action = random_choice()
+        self.prev_action = self.original_prev_action
 
 
 class ArrogantQLearner(RiskyQLearner):

--- a/axelrod/strategies/stalker.py
+++ b/axelrod/strategies/stalker.py
@@ -34,7 +34,7 @@ class Stalker(Player):
     classifier = {
         'memory_depth': float('inf'),
         'stochastic': True,
-        'makes_use_of': set(),
+        'makes_use_of': set(["game", "length"]),
         'long_run_time': False,
         'inspects_source': False,
         'manipulates_source': False,
@@ -46,7 +46,7 @@ class Stalker(Player):
         R, P, S, T  = self.match_attributes["game"].RPST()
         self.very_good_score = R
         self.very_bad_score = P
-        self.wish_score = ( R + P ) / 2
+        self.wish_score = (R + P) / 2
         self.current_score = 0
 
     def score_last_round(self, opponent: Player):

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -304,7 +304,7 @@ class OmegaTFT(Player):
 
         # Are we deadlocked? (in a CD -> DC loop)
         if (self.deadlock_counter >= self.deadlock_threshold):
-            self.move = C
+            move = C
             if self.deadlock_counter == self.deadlock_threshold:
                 self.deadlock_counter = self.deadlock_threshold + 1
             else:
@@ -323,16 +323,16 @@ class OmegaTFT(Player):
             # Compare counts to thresholds
             # If randomness_counter exceeds Y, Defect for the remainder
             if self.randomness_counter >= 8:
-                self.move = D
+                move = D
             else:
                 # TFT
-                self.move = D if opponent.history[-1:] == [D] else C
+                move = D if opponent.history[-1:] == [D] else C
                 # Check for deadlock
                 if opponent.history[-2] != opponent.history[-1]:
                     self.deadlock_counter += 1
                 else:
                     self.deadlock_counter = 0
-        return self.move
+        return move
 
     def reset(self):
         super().reset()

--- a/axelrod/tests/unit/test_calculator.py
+++ b/axelrod/tests/unit/test_calculator.py
@@ -44,6 +44,7 @@ class TestCalculator(TestPlayer):
                    D, C]
         self.responses_test([C], [C] * 22, history)
 
-    def attribute_test(self, player, clone):
+    def attribute_equality_test(self, player, clone):
         """Overwrite the default test to check Joss instance"""
         self.assertIsInstance(player.joss_instance, axelrod.Joss)
+        self.assertIsInstance(clone.joss_instance, axelrod.Joss)

--- a/axelrod/tests/unit/test_calculator.py
+++ b/axelrod/tests/unit/test_calculator.py
@@ -44,3 +44,6 @@ class TestCalculator(TestPlayer):
                    D, C]
         self.responses_test([C], [C] * 22, history)
 
+    def attribute_test(self, player, clone):
+        """Overwrite the default test to check Joss instance"""
+        self.assertIsInstance(player.joss_instance, axelrod.Joss)

--- a/axelrod/tests/unit/test_grumpy.py
+++ b/axelrod/tests/unit/test_grumpy.py
@@ -45,7 +45,7 @@ class TestGrumpy(TestPlayer):
                             init_kwargs={"grumpy_threshold": 3,
                                          "nice_threshold": 0})
 
-    def test_reset(self):
+    def test_reset_state(self):
         P1 = axelrod.Grumpy(starting_state='Grumpy')
         P1.state = 'Nice'
         P1.reset()

--- a/axelrod/tests/unit/test_grumpy.py
+++ b/axelrod/tests/unit/test_grumpy.py
@@ -45,7 +45,7 @@ class TestGrumpy(TestPlayer):
                             init_kwargs={"grumpy_threshold": 3,
                                          "nice_threshold": 0})
 
-    def test_reset_state(self):
+    def test_reset_state_with_non_default_init(self):
         P1 = axelrod.Grumpy(starting_state='Grumpy')
         P1.state = 'Nice'
         P1.reset()

--- a/axelrod/tests/unit/test_human.py
+++ b/axelrod/tests/unit/test_human.py
@@ -91,3 +91,7 @@ class TestHumanClass(TestPlayer):
         expected_action = C
         actual_action = human.strategy(Player(), lambda: C)
         self.assertEqual(actual_action, expected_action)
+
+    def test_reset_history_and_attributes(self):
+        """Overwrite the reset method for this strategy."""
+        pass

--- a/axelrod/tests/unit/test_match_generator.py
+++ b/axelrod/tests/unit/test_match_generator.py
@@ -32,11 +32,11 @@ class TestTournamentType(unittest.TestCase):
         self.assertEqual(tt.turns, test_turns)
         player = tt.players[0]
         opponent = tt.opponents[0]
-        self.assertEqual(player, opponent)
-        self.assertIsNot(player, opponent)
+        self.assertEqual(player.name, opponent.name)
+        self.assertNotEqual(player, opponent)
         # Check that the two player instances are wholly independent
         opponent.name = 'Test'
-        self.assertNotEqual(player, opponent)
+        self.assertNotEqual(player.name, opponent.name)
 
     def test_len(self):
         tt = axelrod.MatchGenerator(

--- a/axelrod/tests/unit/test_match_generator.py
+++ b/axelrod/tests/unit/test_match_generator.py
@@ -32,11 +32,11 @@ class TestTournamentType(unittest.TestCase):
         self.assertEqual(tt.turns, test_turns)
         player = tt.players[0]
         opponent = tt.opponents[0]
-        self.assertEqual(player.name, opponent.name)
-        self.assertNotEqual(player, opponent)
+        self.assertEqual(player, opponent)
+        self.assertIsNot(player, opponent)
         # Check that the two player instances are wholly independent
         opponent.name = 'Test'
-        self.assertNotEqual(player.name, opponent.name)
+        self.assertNotEqual(player, opponent)
 
     def test_len(self):
         tt = axelrod.MatchGenerator(

--- a/axelrod/tests/unit/test_memorytwo.py
+++ b/axelrod/tests/unit/test_memorytwo.py
@@ -41,3 +41,16 @@ class TestMEM2(TestPlayer):
         # ALLD forever if all D twice
         self.responses_test([D] * 10, [C, D, D, D, D, D], [D, D, D, D, D, D])
         self.responses_test([D] * 9, [C] + [D] * 5 + [C] * 4, [D] * 6 + [C] * 4)
+
+    def attribute_equality_test(self, player, clone):
+        """Overwrite specific test to be able to test self.players"""
+        for p in [player, clone]:
+            self.assertEqual(p.play_as, "TFT")
+            self.assertEqual(p.shift_counter, 3)
+            self.assertEqual(p.alld_counter, 0)
+
+        for key, value in [("TFT", axelrod.TitForTat),
+                           ("TFTT", axelrod.TitFor2Tats),
+                           ("ALLD", axelrod.Defector)]:
+            self.assertEqual(p.players[key].history, [])
+            self.assertIsInstance(p.players[key], value)

--- a/axelrod/tests/unit/test_meta.py
+++ b/axelrod/tests/unit/test_meta.py
@@ -46,16 +46,11 @@ class TestMetaPlayer(TestPlayer):
                              msg="%s - Behaviour: %s != Expected Behaviour: %s" %
                                  (key, player.classifier[key], classifier[key]))
 
-    def attribute_test(self, player, clone):
+    def attribute_equality_test(self, player, clone):
         """Overwriting this specific method to check team."""
-        opponent = axelrod.Cooperator()
-        player.play(opponent)
-        player.play(opponent)
-        player.play(opponent)
-        player.reset()
-        for i, p in enumerate(player.team):
-            self.assertEqual(len(p.history), 0)
-
+        for p1, p2 in zip(player.team, clone.team):
+            self.assertEqual(len(p1.history), 0)
+            self.assertEqual(len(p2.history), 0)
 
         team_player_names = [p.__repr__() for p in player.team]
         team_clone_names = [p.__repr__() for p in clone.team]

--- a/axelrod/tests/unit/test_meta.py
+++ b/axelrod/tests/unit/test_meta.py
@@ -46,16 +46,21 @@ class TestMetaPlayer(TestPlayer):
                              msg="%s - Behaviour: %s != Expected Behaviour: %s" %
                                  (key, player.classifier[key], classifier[key]))
 
-    def test_reset(self):
-        p1 = self.player()
-        p2 = axelrod.Cooperator()
-        p1.play(p2)
-        p1.play(p2)
-        p1.play(p2)
-        p1.reset()
-        for player in p1.team:
-            self.assertEqual(len(player.history), 0)
+    def test_reset_history_and_attributes(self):
+        player = self.player()
+        clone = player.clone()
+        opponent = axelrod.Cooperator()
+        player.play(opponent)
+        player.play(opponent)
+        player.play(opponent)
+        player.reset()
+        for i, p in enumerate(player.team):
+            self.assertEqual(len(p.history), 0)
 
+
+        team_player_names = [p.__repr__() for p in player.team]
+        team_clone_names = [p.__repr__() for p in clone.team]
+        self.assertEqual(team_player_names, team_clone_names)
 
 class TestMetaMajority(TestMetaPlayer):
 
@@ -222,8 +227,6 @@ class TestMetaHunter(TestMetaPlayer):
         self.responses_test([D], [C] * 4, [D] * 4)
         self.responses_test([D], [C] * 6, [C, D] * 3)
         self.responses_test([D], [C] * 8, [C, C, C, D, C, C, C, D])
-        self.responses_test([D], [C] * 100,
-                            [random.choice([C, D]) for i in range(100)])
         # Test post 100 rounds responses
         self.responses_test([C], [C] * 101, [C] * 101)
         self.responses_test([D], [C] * 101, [C] * 100 + [D])
@@ -257,8 +260,6 @@ class TestMetaHunterAggressive(TestMetaPlayer):
         self.responses_test([D], [C] * 4, [D] * 4)
         self.responses_test([D], [C] * 6, [C, D] * 3)
         self.responses_test([D], [C] * 8, [C, C, C, D, C, C, C, D])
-        self.responses_test([D], [C] * 100,
-                            [random.choice([C, D]) for i in range(100)])
         # Test post 100 rounds responses
         self.responses_test([D], [C] * 101, [C] * 101)
         self.responses_test([D], [C] * 101, [C] * 100 + [D])

--- a/axelrod/tests/unit/test_meta.py
+++ b/axelrod/tests/unit/test_meta.py
@@ -46,9 +46,8 @@ class TestMetaPlayer(TestPlayer):
                              msg="%s - Behaviour: %s != Expected Behaviour: %s" %
                                  (key, player.classifier[key], classifier[key]))
 
-    def test_reset_history_and_attributes(self):
-        player = self.player()
-        clone = player.clone()
+    def attribute_test(self, player, clone):
+        """Overwriting this specific method to check team."""
         opponent = axelrod.Cooperator()
         player.play(opponent)
         player.play(opponent)

--- a/axelrod/tests/unit/test_mock_player.py
+++ b/axelrod/tests/unit/test_mock_player.py
@@ -23,13 +23,14 @@ class TestMockPlayer(unittest.TestCase):
     def test_history(self):
         t = TestOpponent()
         m1 = MockPlayer([C], history=[C]*10)
-        self.assertEqual(m1.actions[0], C)
+        self.assertEqual(m1.actions.__next__(), C)
         self.assertEqual(m1.history, [C] * 10)
         self.assertEqual(m1.cooperations, 10)
         self.assertEqual(m1.defections, 0)
         self.assertEqual(m1.strategy(t), C)
+
         m2 = MockPlayer([D], history=[D]*10)
-        self.assertEqual(m2.actions[0], D)
+        self.assertEqual(m2.actions.__next__(), D)
         self.assertEqual(m2.history, [D] * 10)
         self.assertEqual(m2.cooperations, 0)
         self.assertEqual(m2.defections, 10)

--- a/axelrod/tests/unit/test_player.py
+++ b/axelrod/tests/unit/test_player.py
@@ -324,9 +324,6 @@ class TestPlayer(unittest.TestCase):
             A list of keyword arguments to instantiate player with
         """
 
-        if type(opponent) is list:
-            opponent = MockPlayer(opponent)
-
         turns = len(expected_outcomes)
 
         if init_args is None:

--- a/axelrod/tests/unit/test_player.py
+++ b/axelrod/tests/unit/test_player.py
@@ -1,6 +1,7 @@
 import random
 import unittest
 import warnings
+import types
 
 import numpy as np
 
@@ -225,9 +226,15 @@ class TestPlayer(unittest.TestCase):
 
         for attribute, reset_value in player.__dict__.items():
             original_value = getattr(clone, attribute)
+
             if isinstance(reset_value, np.ndarray):
                 self.assertTrue(np.array_equal(reset_value, original_value),
                                 msg=attribute)
+
+            if isinstance(reset_value, types.GeneratorType):
+                for _ in range(10):
+                    self.assertEqual(next(reset_value),
+                                     next(original_value), msg=attribute)
             else:
                 self.assertEqual(reset_value, original_value, msg=attribute)
 

--- a/axelrod/tests/unit/test_player.py
+++ b/axelrod/tests/unit/test_player.py
@@ -303,7 +303,7 @@ class TestPlayer(unittest.TestCase):
             actions is passed, a Mock Player is created that cycles over that
             sequence.
         expected_outcomes: List
-            the expected outcomes of the match (list of tuples of actions).
+            The expected outcomes of the match (list of tuples of actions).
         noise: float
             Any noise to be passed to a match
         seed: int
@@ -316,7 +316,7 @@ class TestPlayer(unittest.TestCase):
             `{length:-1}` implies that the players do not know the length of the
             match.
         attrs: dict
-            dictionary of internal attributes to check at the end of all plays
+            Dictionary of internal attributes to check at the end of all plays
             in player
         init_kwargs: dict
             A dictionary of keyword arguments to instantiate player with

--- a/axelrod/tests/unit/test_player.py
+++ b/axelrod/tests/unit/test_player.py
@@ -224,18 +224,22 @@ class TestPlayer(unittest.TestCase):
         self.assertEqual(player.defections, 0)
         self.assertEqual(player.state_distribution, dict())
 
-        self.attribute_test(player, clone)
+        self.attribute_equality_test(player, clone)
 
     def test_reset_clone(self):
         """Make sure history resetting with cloning works correctly, regardless
         if self.test_reset() is overwritten."""
         player = self.player()
         clone = player.clone()
-        self.attribute_test(player, clone)
+        self.attribute_equality_test(player, clone)
 
-    def attribute_test(self, player, clone):
+    def attribute_equality_test(self, player, clone):
         """A separate method to test equality of attributes. This method can be
-        overwritten in certain cases"""
+        overwritten in certain cases.
+
+        This method checks that all the attributes of `player` and `clone` are
+        the same which is used in the test of the cloning and the resetting.
+        """
 
         for attribute, reset_value in player.__dict__.items():
             original_value = getattr(clone, attribute)

--- a/axelrod/tests/unit/test_player.py
+++ b/axelrod/tests/unit/test_player.py
@@ -224,6 +224,19 @@ class TestPlayer(unittest.TestCase):
         self.assertEqual(player.defections, 0)
         self.assertEqual(player.state_distribution, dict())
 
+        self.attribute_test(player, clone)
+
+    def test_reset_clone(self):
+        """Make sure history resetting with cloning works correctly, regardless
+        if self.test_reset() is overwritten."""
+        player = self.player()
+        clone = player.clone()
+        self.attribute_test(player, clone)
+
+    def attribute_test(self, player, clone):
+        """A separate method to test equality of attributes. This method can be
+        overwritten in certain cases"""
+
         for attribute, reset_value in player.__dict__.items():
             original_value = getattr(clone, attribute)
 
@@ -237,19 +250,6 @@ class TestPlayer(unittest.TestCase):
                                      next(original_value), msg=attribute)
             else:
                 self.assertEqual(reset_value, original_value, msg=attribute)
-
-    def test_reset_clone(self):
-        """Make sure history resetting with cloning works correctly, regardless
-        if self.test_reset() is overwritten."""
-        player = self.player()
-        clone = player.clone()
-        for attribute, value in player.__dict__.items():
-            clone_value = getattr(player, attribute)
-            if isinstance(value, np.ndarray):
-                self.assertTrue(np.array_equal(value, clone_value),
-                                msg=attribute)
-            else:
-                self.assertEqual(value, clone_value, msg=attribute)
 
     def test_clone(self):
         # Test that the cloned player produces identical play

--- a/axelrod/tests/unit/test_player.py
+++ b/axelrod/tests/unit/test_player.py
@@ -291,7 +291,7 @@ class TestPlayer(unittest.TestCase):
     def versus_test(self, opponent, expected_outcomes,
                     noise=None, seed=None, turns=10,
                     match_attributes=None, attrs=None,
-                    init_args=None, init_kwargs=None):
+                    init_kwargs=None):
         """
         Tests a sequence of outcomes for two given players.
 
@@ -318,23 +318,18 @@ class TestPlayer(unittest.TestCase):
         attrs: dict
             dictionary of internal attributes to check at the end of all plays
             in player
-        init_args: tuple or list
-            A list of arguments to instantiate player with
-        init_kwargs: dictionary
-            A list of keyword arguments to instantiate player with
+        init_kwargs: dict
+            A dictionary of keyword arguments to instantiate player with
         """
 
         turns = len(expected_outcomes)
-
-        if init_args is None:
-            init_args = ()
         if init_kwargs is None:
             init_kwargs = dict()
 
         if seed is not None:
             axelrod.seed(seed)
 
-        player = self.player(*init_args, **init_kwargs)
+        player = self.player(**init_kwargs)
 
         match = axelrod.Match((player, opponent), turns=turns, noise=noise,
                               match_attributes=match_attributes)

--- a/axelrod/tests/unit/test_player.py
+++ b/axelrod/tests/unit/test_player.py
@@ -231,7 +231,7 @@ class TestPlayer(unittest.TestCase):
                 self.assertTrue(np.array_equal(reset_value, original_value),
                                 msg=attribute)
 
-            if isinstance(reset_value, types.GeneratorType):
+            elif isinstance(reset_value, types.GeneratorType):
                 for _ in range(10):
                     self.assertEqual(next(reset_value),
                                      next(original_value), msg=attribute)

--- a/axelrod/tests/unit/test_player.py
+++ b/axelrod/tests/unit/test_player.py
@@ -323,8 +323,6 @@ class TestPlayer(unittest.TestCase):
         init_kwargs: dictionary
             A list of keyword arguments to instantiate player with
         """
-        if seed:
-            axelrod.seed(seed)
 
         if type(opponent) is list:
             opponent = MockPlayer(opponent)
@@ -335,6 +333,10 @@ class TestPlayer(unittest.TestCase):
             init_args = ()
         if init_kwargs is None:
             init_kwargs = dict()
+
+        if seed is not None:
+            axelrod.seed(seed)
+
         player = self.player(*init_args, **init_kwargs)
 
         match = axelrod.Match((player, opponent), turns=turns, noise=noise,

--- a/axelrod/tests/unit/test_player.py
+++ b/axelrod/tests/unit/test_player.py
@@ -304,7 +304,7 @@ class TestPlayer(unittest.TestCase):
             test_responses(self, self.player(), axelrod.Defector(),
                            rDD, D, D, seed=seed)
 
-    def versus_test(self, opponent, expected_outcomes,
+    def versus_test(self, opponent, expected_actions,
                     noise=None, seed=None, turns=10,
                     match_attributes=None, attrs=None,
                     init_kwargs=None):
@@ -318,7 +318,7 @@ class TestPlayer(unittest.TestCase):
             An instance of a player OR a sequence of actions. If a sequence of
             actions is passed, a Mock Player is created that cycles over that
             sequence.
-        expected_outcomes: List
+        expected_actions: List
             The expected outcomes of the match (list of tuples of actions).
         noise: float
             Any noise to be passed to a match
@@ -338,7 +338,7 @@ class TestPlayer(unittest.TestCase):
             A dictionary of keyword arguments to instantiate player with
         """
 
-        turns = len(expected_outcomes)
+        turns = len(expected_actions)
         if init_kwargs is None:
             init_kwargs = dict()
 
@@ -349,7 +349,7 @@ class TestPlayer(unittest.TestCase):
 
         match = axelrod.Match((player, opponent), turns=turns, noise=noise,
                               match_attributes=match_attributes)
-        self.assertEqual(match.play(), expected_outcomes)
+        self.assertEqual(match.play(), expected_actions)
 
         if attrs:
             player = match.players[0]

--- a/axelrod/tests/unit/test_punisher.py
+++ b/axelrod/tests/unit/test_punisher.py
@@ -47,16 +47,6 @@ class TestPunisher(TestPlayer):
                             attrs={"grudged": True, "grudge_memory": 0,
                                    "mem_length": 2})
 
-    def test_reset_method(self):
-        """Tests the reset method."""
-        P1 = axelrod.Punisher()
-        P1.history = [C, D, D, D]
-        P1.grudged = True
-        P1.grudge_memory = 4
-        P1.reset()
-        self.assertEqual(P1.grudged, False)
-        self.assertEqual(P1.grudge_memory, 0)
-
 
 class TestInversePunisher(TestPlayer):
 
@@ -103,15 +93,6 @@ class TestInversePunisher(TestPlayer):
                             attrs={"grudged": True, "grudge_memory": 0,
                                    "mem_length": 16})
 
-    def test_reset_method(self):
-        P1 = axelrod.InversePunisher()
-        P1.history = [C, D, D, D]
-        P1.grudged = True
-        P1.grudge_memory = 4
-        P1.reset()
-        self.assertEqual(P1.grudged, False)
-        self.assertEqual(P1.grudge_memory, 0)
-
 class TestLevelPunisher(TestPlayer):
 
     name = "Level Punisher"
@@ -129,11 +110,11 @@ class TestLevelPunisher(TestPlayer):
     def test_strategy(self):
         # Starts by Cooperating
         self.first_play_test(C)
-        
+
         # Defects if the turns played are less than 10.
         self.responses_test([C], [C], [C])
         self.responses_test([C], [C] * 4, [C, D, C, D])
-        
+
         # Check for the number of rounds greater than 10.
         self.responses_test([C], [C] * 10, [C, C, C, C, D, C, C, C, C, D])
         #Check if number of defections by opponent is greater than 20%

--- a/axelrod/tests/unit/test_rand.py
+++ b/axelrod/tests/unit/test_rand.py
@@ -26,7 +26,7 @@ class TestRandom(TestPlayer):
         self.first_play_test(D, seed=2)
 
         opponent = axelrod.MockPlayer()
-        outcomes = [(C, C), (D, C), (D, C)]
+        outcomes = [(C, C), (D, C), (D, C), (C, C)]
         self.versus_test(opponent, expected_outcomes=outcomes, seed=1)
 
         opponent = axelrod.MockPlayer()

--- a/axelrod/tests/unit/test_rand.py
+++ b/axelrod/tests/unit/test_rand.py
@@ -24,7 +24,24 @@ class TestRandom(TestPlayer):
         """Test that strategy is randomly picked (not affected by history)."""
         self.first_play_test(C, seed=1)
         self.first_play_test(D, seed=2)
-        self.responses_test([C], [C, D, C], [C, C, D], seed=1)
+
+        opponent = axelrod.MockPlayer()
+        outcomes = [(C, C), (D, C), (D, C)]
+        self.versus_test(opponent, expected_outcomes=outcomes, seed=1)
+
+        opponent = axelrod.MockPlayer()
+        outcomes = [(D, C), (D, C), (C, C)]
+        self.versus_test(opponent, expected_outcomes=outcomes, seed=2)
+
+        opponent = axelrod.MockPlayer()
+        outcomes = [(D, C), (D, C), (D, C)]
+        self.versus_test(opponent, expected_outcomes=outcomes,
+                         init_kwargs={"p": 0})
+
+        opponent = axelrod.MockPlayer()
+        outcomes = [(C, C), (C, C), (C, C)]
+        self.versus_test(opponent, expected_outcomes=outcomes,
+                         init_kwargs={"p": 1})
 
     def test_deterministic_classification(self):
         """Test classification when p is 0 or 1"""

--- a/axelrod/tests/unit/test_rand.py
+++ b/axelrod/tests/unit/test_rand.py
@@ -26,21 +26,21 @@ class TestRandom(TestPlayer):
         self.first_play_test(D, seed=2)
 
         opponent = axelrod.MockPlayer()
-        outcomes = [(C, C), (D, C), (D, C), (C, C)]
-        self.versus_test(opponent, expected_outcomes=outcomes, seed=1)
+        actions = [(C, C), (D, C), (D, C), (C, C)]
+        self.versus_test(opponent, expected_actions=actions, seed=1)
 
         opponent = axelrod.MockPlayer()
-        outcomes = [(D, C), (D, C), (C, C)]
-        self.versus_test(opponent, expected_outcomes=outcomes, seed=2)
+        actions = [(D, C), (D, C), (C, C)]
+        self.versus_test(opponent, expected_actions=actions, seed=2)
 
         opponent = axelrod.MockPlayer()
-        outcomes = [(D, C), (D, C), (D, C)]
-        self.versus_test(opponent, expected_outcomes=outcomes,
+        actions = [(D, C), (D, C), (D, C)]
+        self.versus_test(opponent, expected_actions=actions,
                          init_kwargs={"p": 0})
 
         opponent = axelrod.MockPlayer()
-        outcomes = [(C, C), (C, C), (C, C)]
-        self.versus_test(opponent, expected_outcomes=outcomes,
+        actions = [(C, C), (C, C), (C, C)]
+        self.versus_test(opponent, expected_actions=actions,
                          init_kwargs={"p": 1})
 
     def test_deterministic_classification(self):

--- a/axelrod/tests/unit/test_rand.py
+++ b/axelrod/tests/unit/test_rand.py
@@ -22,6 +22,8 @@ class TestRandom(TestPlayer):
 
     def test_strategy(self):
         """Test that strategy is randomly picked (not affected by history)."""
+        self.first_play_test(C, seed=1)
+        self.first_play_test(D, seed=2)
 
         opponent = axelrod.MockPlayer()
         actions = [(C, C), (D, C), (D, C), (C, C)]

--- a/axelrod/tests/unit/test_rand.py
+++ b/axelrod/tests/unit/test_rand.py
@@ -22,8 +22,6 @@ class TestRandom(TestPlayer):
 
     def test_strategy(self):
         """Test that strategy is randomly picked (not affected by history)."""
-        self.first_play_test(C, seed=1)
-        self.first_play_test(D, seed=2)
 
         opponent = axelrod.MockPlayer()
         actions = [(C, C), (D, C), (D, C), (C, C)]

--- a/axelrod/tests/unit/test_stalker.py
+++ b/axelrod/tests/unit/test_stalker.py
@@ -13,7 +13,7 @@ class TestStalker(TestPlayer):
     expected_classifier = {
         'memory_depth': float('inf'),
         'stochastic': True,
-        'makes_use_of': set(),
+        'makes_use_of': set(["game", "length"]),
         'long_run_time': False,
         'inspects_source': False,
         'manipulates_source': False,
@@ -44,10 +44,3 @@ class TestStalker(TestPlayer):
 
         # defect in last round
         self.responses_test([C, D], [C] * 198, [C] * 198, length=200)
-
-    def test_reset(self):
-        """Tests to see if the score is reset correctly """
-        P1 = axelrod.Stalker()
-        P1.current_score = 14
-        P1.reset()
-        self.assertEqual(P1.current_score, 0)

--- a/axelrod/tests/unit/test_titfortat.py
+++ b/axelrod/tests/unit/test_titfortat.py
@@ -290,14 +290,6 @@ class TestOmegaTFT(TestPlayer):
         self.versus_test(axelrod.SuspiciousTitForTat(),
                          expected_outcomes=outcomes)
 
-    def test_reset_counters(self):
-        player = self.player()
-        opponent = axelrod.Defector()
-        [player.play(opponent) for _ in range(10)]
-        player.reset()
-        self.assertEqual(player.randomness_counter, 0)
-        self.assertEqual(player.deadlock_counter, 0)
-
 
 class TestGradual(TestPlayer):
 
@@ -460,7 +452,8 @@ class TestContriteTitForTat(TestPlayer):
         self.assertEqual(opponent.history, [C, D, D, D])
         self.assertFalse(ctft.contrite)
 
-    def test_reset_cleans_all(self):
+    def test_reset_history_and_attributes(self):
+        """Overwrite reset test because of decorator"""
         p = self.player()
         p.contrite = True
         p.reset()

--- a/axelrod/tests/unit/test_titfortat.py
+++ b/axelrod/tests/unit/test_titfortat.py
@@ -34,22 +34,22 @@ class TestTitForTat(TestPlayer):
         self.second_play_test(rCC=C, rCD=D, rDC=C, rDD=D)
 
         # Play against opponents
-        outcomes = [(C, C), (C, D), (D, C), (C, D)]
+        outcomes = [(C, C), (C, D), (D, C), (C, D), (D, C)]
         self.versus_test(axelrod.Alternator(), expected_outcomes=outcomes)
 
-        outcomes = [(C, C), (C, C), (C, C), (C, C)]
+        outcomes = [(C, C), (C, C), (C, C), (C, C), (C, C)]
         self.versus_test(axelrod.Cooperator(), expected_outcomes=outcomes)
 
-        outcomes = [(C, D), (D, D), (D, D), (D, D)]
+        outcomes = [(C, D), (D, D), (D, D), (D, D), (D, D)]
         self.versus_test(axelrod.Defector(), expected_outcomes=outcomes)
 
         # This behaviour is independent of knowledge of the Match length
-        outcomes = [(C, C), (C, D), (D, C), (C, D)]
+        outcomes = [(C, C), (C, D), (D, C), (C, D), (D, C)]
         self.versus_test(axelrod.Alternator(), expected_outcomes=outcomes,
                          match_attributes={"length": -1})
 
         # We can also test against random strategies
-        outcomes = [(C, D), (D, D), (D, C), (C, C)]
+        outcomes = [(C, D), (D, D), (D, C), (C, C), (C, D)]
         self.versus_test(axelrod.Random(), expected_outcomes=outcomes,
                          seed=0)
 
@@ -373,18 +373,6 @@ class TestGradual(TestPlayer):
                          attrs={"calming": False, "punishing": True,
                                 "punishment_count": 2, "punishment_limit": 2})
 
-    def test_reset_cleans_all(self):
-        p = axelrod.Gradual()
-        p.calming = True
-        p.punishing = True
-        p.punishment_count = 1
-        p.punishment_limit = 1
-        p.reset()
-
-        self.assertFalse(p.calming)
-        self.assertFalse(p.punishing)
-        self.assertEqual(p.punishment_count, 0)
-        self.assertEqual(p.punishment_limit, 0)
 
     def test_output_from_literature(self):
         """
@@ -525,14 +513,6 @@ class TestAdaptiveTitForTat(TestPlayer):
         self.versus_test(self.player(), expected_outcomes=outcomes,
                          attrs={"world":0.75, "rate":0.5})
 
-    def test_world_rate_reset(self):
-        p1, p2 = self.player(), self.player()
-        p1.play(p2)
-        p1.play(p2)
-        p2.reset()
-        self.assertEqual(p2.world, 0.5)
-        self.assertEqual(p2.rate, 0.5)
-
 
 class TestSpitefulTitForTat(TestPlayer):
     name = "Spiteful Tit For Tat"
@@ -567,9 +547,3 @@ class TestSpitefulTitForTat(TestPlayer):
         outcomes = [(C, C), (C, C), (C, D), (D, D), (D, C)]
         self.versus_test(opponent, expected_outcomes=outcomes,
                          attrs={"retaliating": True})
-
-    def test_reset_retaliating(self):
-        player = self.player()
-        player.retaliating = True
-        player.reset()
-        self.assertFalse(player.retaliating)

--- a/axelrod/tests/unit/test_titfortat.py
+++ b/axelrod/tests/unit/test_titfortat.py
@@ -57,18 +57,15 @@ class TestTitForTat(TestPlayer):
         self.versus_test(axelrod.Random(), expected_outcomes=outcomes,
                          seed=1)
 
-        #  Play against sequence of moves
-        opponent_sequence = [C, D]
+        #  If you would like to test against a sequence of moves you should use
+        #  a MockPlayer
+        opponent = axelrod.MockPlayer([C, D])
         outcomes = [(C, C), (C, D), (D, C), (C, D)]
-        self.versus_test(opponent_sequence, expected_outcomes=outcomes)
+        self.versus_test(opponent, expected_outcomes=outcomes)
 
-        opponent_sequence = [D, D]
-        outcomes = [(C, D), (D, D), (D, D), (D, D)]
-        self.versus_test(opponent_sequence, expected_outcomes=outcomes)
-
-        opponent_sequence = [C, C, D, D, C, D]
+        opponent = axelrod.MockPlayer([C, C, D, D, C, D])
         outcomes = [(C, C), (C, C), (C, D), (D, D), (D, C), (C, D)]
-        self.versus_test(opponent_sequence, expected_outcomes=outcomes)
+        self.versus_test(opponent, expected_outcomes=outcomes)
 
 
 class TestTitFor2Tats(TestPlayer):
@@ -89,9 +86,9 @@ class TestTitFor2Tats(TestPlayer):
         self.second_play_test(rCC=C, rCD=C, rDC=C, rDD=C)
 
         # Will punish sequence of 2 defections but will forgive
-        opponent_sequence = [D, D, D, C, C]
+        opponent = axelrod.MockPlayer([D, D, D, C, C])
         outcomes = [(C, D), (C, D), (D, D), (D, C), (C, C)]
-        self.versus_test(opponent_sequence, expected_outcomes=outcomes)
+        self.versus_test(opponent, expected_outcomes=outcomes)
 
 
 class TestTwoTitsForTat(TestPlayer):
@@ -112,9 +109,9 @@ class TestTwoTitsForTat(TestPlayer):
         self.second_play_test(rCC=C, rCD=D, rDC=C, rDD=D)
 
         # Will defect twice when last turn of opponent was defection.
-        opponent_sequence = [D, C, C, D, C]
+        opponent = axelrod.MockPlayer([D, C, C, D, C])
         outcomes = [(C, D), (D, C), (D, C), (C, D), (D, C)]
-        self.versus_test(opponent_sequence, expected_outcomes=outcomes)
+        self.versus_test(opponent, expected_outcomes=outcomes)
 
 
 class TestBully(TestPlayer):
@@ -163,9 +160,9 @@ class TestSneakyTitForTat(TestPlayer):
         # Starts by cooperating.
         self.first_play_test(C)
 
-        opponent_sequence = [C, C, C, D, C, C]
+        opponent = axelrod.MockPlayer([C, C, C, D, C, C])
         outcomes = [(C, C), (C, C), (D, C), (D, D), (C, C), (C, C)]
-        self.versus_test(opponent_sequence, expected_outcomes=outcomes)
+        self.versus_test(opponent, expected_outcomes=outcomes)
 
         # Repents if punished for a defection
         outcomes = [(C, C), (C, D), (D, C), (C, D), (C, C)]
@@ -236,9 +233,9 @@ class TestHardTitForTat(TestPlayer):
         # Starts by cooperating.
         self.first_play_test(C)
 
-        opponent_sequence = [D, C, C, C, D, C]
+        opponent = axelrod.MockPlayer([D, C, C, C, D, C])
         outcomes = [(C, D), (D, C), (D, C), (D, C), (C, D), (D, C)]
-        self.versus_test(opponent_sequence, expected_outcomes=outcomes)
+        self.versus_test(opponent, expected_outcomes=outcomes)
 
 
 class TestHardTitFor2Tats(TestPlayer):
@@ -259,9 +256,9 @@ class TestHardTitFor2Tats(TestPlayer):
         self.first_play_test(C)
 
         # Uses memory 3 to punish 2 consecutive defections
-        opponent_sequence = [D, C, C, D, D, D, C]
+        opponent = axelrod.MockPlayer([D, C, C, D, D, D, C])
         outcomes = [(C, D), (C, C), (C, C), (C, D), (C, D), (D, D), (D, C)]
-        self.versus_test(opponent_sequence, expected_outcomes=outcomes)
+        self.versus_test(opponent, expected_outcomes=outcomes)
 
 
 class TestOmegaTFT(TestPlayer):
@@ -320,59 +317,59 @@ class TestGradual(TestPlayer):
         self.first_play_test(C)
         # Punishes defection with a growing number of defections and calms
         # the opponent with two cooperations in a row.
-        opponent_sequence = [C]
+        opponent = axelrod.MockPlayer([C])
         outcomes = [(C, C)]
-        self.versus_test(opponent_sequence, expected_outcomes=outcomes,
+        self.versus_test(opponent, expected_outcomes=outcomes,
                          attrs={"calming": False, "punishing": False,
                                 "punishment_count": 0, "punishment_limit": 0})
 
-        opponent_sequence = [D]
+        opponent = axelrod.MockPlayer([D])
         outcomes = [(C, D)]
-        self.versus_test(opponent_sequence, expected_outcomes=outcomes,
+        self.versus_test(opponent, expected_outcomes=outcomes,
                          attrs={"calming": False, "punishing": False,
                                 "punishment_count": 0, "punishment_limit": 0})
 
-        opponent_sequence = [D, C]
+        opponent = axelrod.MockPlayer([D, C])
         outcomes = [(C, D), (D, C)]
-        self.versus_test(opponent_sequence, expected_outcomes=outcomes,
+        self.versus_test(opponent, expected_outcomes=outcomes,
                          attrs={"calming": False, "punishing": True,
                                 "punishment_count": 1, "punishment_limit": 1})
 
-        opponent_sequence = [D, C, C]
+        opponent = axelrod.MockPlayer([D, C, C])
         outcomes = [(C, D), (D, C), (C, C)]
-        self.versus_test(opponent_sequence, expected_outcomes=outcomes,
+        self.versus_test(opponent, expected_outcomes=outcomes,
                          attrs={"calming": True, "punishing": False,
                                 "punishment_count": 0, "punishment_limit": 1})
 
-        opponent_sequence = [D, C, D, C]
+        opponent = axelrod.MockPlayer([D, C, D, C])
         outcomes = [(C, D), (D, C), (C, D), (C, C)]
-        self.versus_test(opponent_sequence, expected_outcomes=outcomes,
+        self.versus_test(opponent, expected_outcomes=outcomes,
                          attrs={"calming": False, "punishing": False,
                                 "punishment_count": 0, "punishment_limit": 1})
 
-        opponent_sequence = [D, C, D, C, C]
+        opponent = axelrod.MockPlayer([D, C, D, C, C])
         outcomes = [(C, D), (D, C), (C, D), (C, C), (C, C)]
-        self.versus_test(opponent_sequence, expected_outcomes=outcomes,
+        self.versus_test(opponent, expected_outcomes=outcomes,
                          attrs={"calming": False, "punishing": False,
                                 "punishment_count": 0, "punishment_limit": 1})
 
-        opponent_sequence = [D, C, D, C, C, C]
+        opponent = axelrod.MockPlayer([D, C, D, C, C, C])
         outcomes = [(C, D), (D, C), (C, D), (C, C), (C, C), (C, C)]
-        self.versus_test(opponent_sequence, expected_outcomes=outcomes,
+        self.versus_test(opponent, expected_outcomes=outcomes,
                          attrs={"calming": False, "punishing": False,
                                 "punishment_count": 0, "punishment_limit": 1})
 
-        opponent_sequence = [D, C, D, C, C, C, D, C]
+        opponent = axelrod.MockPlayer([D, C, D, C, C, C, D, C])
         outcomes = [(C, D), (D, C), (C, D), (C, C),
                     (C, C), (C, C), (C, D), (D, C)]
-        self.versus_test(opponent_sequence, expected_outcomes=outcomes,
+        self.versus_test(opponent, expected_outcomes=outcomes,
                          attrs={"calming": False, "punishing": True,
                                 "punishment_count": 1, "punishment_limit": 2})
 
-        opponent_sequence = [D, C, D, C, C, D, D, D]
+        opponent = axelrod.MockPlayer([D, C, D, C, C, D, D, D])
         outcomes = [(C, D), (D, C), (C, D), (C, C),
                     (C, C), (C, D), (D, D), (D, D)]
-        self.versus_test(opponent_sequence, expected_outcomes=outcomes,
+        self.versus_test(opponent, expected_outcomes=outcomes,
                          attrs={"calming": False, "punishing": True,
                                 "punishment_count": 2, "punishment_limit": 2})
 
@@ -500,10 +497,10 @@ class TestSlowTitForTwoTats(TestPlayer):
         self.first_play_test(C)
         # If opponent plays the same move twice, repeats last action of
         # opponent history.
-        opponent_sequence = [C, C, D, D, C, D, D, C, C, D, D]
+        opponent = axelrod.MockPlayer([C, C, D, D, C, D, D, C, C, D, D])
         outcomes = [(C, C), (C, C), (C, D), (C, D), (D, C), (C, D), (C, D),
                     (D, C), (C, C), (C, D), (C, D)]
-        self.versus_test(opponent_sequence, expected_outcomes=outcomes)
+        self.versus_test(opponent, expected_outcomes=outcomes)
 
 
 class TestAdaptiveTitForTat(TestPlayer):
@@ -556,19 +553,19 @@ class TestSpitefulTitForTat(TestPlayer):
         # defections, then always defects
         self.second_play_test(C, D, C, D)
 
-        opponent_sequence = [C, C, C, C]
+        opponent = axelrod.MockPlayer([C, C, C, C])
         outcomes = [(C, C)] * 5
-        self.versus_test(opponent_sequence, expected_outcomes=outcomes,
+        self.versus_test(opponent, expected_outcomes=outcomes,
                          attrs={"retaliating": False})
 
-        opponent_sequence = [C, C, C, C, D, C]
+        opponent = axelrod.MockPlayer([C, C, C, C, D, C])
         outcomes = [(C, C)] * 4 + [(C, D), (D, C)]
-        self.versus_test(opponent_sequence, expected_outcomes=outcomes,
+        self.versus_test(opponent, expected_outcomes=outcomes,
                          attrs={"retaliating": False})
 
-        opponent_sequence = [C, C, D, D, C]
+        opponent = axelrod.MockPlayer([C, C, D, D, C])
         outcomes = [(C, C), (C, C), (C, D), (D, D), (D, C)]
-        self.versus_test(opponent_sequence, expected_outcomes=outcomes,
+        self.versus_test(opponent, expected_outcomes=outcomes,
                          attrs={"retaliating": True})
 
     def test_reset_retaliating(self):

--- a/axelrod/tests/unit/test_titfortat.py
+++ b/axelrod/tests/unit/test_titfortat.py
@@ -30,12 +30,20 @@ class TestTitForTat(TestPlayer):
     }
 
     def test_strategy(self):
-        # Starts by cooperating.
         self.first_play_test(C)
-        # Repeats last action of opponent history.
         self.second_play_test(C, D, C, D)
-        self.responses_test([C], [C] * 4, [C, C, C, C])
-        self.responses_test([D], [C] * 5, [C, C, C, C, D])
+
+        outcomes = [(C, C), (C, D), (D, C), (C, D)]
+        match = axelrod.Match((self.player(), axelrod.Alternator()), turns=4)
+        self.assertEqual(match.play(), outcomes)
+
+        outcomes = [(C, C), (C, C), (C, C), (C, C)]
+        match = axelrod.Match((self.player(), axelrod.Cooperator()), turns=4)
+        self.assertEqual(match.play(), outcomes)
+
+        outcomes = [(C, D), (D, D), (D, D), (D, D)]
+        match = axelrod.Match((self.player(), axelrod.Defector()), turns=4)
+        self.assertEqual(match.play(), outcomes)
 
 
 class TestTitFor2Tats(TestPlayer):

--- a/axelrod/tests/unit/test_titfortat.py
+++ b/axelrod/tests/unit/test_titfortat.py
@@ -238,7 +238,7 @@ class TestHardTitForTat(TestPlayer):
 
         opponent_sequence = [D, C, C, C, D, C]
         outcomes = [(C, D), (D, C), (D, C), (D, C), (C, D), (D, C)]
-        self.versus_test(opponent_sequence, outcomes)
+        self.versus_test(opponent_sequence, expected_outcomes=outcomes)
 
 
 class TestHardTitFor2Tats(TestPlayer):
@@ -261,7 +261,7 @@ class TestHardTitFor2Tats(TestPlayer):
         # Uses memory 3 to punish 2 consecutive defections
         opponent_sequence = [D, C, C, D, D, D, C]
         outcomes = [(C, D), (C, C), (C, C), (C, D), (C, D), (D, D), (D, C)]
-        self.versus_test(opponent_sequence, outcomes)
+        self.versus_test(opponent_sequence, expected_outcomes=outcomes)
 
 
 class TestOmegaTFT(TestPlayer):
@@ -284,13 +284,14 @@ class TestOmegaTFT(TestPlayer):
 
         player_history = [C, C, D, C, D, C, C, C, D, C, C, C, D, D, D, D, D, D]
         opp_history = [C, D] * 9
-        expected_outcomes = list(zip(player_history, opp_history))
-        self.versus_test(axelrod.Alternator(), expected_outcomes)
+        outcomes = list(zip(player_history, opp_history))
+        self.versus_test(axelrod.Alternator(), expected_outcomes=outcomes)
 
         player_history =  [C, D, C, D, C, C, C, C, C]
         opp_history = [D, C, D, C, D, C, C, C, C]
-        expected_outcomes = list(zip(player_history, opp_history))
-        self.versus_test(axelrod.SuspiciousTitForTat(), expected_outcomes)
+        outcomes = list(zip(player_history, opp_history))
+        self.versus_test(axelrod.SuspiciousTitForTat(),
+                         expected_outcomes=outcomes)
 
     def test_reset(self):
         player = self.player()
@@ -502,7 +503,7 @@ class TestSlowTitForTwoTats(TestPlayer):
         opponent_sequence = [C, C, D, D, C, D, D, C, C, D, D]
         outcomes = [(C, C), (C, C), (C, D), (C, D), (D, C), (C, D), (C, D),
                     (D, C), (C, C), (C, D), (C, D)]
-        self.versus_test(opponent_sequence, outcomes)
+        self.versus_test(opponent_sequence, expected_outcomes=outcomes)
 
 
 class TestAdaptiveTitForTat(TestPlayer):

--- a/axelrod/tests/unit/test_titfortat.py
+++ b/axelrod/tests/unit/test_titfortat.py
@@ -290,7 +290,7 @@ class TestOmegaTFT(TestPlayer):
         self.versus_test(axelrod.SuspiciousTitForTat(),
                          expected_outcomes=outcomes)
 
-    def test_reset(self):
+    def test_reset_counters(self):
         player = self.player()
         opponent = axelrod.Defector()
         [player.play(opponent) for _ in range(10)]

--- a/axelrod/tests/unit/test_titfortat.py
+++ b/axelrod/tests/unit/test_titfortat.py
@@ -30,6 +30,9 @@ class TestTitForTat(TestPlayer):
     }
 
     def test_strategy(self):
+        self.first_play_test(C)
+        self.second_play_test(rCC=C, rCD=D, rDC=C, rDD=D)
+
         # Play against opponents
         actions = [(C, C), (C, D), (D, C), (C, D), (D, C)]
         self.versus_test(axelrod.Alternator(), expected_actions=actions)
@@ -79,9 +82,12 @@ class TestTitFor2Tats(TestPlayer):
     }
 
     def test_strategy(self):
+        self.first_play_test(C)
+        self.second_play_test(rCC=C, rCD=C, rDC=C, rDD=C)
+
         # Will punish sequence of 2 defections but will forgive
         opponent = axelrod.MockPlayer([D, D, D, C, C])
-        actions = [(C, D), (C, D), (D, D), (D, C), (C, C), (C ,D)]
+        actions = [(C, D), (C, D), (D, D), (D, C), (C, C)]
         self.versus_test(opponent, expected_actions=actions)
 
 
@@ -99,13 +105,12 @@ class TestTwoTitsForTat(TestPlayer):
     }
 
     def test_strategy(self):
-        # Will defect twice when last turn of opponent was defection.
-        opponent = axelrod.MockPlayer([D, C, C, D, C, C, C])
-        actions = [(C, D), (D, C), (D, C), (C, D), (D, C), (D, C), (C, C)]
-        self.versus_test(opponent, expected_actions=actions)
+        self.first_play_test(C)
+        self.second_play_test(rCC=C, rCD=D, rDC=C, rDD=D)
 
-        opponent = axelrod.MockPlayer([D, D, C, C])
-        actions = [(C, D), (D, D), (D, C), (D, C), (C, D)]
+        # Will defect twice when last turn of opponent was defection.
+        opponent = axelrod.MockPlayer([D, C, C, D, C])
+        actions = [(C, D), (D, C), (D, C), (C, D), (D, C)]
         self.versus_test(opponent, expected_actions=actions)
 
 
@@ -123,6 +128,11 @@ class TestBully(TestPlayer):
     }
 
     def test_strategy(self):
+        # Starts by defecting.
+        self.first_play_test(D)
+        # Will do opposite of what opponent does.
+        self.second_play_test(rCC=D, rCD=C, rDC=D, rDD=C)
+
         actions = [(D, C), (D, D), (C, C), (D, D), (C, C)]
         self.versus_test(axelrod.Alternator(), expected_actions=actions)
 
@@ -147,6 +157,9 @@ class TestSneakyTitForTat(TestPlayer):
     }
 
     def test_strategy(self):
+        # Starts by cooperating.
+        self.first_play_test(C)
+
         opponent = axelrod.MockPlayer([C, C, C, D, C, C])
         actions = [(C, C), (C, C), (D, C), (D, D), (C, C), (C, C)]
         self.versus_test(opponent, expected_actions=actions)
@@ -170,14 +183,14 @@ class TestSuspiciousTitForTat(TestPlayer):
     }
 
     def test_strategy(self):
+        # Starts by Defecting
+        self.first_play_test(D)
+        # Plays like TFT after the first move, repeating the opponents last
+        # move.
+        self.second_play_test(rCC=C, rCD=D, rDC=C, rDD=D)
+
         actions = [(D, C), (C, D)] * 8
         self.versus_test(axelrod.TitForTat(), expected_actions=actions)
-
-        actions = [(D, C)] +  [(C, C)] * 8
-        self.versus_test(axelrod.Cooperator(), expected_actions=actions)
-
-        actions = [(D, D)] * 8
-        self.versus_test(axelrod.Defector(), expected_actions=actions)
 
 
 class TestAntiTitForTat(TestPlayer):
@@ -194,6 +207,11 @@ class TestAntiTitForTat(TestPlayer):
     }
 
     def test_strategy(self):
+        # Starts by Cooperating
+        self.first_play_test(C)
+        # Will do opposite of what opponent does.
+        self.second_play_test(D, C, D, C)
+
         actions = [(C, C), (D, C), (D, D), (C, D)] * 4
         self.versus_test(axelrod.TitForTat(), expected_actions=actions)
 
@@ -212,6 +230,9 @@ class TestHardTitForTat(TestPlayer):
     }
 
     def test_strategy(self):
+        # Starts by cooperating.
+        self.first_play_test(C)
+
         opponent = axelrod.MockPlayer([D, C, C, C, D, C])
         actions = [(C, D), (D, C), (D, C), (D, C), (C, D), (D, C)]
         self.versus_test(opponent, expected_actions=actions)
@@ -231,6 +252,9 @@ class TestHardTitFor2Tats(TestPlayer):
     }
 
     def test_strategy(self):
+        # Starts by cooperating.
+        self.first_play_test(C)
+
         # Uses memory 3 to punish 2 consecutive defections
         opponent = axelrod.MockPlayer([D, C, C, D, D, D, C])
         actions = [(C, D), (C, C), (C, C), (C, D), (C, D), (D, D), (D, C)]
@@ -252,6 +276,9 @@ class TestOmegaTFT(TestPlayer):
     }
 
     def test_strategy(self):
+        # Starts by cooperating.
+        self.first_play_test(C)
+
         player_history = [C, C, D, C, D, C, C, C, D, C, C, C, D, D, D, D, D, D]
         opp_history = [C, D] * 9
         actions = list(zip(player_history, opp_history))
@@ -278,6 +305,8 @@ class TestGradual(TestPlayer):
     }
 
     def test_strategy(self):
+        # Starts by cooperating.
+        self.first_play_test(C)
         # Punishes defection with a growing number of defections and calms
         # the opponent with two cooperations in a row.
         opponent = axelrod.MockPlayer([C])
@@ -445,6 +474,8 @@ class TestSlowTitForTwoTats(TestPlayer):
     }
 
     def test_strategy(self):
+        # Starts by cooperating.
+        self.first_play_test(C)
         # If opponent plays the same move twice, repeats last action of
         # opponent history.
         opponent = axelrod.MockPlayer([C, C, D, D, C, D, D, C, C, D, D])
@@ -467,10 +498,13 @@ class TestAdaptiveTitForTat(TestPlayer):
     }
 
     def test_strategy(self):
-        opponent = axelrod.MockPlayer([C, D, C, D, D])
-        actions = [(C, C), (C, D), (D, C), (C, D), (D, D), (D, C)]
-        self.versus_test(opponent, expected_actions=actions,
-                         attrs={"world":0.171875, "rate":0.5})
+        # Start by cooperating.
+        self.first_play_test(C)
+        self.second_play_test(C, D, C, D)
+
+        actions = [(C, C), (C, C)]
+        self.versus_test(self.player(), expected_actions=actions,
+                         attrs={"world":0.75, "rate":0.5})
 
 
 class TestSpitefulTitForTat(TestPlayer):
@@ -486,8 +520,11 @@ class TestSpitefulTitForTat(TestPlayer):
     }
 
     def test_strategy(self):
+        # Starts by cooperating.
+        self.first_play_test(C)
         # Repeats last action of opponent history until 2 consecutive
         # defections, then always defects
+        self.second_play_test(C, D, C, D)
 
         opponent = axelrod.MockPlayer([C, C, C, C])
         actions = [(C, C)] * 5
@@ -501,10 +538,5 @@ class TestSpitefulTitForTat(TestPlayer):
 
         opponent = axelrod.MockPlayer([C, C, D, D, C])
         actions = [(C, C), (C, C), (C, D), (D, D), (D, C)]
-        self.versus_test(opponent, expected_actions=actions,
-                         attrs={"retaliating": True})
-
-        opponent = axelrod.MockPlayer([C, D, C, D, D])
-        actions = [(C, C), (C, D), (D, C), (C, D), (D, D), (D, C)]
         self.versus_test(opponent, expected_actions=actions,
                          attrs={"retaliating": True})

--- a/axelrod/tests/unit/test_titfortat.py
+++ b/axelrod/tests/unit/test_titfortat.py
@@ -30,9 +30,6 @@ class TestTitForTat(TestPlayer):
     }
 
     def test_strategy(self):
-        self.first_play_test(C)
-        self.second_play_test(rCC=C, rCD=D, rDC=C, rDD=D)
-
         # Play against opponents
         actions = [(C, C), (C, D), (D, C), (C, D), (D, C)]
         self.versus_test(axelrod.Alternator(), expected_actions=actions)
@@ -82,12 +79,9 @@ class TestTitFor2Tats(TestPlayer):
     }
 
     def test_strategy(self):
-        self.first_play_test(C)
-        self.second_play_test(rCC=C, rCD=C, rDC=C, rDD=C)
-
         # Will punish sequence of 2 defections but will forgive
         opponent = axelrod.MockPlayer([D, D, D, C, C])
-        actions = [(C, D), (C, D), (D, D), (D, C), (C, C)]
+        actions = [(C, D), (C, D), (D, D), (D, C), (C, C), (C ,D)]
         self.versus_test(opponent, expected_actions=actions)
 
 
@@ -105,12 +99,13 @@ class TestTwoTitsForTat(TestPlayer):
     }
 
     def test_strategy(self):
-        self.first_play_test(C)
-        self.second_play_test(rCC=C, rCD=D, rDC=C, rDD=D)
-
         # Will defect twice when last turn of opponent was defection.
-        opponent = axelrod.MockPlayer([D, C, C, D, C])
-        actions = [(C, D), (D, C), (D, C), (C, D), (D, C)]
+        opponent = axelrod.MockPlayer([D, C, C, D, C, C, C])
+        actions = [(C, D), (D, C), (D, C), (C, D), (D, C), (D, C), (C, C)]
+        self.versus_test(opponent, expected_actions=actions)
+
+        opponent = axelrod.MockPlayer([D, D, C, C])
+        actions = [(C, D), (D, D), (D, C), (D, C), (C, D)]
         self.versus_test(opponent, expected_actions=actions)
 
 
@@ -128,11 +123,6 @@ class TestBully(TestPlayer):
     }
 
     def test_strategy(self):
-        # Starts by defecting.
-        self.first_play_test(D)
-        # Will do opposite of what opponent does.
-        self.second_play_test(rCC=D, rCD=C, rDC=D, rDD=C)
-
         actions = [(D, C), (D, D), (C, C), (D, D), (C, C)]
         self.versus_test(axelrod.Alternator(), expected_actions=actions)
 
@@ -157,9 +147,6 @@ class TestSneakyTitForTat(TestPlayer):
     }
 
     def test_strategy(self):
-        # Starts by cooperating.
-        self.first_play_test(C)
-
         opponent = axelrod.MockPlayer([C, C, C, D, C, C])
         actions = [(C, C), (C, C), (D, C), (D, D), (C, C), (C, C)]
         self.versus_test(opponent, expected_actions=actions)
@@ -183,14 +170,14 @@ class TestSuspiciousTitForTat(TestPlayer):
     }
 
     def test_strategy(self):
-        # Starts by Defecting
-        self.first_play_test(D)
-        # Plays like TFT after the first move, repeating the opponents last
-        # move.
-        self.second_play_test(rCC=C, rCD=D, rDC=C, rDD=D)
-
         actions = [(D, C), (C, D)] * 8
         self.versus_test(axelrod.TitForTat(), expected_actions=actions)
+
+        actions = [(D, C)] +  [(C, C)] * 8
+        self.versus_test(axelrod.Cooperator(), expected_actions=actions)
+
+        actions = [(D, D)] * 8
+        self.versus_test(axelrod.Defector(), expected_actions=actions)
 
 
 class TestAntiTitForTat(TestPlayer):
@@ -207,11 +194,6 @@ class TestAntiTitForTat(TestPlayer):
     }
 
     def test_strategy(self):
-        # Starts by Cooperating
-        self.first_play_test(C)
-        # Will do opposite of what opponent does.
-        self.second_play_test(D, C, D, C)
-
         actions = [(C, C), (D, C), (D, D), (C, D)] * 4
         self.versus_test(axelrod.TitForTat(), expected_actions=actions)
 
@@ -230,9 +212,6 @@ class TestHardTitForTat(TestPlayer):
     }
 
     def test_strategy(self):
-        # Starts by cooperating.
-        self.first_play_test(C)
-
         opponent = axelrod.MockPlayer([D, C, C, C, D, C])
         actions = [(C, D), (D, C), (D, C), (D, C), (C, D), (D, C)]
         self.versus_test(opponent, expected_actions=actions)
@@ -252,9 +231,6 @@ class TestHardTitFor2Tats(TestPlayer):
     }
 
     def test_strategy(self):
-        # Starts by cooperating.
-        self.first_play_test(C)
-
         # Uses memory 3 to punish 2 consecutive defections
         opponent = axelrod.MockPlayer([D, C, C, D, D, D, C])
         actions = [(C, D), (C, C), (C, C), (C, D), (C, D), (D, D), (D, C)]
@@ -276,9 +252,6 @@ class TestOmegaTFT(TestPlayer):
     }
 
     def test_strategy(self):
-        # Starts by cooperating.
-        self.first_play_test(C)
-
         player_history = [C, C, D, C, D, C, C, C, D, C, C, C, D, D, D, D, D, D]
         opp_history = [C, D] * 9
         actions = list(zip(player_history, opp_history))
@@ -305,8 +278,6 @@ class TestGradual(TestPlayer):
     }
 
     def test_strategy(self):
-        # Starts by cooperating.
-        self.first_play_test(C)
         # Punishes defection with a growing number of defections and calms
         # the opponent with two cooperations in a row.
         opponent = axelrod.MockPlayer([C])
@@ -474,8 +445,6 @@ class TestSlowTitForTwoTats(TestPlayer):
     }
 
     def test_strategy(self):
-        # Starts by cooperating.
-        self.first_play_test(C)
         # If opponent plays the same move twice, repeats last action of
         # opponent history.
         opponent = axelrod.MockPlayer([C, C, D, D, C, D, D, C, C, D, D])
@@ -498,13 +467,10 @@ class TestAdaptiveTitForTat(TestPlayer):
     }
 
     def test_strategy(self):
-        # Start by cooperating.
-        self.first_play_test(C)
-        self.second_play_test(C, D, C, D)
-
-        actions = [(C, C), (C, C)]
-        self.versus_test(self.player(), expected_actions=actions,
-                         attrs={"world":0.75, "rate":0.5})
+        opponent = axelrod.MockPlayer([C, D, C, D, D])
+        actions = [(C, C), (C, D), (D, C), (C, D), (D, D), (D, C)]
+        self.versus_test(opponent, expected_actions=actions,
+                         attrs={"world":0.171875, "rate":0.5})
 
 
 class TestSpitefulTitForTat(TestPlayer):
@@ -520,11 +486,8 @@ class TestSpitefulTitForTat(TestPlayer):
     }
 
     def test_strategy(self):
-        # Starts by cooperating.
-        self.first_play_test(C)
         # Repeats last action of opponent history until 2 consecutive
         # defections, then always defects
-        self.second_play_test(C, D, C, D)
 
         opponent = axelrod.MockPlayer([C, C, C, C])
         actions = [(C, C)] * 5
@@ -538,5 +501,10 @@ class TestSpitefulTitForTat(TestPlayer):
 
         opponent = axelrod.MockPlayer([C, C, D, D, C])
         actions = [(C, C), (C, C), (C, D), (D, D), (D, C)]
+        self.versus_test(opponent, expected_actions=actions,
+                         attrs={"retaliating": True})
+
+        opponent = axelrod.MockPlayer([C, D, C, D, D])
+        actions = [(C, C), (C, D), (D, C), (C, D), (D, D), (D, C)]
         self.versus_test(opponent, expected_actions=actions,
                          attrs={"retaliating": True})

--- a/axelrod/tests/unit/test_titfortat.py
+++ b/axelrod/tests/unit/test_titfortat.py
@@ -34,38 +34,38 @@ class TestTitForTat(TestPlayer):
         self.second_play_test(rCC=C, rCD=D, rDC=C, rDD=D)
 
         # Play against opponents
-        outcomes = [(C, C), (C, D), (D, C), (C, D), (D, C)]
-        self.versus_test(axelrod.Alternator(), expected_outcomes=outcomes)
+        actions = [(C, C), (C, D), (D, C), (C, D), (D, C)]
+        self.versus_test(axelrod.Alternator(), expected_actions=actions)
 
-        outcomes = [(C, C), (C, C), (C, C), (C, C), (C, C)]
-        self.versus_test(axelrod.Cooperator(), expected_outcomes=outcomes)
+        actions = [(C, C), (C, C), (C, C), (C, C), (C, C)]
+        self.versus_test(axelrod.Cooperator(), expected_actions=actions)
 
-        outcomes = [(C, D), (D, D), (D, D), (D, D), (D, D)]
-        self.versus_test(axelrod.Defector(), expected_outcomes=outcomes)
+        actions = [(C, D), (D, D), (D, D), (D, D), (D, D)]
+        self.versus_test(axelrod.Defector(), expected_actions=actions)
 
         # This behaviour is independent of knowledge of the Match length
-        outcomes = [(C, C), (C, D), (D, C), (C, D), (D, C)]
-        self.versus_test(axelrod.Alternator(), expected_outcomes=outcomes,
+        actions = [(C, C), (C, D), (D, C), (C, D), (D, C)]
+        self.versus_test(axelrod.Alternator(), expected_actions=actions,
                          match_attributes={"length": -1})
 
         # We can also test against random strategies
-        outcomes = [(C, D), (D, D), (D, C), (C, C), (C, D)]
-        self.versus_test(axelrod.Random(), expected_outcomes=outcomes,
+        actions = [(C, D), (D, D), (D, C), (C, C), (C, D)]
+        self.versus_test(axelrod.Random(), expected_actions=actions,
                          seed=0)
 
-        outcomes = [(C, C), (C, D), (D, D), (D, C)]
-        self.versus_test(axelrod.Random(), expected_outcomes=outcomes,
+        actions = [(C, C), (C, D), (D, D), (D, C)]
+        self.versus_test(axelrod.Random(), expected_actions=actions,
                          seed=1)
 
         #  If you would like to test against a sequence of moves you should use
         #  a MockPlayer
         opponent = axelrod.MockPlayer([C, D])
-        outcomes = [(C, C), (C, D), (D, C), (C, D)]
-        self.versus_test(opponent, expected_outcomes=outcomes)
+        actions = [(C, C), (C, D), (D, C), (C, D)]
+        self.versus_test(opponent, expected_actions=actions)
 
         opponent = axelrod.MockPlayer([C, C, D, D, C, D])
-        outcomes = [(C, C), (C, C), (C, D), (D, D), (D, C), (C, D)]
-        self.versus_test(opponent, expected_outcomes=outcomes)
+        actions = [(C, C), (C, C), (C, D), (D, D), (D, C), (C, D)]
+        self.versus_test(opponent, expected_actions=actions)
 
 
 class TestTitFor2Tats(TestPlayer):
@@ -87,8 +87,8 @@ class TestTitFor2Tats(TestPlayer):
 
         # Will punish sequence of 2 defections but will forgive
         opponent = axelrod.MockPlayer([D, D, D, C, C])
-        outcomes = [(C, D), (C, D), (D, D), (D, C), (C, C)]
-        self.versus_test(opponent, expected_outcomes=outcomes)
+        actions = [(C, D), (C, D), (D, D), (D, C), (C, C)]
+        self.versus_test(opponent, expected_actions=actions)
 
 
 class TestTwoTitsForTat(TestPlayer):
@@ -110,8 +110,8 @@ class TestTwoTitsForTat(TestPlayer):
 
         # Will defect twice when last turn of opponent was defection.
         opponent = axelrod.MockPlayer([D, C, C, D, C])
-        outcomes = [(C, D), (D, C), (D, C), (C, D), (D, C)]
-        self.versus_test(opponent, expected_outcomes=outcomes)
+        actions = [(C, D), (D, C), (D, C), (C, D), (D, C)]
+        self.versus_test(opponent, expected_actions=actions)
 
 
 class TestBully(TestPlayer):
@@ -133,14 +133,14 @@ class TestBully(TestPlayer):
         # Will do opposite of what opponent does.
         self.second_play_test(rCC=D, rCD=C, rDC=D, rDD=C)
 
-        outcomes = [(D, C), (D, D), (C, C), (D, D), (C, C)]
-        self.versus_test(axelrod.Alternator(), expected_outcomes=outcomes)
+        actions = [(D, C), (D, D), (C, C), (D, D), (C, C)]
+        self.versus_test(axelrod.Alternator(), expected_actions=actions)
 
-        outcomes = [(D, C), (D, C), (D, C), (D, C), (D, C)]
-        self.versus_test(axelrod.Cooperator(), expected_outcomes=outcomes)
+        actions = [(D, C), (D, C), (D, C), (D, C), (D, C)]
+        self.versus_test(axelrod.Cooperator(), expected_actions=actions)
 
-        outcomes = [(D, D), (C, D), (C, D), (C, D), (C, D)]
-        self.versus_test(axelrod.Defector(), expected_outcomes=outcomes)
+        actions = [(D, D), (C, D), (C, D), (C, D), (C, D)]
+        self.versus_test(axelrod.Defector(), expected_actions=actions)
 
 
 class TestSneakyTitForTat(TestPlayer):
@@ -161,12 +161,12 @@ class TestSneakyTitForTat(TestPlayer):
         self.first_play_test(C)
 
         opponent = axelrod.MockPlayer([C, C, C, D, C, C])
-        outcomes = [(C, C), (C, C), (D, C), (D, D), (C, C), (C, C)]
-        self.versus_test(opponent, expected_outcomes=outcomes)
+        actions = [(C, C), (C, C), (D, C), (D, D), (C, C), (C, C)]
+        self.versus_test(opponent, expected_actions=actions)
 
         # Repents if punished for a defection
-        outcomes = [(C, C), (C, D), (D, C), (C, D), (C, C)]
-        self.versus_test(axelrod.Alternator(), expected_outcomes=outcomes)
+        actions = [(C, C), (C, D), (D, C), (C, D), (C, C)]
+        self.versus_test(axelrod.Alternator(), expected_actions=actions)
 
 
 class TestSuspiciousTitForTat(TestPlayer):
@@ -189,8 +189,8 @@ class TestSuspiciousTitForTat(TestPlayer):
         # move.
         self.second_play_test(rCC=C, rCD=D, rDC=C, rDD=D)
 
-        outcomes = [(D, C), (C, D)] * 8
-        self.versus_test(axelrod.TitForTat(), expected_outcomes=outcomes)
+        actions = [(D, C), (C, D)] * 8
+        self.versus_test(axelrod.TitForTat(), expected_actions=actions)
 
 
 class TestAntiTitForTat(TestPlayer):
@@ -212,8 +212,8 @@ class TestAntiTitForTat(TestPlayer):
         # Will do opposite of what opponent does.
         self.second_play_test(D, C, D, C)
 
-        outcomes = [(C, C), (D, C), (D, D), (C, D)] * 4
-        self.versus_test(axelrod.TitForTat(), expected_outcomes=outcomes)
+        actions = [(C, C), (D, C), (D, D), (C, D)] * 4
+        self.versus_test(axelrod.TitForTat(), expected_actions=actions)
 
 
 class TestHardTitForTat(TestPlayer):
@@ -234,8 +234,8 @@ class TestHardTitForTat(TestPlayer):
         self.first_play_test(C)
 
         opponent = axelrod.MockPlayer([D, C, C, C, D, C])
-        outcomes = [(C, D), (D, C), (D, C), (D, C), (C, D), (D, C)]
-        self.versus_test(opponent, expected_outcomes=outcomes)
+        actions = [(C, D), (D, C), (D, C), (D, C), (C, D), (D, C)]
+        self.versus_test(opponent, expected_actions=actions)
 
 
 class TestHardTitFor2Tats(TestPlayer):
@@ -257,8 +257,8 @@ class TestHardTitFor2Tats(TestPlayer):
 
         # Uses memory 3 to punish 2 consecutive defections
         opponent = axelrod.MockPlayer([D, C, C, D, D, D, C])
-        outcomes = [(C, D), (C, C), (C, C), (C, D), (C, D), (D, D), (D, C)]
-        self.versus_test(opponent, expected_outcomes=outcomes)
+        actions = [(C, D), (C, C), (C, C), (C, D), (C, D), (D, D), (D, C)]
+        self.versus_test(opponent, expected_actions=actions)
 
 
 class TestOmegaTFT(TestPlayer):
@@ -281,14 +281,14 @@ class TestOmegaTFT(TestPlayer):
 
         player_history = [C, C, D, C, D, C, C, C, D, C, C, C, D, D, D, D, D, D]
         opp_history = [C, D] * 9
-        outcomes = list(zip(player_history, opp_history))
-        self.versus_test(axelrod.Alternator(), expected_outcomes=outcomes)
+        actions = list(zip(player_history, opp_history))
+        self.versus_test(axelrod.Alternator(), expected_actions=actions)
 
         player_history =  [C, D, C, D, C, C, C, C, C]
         opp_history = [D, C, D, C, D, C, C, C, C]
-        outcomes = list(zip(player_history, opp_history))
+        actions = list(zip(player_history, opp_history))
         self.versus_test(axelrod.SuspiciousTitForTat(),
-                         expected_outcomes=outcomes)
+                         expected_actions=actions)
 
 
 class TestGradual(TestPlayer):
@@ -310,58 +310,58 @@ class TestGradual(TestPlayer):
         # Punishes defection with a growing number of defections and calms
         # the opponent with two cooperations in a row.
         opponent = axelrod.MockPlayer([C])
-        outcomes = [(C, C)]
-        self.versus_test(opponent, expected_outcomes=outcomes,
+        actions = [(C, C)]
+        self.versus_test(opponent, expected_actions=actions,
                          attrs={"calming": False, "punishing": False,
                                 "punishment_count": 0, "punishment_limit": 0})
 
         opponent = axelrod.MockPlayer([D])
-        outcomes = [(C, D)]
-        self.versus_test(opponent, expected_outcomes=outcomes,
+        actions = [(C, D)]
+        self.versus_test(opponent, expected_actions=actions,
                          attrs={"calming": False, "punishing": False,
                                 "punishment_count": 0, "punishment_limit": 0})
 
         opponent = axelrod.MockPlayer([D, C])
-        outcomes = [(C, D), (D, C)]
-        self.versus_test(opponent, expected_outcomes=outcomes,
+        actions = [(C, D), (D, C)]
+        self.versus_test(opponent, expected_actions=actions,
                          attrs={"calming": False, "punishing": True,
                                 "punishment_count": 1, "punishment_limit": 1})
 
         opponent = axelrod.MockPlayer([D, C, C])
-        outcomes = [(C, D), (D, C), (C, C)]
-        self.versus_test(opponent, expected_outcomes=outcomes,
+        actions = [(C, D), (D, C), (C, C)]
+        self.versus_test(opponent, expected_actions=actions,
                          attrs={"calming": True, "punishing": False,
                                 "punishment_count": 0, "punishment_limit": 1})
 
         opponent = axelrod.MockPlayer([D, C, D, C])
-        outcomes = [(C, D), (D, C), (C, D), (C, C)]
-        self.versus_test(opponent, expected_outcomes=outcomes,
+        actions = [(C, D), (D, C), (C, D), (C, C)]
+        self.versus_test(opponent, expected_actions=actions,
                          attrs={"calming": False, "punishing": False,
                                 "punishment_count": 0, "punishment_limit": 1})
 
         opponent = axelrod.MockPlayer([D, C, D, C, C])
-        outcomes = [(C, D), (D, C), (C, D), (C, C), (C, C)]
-        self.versus_test(opponent, expected_outcomes=outcomes,
+        actions = [(C, D), (D, C), (C, D), (C, C), (C, C)]
+        self.versus_test(opponent, expected_actions=actions,
                          attrs={"calming": False, "punishing": False,
                                 "punishment_count": 0, "punishment_limit": 1})
 
         opponent = axelrod.MockPlayer([D, C, D, C, C, C])
-        outcomes = [(C, D), (D, C), (C, D), (C, C), (C, C), (C, C)]
-        self.versus_test(opponent, expected_outcomes=outcomes,
+        actions = [(C, D), (D, C), (C, D), (C, C), (C, C), (C, C)]
+        self.versus_test(opponent, expected_actions=actions,
                          attrs={"calming": False, "punishing": False,
                                 "punishment_count": 0, "punishment_limit": 1})
 
         opponent = axelrod.MockPlayer([D, C, D, C, C, C, D, C])
-        outcomes = [(C, D), (D, C), (C, D), (C, C),
+        actions = [(C, D), (D, C), (C, D), (C, C),
                     (C, C), (C, C), (C, D), (D, C)]
-        self.versus_test(opponent, expected_outcomes=outcomes,
+        self.versus_test(opponent, expected_actions=actions,
                          attrs={"calming": False, "punishing": True,
                                 "punishment_count": 1, "punishment_limit": 2})
 
         opponent = axelrod.MockPlayer([D, C, D, C, C, D, D, D])
-        outcomes = [(C, D), (D, C), (C, D), (C, C),
+        actions = [(C, D), (D, C), (C, D), (C, C),
                     (C, C), (C, D), (D, D), (D, D)]
-        self.versus_test(opponent, expected_outcomes=outcomes,
+        self.versus_test(opponent, expected_actions=actions,
                          attrs={"calming": False, "punishing": True,
                                 "punishment_count": 2, "punishment_limit": 2})
 
@@ -479,9 +479,9 @@ class TestSlowTitForTwoTats(TestPlayer):
         # If opponent plays the same move twice, repeats last action of
         # opponent history.
         opponent = axelrod.MockPlayer([C, C, D, D, C, D, D, C, C, D, D])
-        outcomes = [(C, C), (C, C), (C, D), (C, D), (D, C), (C, D), (C, D),
+        actions = [(C, C), (C, C), (C, D), (C, D), (D, C), (C, D), (C, D),
                     (D, C), (C, C), (C, D), (C, D)]
-        self.versus_test(opponent, expected_outcomes=outcomes)
+        self.versus_test(opponent, expected_actions=actions)
 
 
 class TestAdaptiveTitForTat(TestPlayer):
@@ -502,8 +502,8 @@ class TestAdaptiveTitForTat(TestPlayer):
         self.first_play_test(C)
         self.second_play_test(C, D, C, D)
 
-        outcomes = [(C, C), (C, C)]
-        self.versus_test(self.player(), expected_outcomes=outcomes,
+        actions = [(C, C), (C, C)]
+        self.versus_test(self.player(), expected_actions=actions,
                          attrs={"world":0.75, "rate":0.5})
 
 
@@ -527,16 +527,16 @@ class TestSpitefulTitForTat(TestPlayer):
         self.second_play_test(C, D, C, D)
 
         opponent = axelrod.MockPlayer([C, C, C, C])
-        outcomes = [(C, C)] * 5
-        self.versus_test(opponent, expected_outcomes=outcomes,
+        actions = [(C, C)] * 5
+        self.versus_test(opponent, expected_actions=actions,
                          attrs={"retaliating": False})
 
         opponent = axelrod.MockPlayer([C, C, C, C, D, C])
-        outcomes = [(C, C)] * 4 + [(C, D), (D, C)]
-        self.versus_test(opponent, expected_outcomes=outcomes,
+        actions = [(C, C)] * 4 + [(C, D), (D, C)]
+        self.versus_test(opponent, expected_actions=actions,
                          attrs={"retaliating": False})
 
         opponent = axelrod.MockPlayer([C, C, D, D, C])
-        outcomes = [(C, C), (C, C), (C, D), (D, D), (D, C)]
-        self.versus_test(opponent, expected_outcomes=outcomes,
+        actions = [(C, C), (C, C), (C, D), (D, D), (D, C)]
+        self.versus_test(opponent, expected_actions=actions,
                          attrs={"retaliating": True})

--- a/docs/tutorials/advanced/classification_of_strategies.rst
+++ b/docs/tutorials/advanced/classification_of_strategies.rst
@@ -80,7 +80,7 @@ length of each match of the tournament::
     ... }
     >>> strategies = axl.filtered_strategies(filterset)
     >>> len(strategies)
-    24
+    25
 
 Note that in the filterset dictionary, the value for the 'makes_use_of' key
 must be a list. Here is how we might identify the number of strategies that use
@@ -91,7 +91,7 @@ both the length of the tournament and the game being played::
     ... }
     >>> strategies = axl.filtered_strategies(filterset)
     >>> len(strategies)
-    20
+    21
 
 Some strategies have been classified as having a particularly long run time::
 

--- a/docs/tutorials/contributing/strategy/writing_test_for_the_new_strategy.rst
+++ b/docs/tutorials/contributing/strategy/writing_test_for_the_new_strategy.rst
@@ -11,11 +11,6 @@ Typically we want to test the following:
 * That the strategy behaves as intended on the first move and subsequent
   moves, triggering any expected actions
 * That the strategy initializes correctly
-* That the strategy resets and clones correctly
-
-If the strategy does not use any internal variables then there are generic tests
-that are automatically invoked to verify proper initialization, resetting, and
-cloning.
 
 A :code:`TestPlayer` class has been written that has a number of convenience
 methods to help write tests efficiently for how a strategy plays. It has three

--- a/docs/tutorials/contributing/strategy/writing_test_for_the_new_strategy.rst
+++ b/docs/tutorials/contributing/strategy/writing_test_for_the_new_strategy.rst
@@ -78,6 +78,14 @@ argument :code:`seed` (useful and necessary for stochastic strategies,
         self.versus_test(axelrod.Alternator(), expected_outcomes=outcomes,
                          match_attributes={"length": -1})
 
+   The function :code:`versus_test` also accepts a dictionary parameter of
+   keyword arguments that dictate how the player is initiated. For example this
+   test how the player plays when initialised with :code:`p=1`::
+
+        outcomes = [(C, C), (C, D), (C, C), (C, D)]
+        self.versus_test(axelrod.Alternator(), expected_outcomes=outcomes,
+                         init_kwargs={"p": 1})
+
 As an example, the tests for Tit-For-Tat are as follows::
 
     import axelrod

--- a/docs/tutorials/contributing/strategy/writing_test_for_the_new_strategy.rst
+++ b/docs/tutorials/contributing/strategy/writing_test_for_the_new_strategy.rst
@@ -45,16 +45,18 @@ argument :code:`seed` (useful and necessary for stochastic strategies,
    subsequent action.
 
 3. The member function :code:`versus_test` can be used to test how the player
-   plays against a given opponent (from the Axelrod library or defined by a
-   cycle of actions)::
+   plays against a given opponent::
 
-    self.versus_test(opponent=[C, D],
+    self.versus_test(opponent=axelrod.MockPlayer([C, D]),
                      expected_outcomes=[(D, C), (C, D), (C, C)], seed=None)
 
    In this case the player is tested against an opponent that will cycle through
    :code:`C, D`. The :code:`expected_outcomes` are the actions player by both
    the tested player and the opponent in the match. In this case we see that the
    player is expected to play :code:`D, C, C` against :code:`C, D, C`.
+
+   Note that you can either user a :code:`MockPlayer` that will cycle through a
+   given sequence or you can use another strategy from the Axelrod library.
 
    The function :code:`versus_test` also accepts a dictionary parameter of
    attributes to check at the end of the match. For example this test checks
@@ -75,9 +77,6 @@ argument :code:`seed` (useful and necessary for stochastic strategies,
         outcomes = [(C, C), (C, D), (D, C), (C, D)]
         self.versus_test(axelrod.Alternator(), expected_outcomes=outcomes,
                          match_attributes={"length": -1})
-
-   Note here that instead of passing a sequence of actions as an opponent we are
-   passing an actual player from the axelrod library.
 
 As an example, the tests for Tit-For-Tat are as follows::
 
@@ -132,18 +131,15 @@ As an example, the tests for Tit-For-Tat are as follows::
             self.versus_test(axelrod.Random(), expected_outcomes=outcomes,
                              seed=1)
 
-            #  Play against sequence of moves
-            opponent_sequence = [C, D]
+            #  If you would like to test against a sequence of moves you should use
+            #  a MockPlayer
+            opponent = axelrod.MockPlayer([C, D])
             outcomes = [(C, C), (C, D), (D, C), (C, D)]
-            self.versus_test(opponent_sequence, expected_outcomes=outcomes)
+            self.versus_test(opponent, expected_outcomes=outcomes)
 
-            opponent_sequence = [D, D]
-            outcomes = [(C, D), (D, D), (D, D), (D, D)]
-            self.versus_test(opponent_sequence, expected_outcomes=outcomes)
-
-            opponent_sequence = [C, C, D, D, C, D]
+            opponent = axelrod.MockPlayer([C, C, D, D, C, D])
             outcomes = [(C, C), (C, C), (C, D), (D, D), (D, C), (C, D)]
-            self.versus_test(opponent_sequence, expected_outcomes=outcomes)
+            self.versus_test(opponent, expected_outcomes=outcomes)
 
 
 There are other examples of using this testing framework in

--- a/docs/tutorials/contributing/strategy/writing_test_for_the_new_strategy.rst
+++ b/docs/tutorials/contributing/strategy/writing_test_for_the_new_strategy.rst
@@ -43,10 +43,10 @@ argument :code:`seed` (useful and necessary for stochastic strategies,
    plays against a given opponent::
 
     self.versus_test(opponent=axelrod.MockPlayer([C, D]),
-                     expected_outcomes=[(D, C), (C, D), (C, C)], seed=None)
+                     expected_actions=[(D, C), (C, D), (C, C)], seed=None)
 
    In this case the player is tested against an opponent that will cycle through
-   :code:`C, D`. The :code:`expected_outcomes` are the actions player by both
+   :code:`C, D`. The :code:`expected_actions` are the actions player by both
    the tested player and the opponent in the match. In this case we see that the
    player is expected to play :code:`D, C, C` against :code:`C, D, C`.
 
@@ -58,8 +58,8 @@ argument :code:`seed` (useful and necessary for stochastic strategies,
    if the player's internal variable :code:`opponent_class` is set to
    :code:`"Cooperative"`::
 
-       outcomes = [(C, C)] * 6
-       self.versus_test(axelrod.Cooperator(), expected_outcomes=outcomes
+       actions = [(C, C)] * 6
+       self.versus_test(axelrod.Cooperator(), expected_actions=actions
                         attrs={"opponent_class": "Cooperative"})
 
    Note here that instead of passing a sequence of actions as an opponent we are
@@ -69,16 +69,16 @@ argument :code:`seed` (useful and necessary for stochastic strategies,
    attributes that dictate the knowledge of the players. For example this test
    assumes that players do not know the length of the match::
 
-        outcomes = [(C, C), (C, D), (D, C), (C, D)]
-        self.versus_test(axelrod.Alternator(), expected_outcomes=outcomes,
+        actions = [(C, C), (C, D), (D, C), (C, D)]
+        self.versus_test(axelrod.Alternator(), expected_actions=actions,
                          match_attributes={"length": -1})
 
    The function :code:`versus_test` also accepts a dictionary parameter of
    keyword arguments that dictate how the player is initiated. For example this
    test how the player plays when initialised with :code:`p=1`::
 
-        outcomes = [(C, C), (C, D), (C, C), (C, D)]
-        self.versus_test(axelrod.Alternator(), expected_outcomes=outcomes,
+        actions = [(C, C), (C, D), (C, C), (C, D)]
+        self.versus_test(axelrod.Alternator(), expected_actions=actions,
                          init_kwargs={"p": 1})
 
 As an example, the tests for Tit-For-Tat are as follows::
@@ -111,38 +111,38 @@ As an example, the tests for Tit-For-Tat are as follows::
             self.second_play_test(rCC=C, rCD=D, rDC=C, rDD=D)
 
             # Play against opponents
-            outcomes = [(C, C), (C, D), (D, C), (C, D)]
-            self.versus_test(axelrod.Alternator(), expected_outcomes=outcomes)
+            actions = [(C, C), (C, D), (D, C), (C, D)]
+            self.versus_test(axelrod.Alternator(), expected_actions=actions)
 
-            outcomes = [(C, C), (C, C), (C, C), (C, C)]
-            self.versus_test(axelrod.Cooperator(), expected_outcomes=outcomes)
+            actions = [(C, C), (C, C), (C, C), (C, C)]
+            self.versus_test(axelrod.Cooperator(), expected_actions=actions)
 
-            outcomes = [(C, D), (D, D), (D, D), (D, D)]
-            self.versus_test(axelrod.Defector(), expected_outcomes=outcomes)
+            actions = [(C, D), (D, D), (D, D), (D, D)]
+            self.versus_test(axelrod.Defector(), expected_actions=actions)
 
             # This behaviour is independent of knowledge of the Match length
-            outcomes = [(C, C), (C, D), (D, C), (C, D)]
-            self.versus_test(axelrod.Alternator(), expected_outcomes=outcomes,
+            actions = [(C, C), (C, D), (D, C), (C, D)]
+            self.versus_test(axelrod.Alternator(), expected_actions=actions,
                              match_attributes={"length": -1})
 
             # We can also test against random strategies
-            outcomes = [(C, D), (D, D), (D, C), (C, C)]
-            self.versus_test(axelrod.Random(), expected_outcomes=outcomes,
+            actions = [(C, D), (D, D), (D, C), (C, C)]
+            self.versus_test(axelrod.Random(), expected_actions=actions,
                              seed=0)
 
-            outcomes = [(C, C), (C, D), (D, D), (D, C)]
-            self.versus_test(axelrod.Random(), expected_outcomes=outcomes,
+            actions = [(C, C), (C, D), (D, D), (D, C)]
+            self.versus_test(axelrod.Random(), expected_actions=actions,
                              seed=1)
 
             #  If you would like to test against a sequence of moves you should use
             #  a MockPlayer
             opponent = axelrod.MockPlayer([C, D])
-            outcomes = [(C, C), (C, D), (D, C), (C, D)]
-            self.versus_test(opponent, expected_outcomes=outcomes)
+            actions = [(C, C), (C, D), (D, C), (C, D)]
+            self.versus_test(opponent, expected_actions=actions)
 
             opponent = axelrod.MockPlayer([C, C, D, D, C, D])
-            outcomes = [(C, C), (C, C), (C, D), (D, D), (D, C), (C, D)]
-            self.versus_test(opponent, expected_outcomes=outcomes)
+            actions = [(C, C), (C, C), (C, D), (D, D), (D, C), (C, D)]
+            self.versus_test(opponent, expected_actions=actions)
 
 
 There are other examples of using this testing framework in

--- a/docs/tutorials/contributing/strategy/writing_test_for_the_new_strategy.rst
+++ b/docs/tutorials/contributing/strategy/writing_test_for_the_new_strategy.rst
@@ -13,50 +13,73 @@ Typically we want to test the following:
 * That the strategy initializes correctly
 
 A :code:`TestPlayer` class has been written that has a number of convenience
-methods to help write tests efficiently for how a strategy plays. It has a
-helpful method that tests the actions against another player.
+methods to help write tests efficiently for how a strategy plays. It has three
+helpful methods. All three of these functions can take an optional keyword
+argument :code:`seed` (useful and necessary for stochastic strategies,
+:code:`None` by default).
 
-The member function :code:`versus_test` is used to test how the player
-plays against a given opponent::
+1. The member function :code:`first_play_test` tests the first strategy, e.g.::
+
+    self.first_play_test(play=C, seed=None)
+
+   This is equivalent to::
+
+    P1 = axelrod.TitForTat() # Or whatever player is in your test class
+    P2 = axelrod.Player()
+    self.assertEqual(P1.strategy(P2), C)
+
+2. The member function :code:`second_play_test` takes a list of four plays, each
+   following one round of CC, CD, DC, and DD respectively. So for example here
+   we test that Tit for tat will cooperate if and only if the opponent
+   cooperates in the previous round::
+
+    self.second_play_test(rCC=C, rCD=D, rDC=D, rDD=C, seed=None)
+
+   This is equivalent to choosing if an opponent will play :code:`C` or
+   :code:`D` following the last round of play and checking the player's
+   subsequent action.
+
+3. The member function :code:`versus_test` can be used to test how the player
+   plays against a given opponent::
 
     self.versus_test(opponent=axelrod.MockPlayer([C, D]),
                      expected_actions=[(D, C), (C, D), (C, C)], seed=None)
 
-In this case the player is tested against an opponent that will cycle through
-:code:`C, D`. The :code:`expected_actions` are the actions player by both
-the tested player and the opponent in the match. In this case we see that the
-player is expected to play :code:`D, C, C` against :code:`C, D, C`.
+   In this case the player is tested against an opponent that will cycle through
+   :code:`C, D`. The :code:`expected_actions` are the actions player by both
+   the tested player and the opponent in the match. In this case we see that the
+   player is expected to play :code:`D, C, C` against :code:`C, D, C`.
 
-Note that you can either user a :code:`MockPlayer` that will cycle through a
-given sequence or you can use another strategy from the Axelrod library.
+   Note that you can either user a :code:`MockPlayer` that will cycle through a
+   given sequence or you can use another strategy from the Axelrod library.
 
-The function :code:`versus_test` also accepts a dictionary parameter of
-attributes to check at the end of the match. For example this test checks
-if the player's internal variable :code:`opponent_class` is set to
-:code:`"Cooperative"`::
+   The function :code:`versus_test` also accepts a dictionary parameter of
+   attributes to check at the end of the match. For example this test checks
+   if the player's internal variable :code:`opponent_class` is set to
+   :code:`"Cooperative"`::
 
-    actions = [(C, C)] * 6
-    self.versus_test(axelrod.Cooperator(), expected_actions=actions
-                     attrs={"opponent_class": "Cooperative"})
+       actions = [(C, C)] * 6
+       self.versus_test(axelrod.Cooperator(), expected_actions=actions
+                        attrs={"opponent_class": "Cooperative"})
 
-Note here that instead of passing a sequence of actions as an opponent we are
-passing an actual player from the axelrod library.
+   Note here that instead of passing a sequence of actions as an opponent we are
+   passing an actual player from the axelrod library.
 
-The function :code:`versus_test` also accepts a dictionary parameter of match
-attributes that dictate the knowledge of the players. For example this test
-assumes that players do not know the length of the match::
+   The function :code:`versus_test` also accepts a dictionary parameter of match
+   attributes that dictate the knowledge of the players. For example this test
+   assumes that players do not know the length of the match::
 
-     actions = [(C, C), (C, D), (D, C), (C, D)]
-     self.versus_test(axelrod.Alternator(), expected_actions=actions,
-                      match_attributes={"length": -1})
+        actions = [(C, C), (C, D), (D, C), (C, D)]
+        self.versus_test(axelrod.Alternator(), expected_actions=actions,
+                         match_attributes={"length": -1})
 
-The function :code:`versus_test` also accepts a dictionary parameter of
-keyword arguments that dictate how the player is initiated. For example this
-test how the player plays when initialised with :code:`p=1`::
+   The function :code:`versus_test` also accepts a dictionary parameter of
+   keyword arguments that dictate how the player is initiated. For example this
+   test how the player plays when initialised with :code:`p=1`::
 
-     actions = [(C, C), (C, D), (C, C), (C, D)]
-     self.versus_test(axelrod.Alternator(), expected_actions=actions,
-                      init_kwargs={"p": 1})
+        actions = [(C, C), (C, D), (C, C), (C, D)]
+        self.versus_test(axelrod.Alternator(), expected_actions=actions,
+                         init_kwargs={"p": 1})
 
 As an example, the tests for Tit-For-Tat are as follows::
 
@@ -84,6 +107,9 @@ As an example, the tests for Tit-For-Tat are as follows::
         }
 
         def test_strategy(self):
+            self.first_play_test(C)
+            self.second_play_test(rCC=C, rCD=D, rDC=C, rDD=D)
+
             # Play against opponents
             actions = [(C, C), (C, D), (D, C), (C, D)]
             self.versus_test(axelrod.Alternator(), expected_actions=actions)

--- a/docs/tutorials/contributing/strategy/writing_test_for_the_new_strategy.rst
+++ b/docs/tutorials/contributing/strategy/writing_test_for_the_new_strategy.rst
@@ -13,73 +13,50 @@ Typically we want to test the following:
 * That the strategy initializes correctly
 
 A :code:`TestPlayer` class has been written that has a number of convenience
-methods to help write tests efficiently for how a strategy plays. It has three
-helpful methods. All three of these functions can take an optional keyword
-argument :code:`seed` (useful and necessary for stochastic strategies,
-:code:`None` by default).
+methods to help write tests efficiently for how a strategy plays. It has a
+helpful method that tests the actions against another player.
 
-1. The member function :code:`first_play_test` tests the first strategy, e.g.::
-
-    self.first_play_test(play=C, seed=None)
-
-   This is equivalent to::
-
-    P1 = axelrod.TitForTat() # Or whatever player is in your test class
-    P2 = axelrod.Player()
-    self.assertEqual(P1.strategy(P2), C)
-
-2. The member function :code:`second_play_test` takes a list of four plays, each
-   following one round of CC, CD, DC, and DD respectively. So for example here
-   we test that Tit for tat will cooperate if and only if the opponent
-   cooperates in the previous round::
-
-    self.second_play_test(rCC=C, rCD=D, rDC=D, rDD=C, seed=None)
-
-   This is equivalent to choosing if an opponent will play :code:`C` or
-   :code:`D` following the last round of play and checking the player's
-   subsequent action.
-
-3. The member function :code:`versus_test` can be used to test how the player
-   plays against a given opponent::
+The member function :code:`versus_test` is used to test how the player
+plays against a given opponent::
 
     self.versus_test(opponent=axelrod.MockPlayer([C, D]),
                      expected_actions=[(D, C), (C, D), (C, C)], seed=None)
 
-   In this case the player is tested against an opponent that will cycle through
-   :code:`C, D`. The :code:`expected_actions` are the actions player by both
-   the tested player and the opponent in the match. In this case we see that the
-   player is expected to play :code:`D, C, C` against :code:`C, D, C`.
+In this case the player is tested against an opponent that will cycle through
+:code:`C, D`. The :code:`expected_actions` are the actions player by both
+the tested player and the opponent in the match. In this case we see that the
+player is expected to play :code:`D, C, C` against :code:`C, D, C`.
 
-   Note that you can either user a :code:`MockPlayer` that will cycle through a
-   given sequence or you can use another strategy from the Axelrod library.
+Note that you can either user a :code:`MockPlayer` that will cycle through a
+given sequence or you can use another strategy from the Axelrod library.
 
-   The function :code:`versus_test` also accepts a dictionary parameter of
-   attributes to check at the end of the match. For example this test checks
-   if the player's internal variable :code:`opponent_class` is set to
-   :code:`"Cooperative"`::
+The function :code:`versus_test` also accepts a dictionary parameter of
+attributes to check at the end of the match. For example this test checks
+if the player's internal variable :code:`opponent_class` is set to
+:code:`"Cooperative"`::
 
-       actions = [(C, C)] * 6
-       self.versus_test(axelrod.Cooperator(), expected_actions=actions
-                        attrs={"opponent_class": "Cooperative"})
+    actions = [(C, C)] * 6
+    self.versus_test(axelrod.Cooperator(), expected_actions=actions
+                     attrs={"opponent_class": "Cooperative"})
 
-   Note here that instead of passing a sequence of actions as an opponent we are
-   passing an actual player from the axelrod library.
+Note here that instead of passing a sequence of actions as an opponent we are
+passing an actual player from the axelrod library.
 
-   The function :code:`versus_test` also accepts a dictionary parameter of match
-   attributes that dictate the knowledge of the players. For example this test
-   assumes that players do not know the length of the match::
+The function :code:`versus_test` also accepts a dictionary parameter of match
+attributes that dictate the knowledge of the players. For example this test
+assumes that players do not know the length of the match::
 
-        actions = [(C, C), (C, D), (D, C), (C, D)]
-        self.versus_test(axelrod.Alternator(), expected_actions=actions,
-                         match_attributes={"length": -1})
+     actions = [(C, C), (C, D), (D, C), (C, D)]
+     self.versus_test(axelrod.Alternator(), expected_actions=actions,
+                      match_attributes={"length": -1})
 
-   The function :code:`versus_test` also accepts a dictionary parameter of
-   keyword arguments that dictate how the player is initiated. For example this
-   test how the player plays when initialised with :code:`p=1`::
+The function :code:`versus_test` also accepts a dictionary parameter of
+keyword arguments that dictate how the player is initiated. For example this
+test how the player plays when initialised with :code:`p=1`::
 
-        actions = [(C, C), (C, D), (C, C), (C, D)]
-        self.versus_test(axelrod.Alternator(), expected_actions=actions,
-                         init_kwargs={"p": 1})
+     actions = [(C, C), (C, D), (C, C), (C, D)]
+     self.versus_test(axelrod.Alternator(), expected_actions=actions,
+                      init_kwargs={"p": 1})
 
 As an example, the tests for Tit-For-Tat are as follows::
 
@@ -107,9 +84,6 @@ As an example, the tests for Tit-For-Tat are as follows::
         }
 
         def test_strategy(self):
-            self.first_play_test(C)
-            self.second_play_test(rCC=C, rCD=D, rDC=C, rDD=D)
-
             # Play against opponents
             actions = [(C, C), (C, D), (D, C), (C, D)]
             self.versus_test(axelrod.Alternator(), expected_actions=actions)


### PR DESCRIPTION
Addresses #874 with a tweaked testing framework.

The `versus_test` method removes the option to set player histories and can be used to test strategies (and player attributes during matches) by creating a match between the player in question and an opponent.

The opponent can either be an actual player from the library or is defined as a cycle by a passed sequence of actions (there are examples of this in the docs and `test_titfortat.py`).

I've refactored all the tests in `test_titfortat.py` (which is now one module that raises no warnings).

When/if we're happy with this as a suggestion, we should open an issue about refactoring all the tests to use this approach. (This would be a big/important piece of work so we should ask for small contributions at a time to make sure we don't miss anything with the reviews).

Once that refactor is complete we could potentially remove unused methods in the `TestPlayer` class.