### PR TITLE
Remove redundant try except block

### DIFF
--- a/axelrod/deterministic_cache.py
+++ b/axelrod/deterministic_cache.py
@@ -105,14 +105,11 @@ class DeterministicCache(UserDict):
 
         # The triplet should be a pair of axelrod.Player instances and an
         # integer
-        try:
-            if not (
-                isinstance(key[0], Player) and
-                isinstance(key[1], Player) and
-                isinstance(key[2], int)
-            ):
-                return False
-        except TypeError:
+        if not (
+            isinstance(key[0], Player) and
+            isinstance(key[1], Player) and
+            isinstance(key[2], int)
+        ):
             return False
 
         # Each Player should be deterministic


### PR DESCRIPTION
The exception in line 120 of deterministic_cache.py can never be thrown and is therefore impossible to test and so I've removed the entire try/except block.

Caught by coverage report