### PR TITLE
921

### DIFF
--- a/axelrod/strategies/gobymajority.py
+++ b/axelrod/strategies/gobymajority.py
@@ -32,7 +32,7 @@ class GoByMajority(Player):
         'memory_depth': float('inf')
     } # type: Dict[str, Any]
 
-    def __init__(self, memory_depth: float = float('inf'), soft: bool = True) -> None:
+    def __init__(self, memory_depth: int = float('inf'), soft: bool = True) -> None:
         """
         Parameters
         ----------
@@ -138,7 +138,7 @@ class HardGoByMajority(GoByMajority):
     """
     name = 'Hard Go By Majority'
 
-    def __init__(self, memory_depth: float = float('inf')) -> None:
+    def __init__(self, memory_depth: int = float('inf')) -> None:
         super().__init__(memory_depth=memory_depth, soft=False)
 
 

--- a/axelrod/strategies/gobymajority.py
+++ b/axelrod/strategies/gobymajority.py
@@ -88,8 +88,8 @@ class GoByMajority40(GoByMajority):
     classifier = copy.copy(GoByMajority.classifier)
     classifier['memory_depth'] = 40
 
-    def __init__(self, memory_depth: float = 40, soft: bool = True) -> None:
-        super().__init__(memory_depth=memory_depth, soft=soft)
+    def __init__(self) -> None:
+        super().__init__(memory_depth=40)
 
 
 class GoByMajority20(GoByMajority):
@@ -100,8 +100,8 @@ class GoByMajority20(GoByMajority):
     classifier = copy.copy(GoByMajority.classifier)
     classifier['memory_depth'] = 20
 
-    def __init__(self, memory_depth: float = 20, soft: bool = True) -> None:
-        super().__init__(memory_depth=memory_depth, soft=soft)
+    def __init__(self) -> None:
+        super().__init__(memory_depth=20)
 
 
 class GoByMajority10(GoByMajority):
@@ -112,8 +112,8 @@ class GoByMajority10(GoByMajority):
     classifier = copy.copy(GoByMajority.classifier)
     classifier['memory_depth'] = 10
 
-    def __init__(self, memory_depth: float = 10, soft: bool = True) -> None:
-        super().__init__(memory_depth=memory_depth, soft=soft)
+    def __init__(self) -> None:
+        super().__init__(memory_depth=10)
 
 
 class GoByMajority5(GoByMajority):
@@ -124,8 +124,8 @@ class GoByMajority5(GoByMajority):
     classifier = copy.copy(GoByMajority.classifier)
     classifier['memory_depth'] = 5
 
-    def __init__(self, memory_depth: float = 5, soft: bool = True) -> None:
-        super().__init__(memory_depth=memory_depth, soft=soft)
+    def __init__(self) -> None:
+        super().__init__(memory_depth=5)
 
 
 class HardGoByMajority(GoByMajority):
@@ -138,8 +138,8 @@ class HardGoByMajority(GoByMajority):
     """
     name = 'Hard Go By Majority'
 
-    def __init__(self, memory_depth: float = float('inf'), soft: bool = False) -> None:
-        super().__init__(memory_depth=memory_depth, soft=soft)
+    def __init__(self, memory_depth: float = float('inf')) -> None:
+        super().__init__(memory_depth=memory_depth, soft=False)
 
 
 class HardGoByMajority40(HardGoByMajority):
@@ -150,8 +150,8 @@ class HardGoByMajority40(HardGoByMajority):
     classifier = copy.copy(GoByMajority.classifier)
     classifier['memory_depth'] = 40
 
-    def __init__(self, memory_depth: float = 40, soft: bool = False) -> None:
-        super().__init__(memory_depth=memory_depth, soft=soft)
+    def __init__(self) -> None:
+        super().__init__(memory_depth=40)
 
 
 class HardGoByMajority20(HardGoByMajority):
@@ -162,8 +162,8 @@ class HardGoByMajority20(HardGoByMajority):
     classifier = copy.copy(GoByMajority.classifier)
     classifier['memory_depth'] = 20
 
-    def __init__(self, memory_depth: float = 20, soft: bool = False) -> None:
-        super().__init__(memory_depth=memory_depth, soft=soft)
+    def __init__(self) -> None:
+        super().__init__(memory_depth=20)
 
 
 class HardGoByMajority10(HardGoByMajority):
@@ -174,8 +174,8 @@ class HardGoByMajority10(HardGoByMajority):
     classifier = copy.copy(GoByMajority.classifier)
     classifier['memory_depth'] = 10
 
-    def __init__(self, memory_depth: float = 10, soft: bool = False) -> None:
-        super().__init__(memory_depth=memory_depth, soft=soft)
+    def __init__(self) -> None:
+        super().__init__(memory_depth=10)
 
 
 class HardGoByMajority5(HardGoByMajority):
@@ -186,5 +186,5 @@ class HardGoByMajority5(HardGoByMajority):
     classifier = copy.copy(GoByMajority.classifier)
     classifier['memory_depth'] = 5
 
-    def __init__(self, memory_depth: float = 5, soft: bool = False) -> None:
-        super().__init__(memory_depth=memory_depth, soft=soft)
+    def __init__(self) -> None:
+        super().__init__(memory_depth=5)

--- a/axelrod/tests/strategies/test_gobymajority.py
+++ b/axelrod/tests/strategies/test_gobymajority.py
@@ -6,11 +6,12 @@ from .test_player import TestPlayer
 C, D = axelrod.Actions.C, axelrod.Actions.D
 
 
-class TestGoByMajority(TestPlayer):
+class TestHardGoByMajority(TestPlayer):
 
-    name = "Soft Go By Majority"
-    player = axelrod.GoByMajority
-    default_soft = True
+    name = "Hard Go By Majority"
+    player = axelrod.HardGoByMajority
+    default_soft = False
+    eq_play = D
 
     expected_classifier = {
         'stochastic': False,
@@ -23,21 +24,38 @@ class TestGoByMajority(TestPlayer):
     }
 
     def test_strategy(self):
-        # Starts by cooperating """
-        self.first_play_test(C)
+        # Starts by defecting.
+        self.first_play_test(self.eq_play)
         # If opponent cooperates at least as often as they defect then the
-        # player cooperates.
-        self.responses_test([C], [C, D, D, D], [D, D, C, C])
+        # player defects.
+        self.responses_test([self.eq_play], [C, D, D, D], [D, D, C, C])
+        # If opponent defects strictly more often than they defect then the
+        # player defects.
         self.responses_test([D], [C, C, D, D, C], [D, D, C, C, D])
+        # If opponent cooperates strictly more often than they defect then the
+        # player cooperates.
+        self.responses_test([C], [C, C, D, D, C], [D, C, C, C, D])
+
+    def test_default_soft(self):
+        player = self.player()
+        self.assertEqual(player.soft, self.default_soft)
+
+
+class TestGoByMajority(TestHardGoByMajority):
+
+    name = "Soft Go By Majority"
+    player = axelrod.GoByMajority
+    default_soft = True
+    eq_play = C
+
+    def test_strategy(self):
+        # In case of equality (including first play), cooperates.
+        super().test_strategy()
 
         # Test tie break rule for soft=False
         player = self.player(soft=False)
         opponent = axelrod.Cooperator()
         self.assertEqual('D', player.strategy(opponent))
-
-    def test_default_soft(self):
-        player = self.player()
-        self.assertEqual(player.soft, self.default_soft)
 
     def test_soft(self):
         player = self.player(soft=True)
@@ -57,31 +75,6 @@ class TestGoByMajority(TestPlayer):
         self.assertEqual(name, "Soft Go By Majority")
         player = self.player(soft=False)
         name = str(player)
-        self.assertEqual(name, "Hard Go By Majority")
-
-
-class TestHardGoByMajority(TestGoByMajority):
-
-    name = "Hard Go By Majority"
-    player = axelrod.HardGoByMajority
-    default_soft = False
-
-    def test_strategy(self):
-        # Starts by defecting.
-        self.first_play_test(D)
-        # If opponent cooperates strictly more often as they defect then the
-        # player cooperates.
-        self.responses_test([D], [C, D, D, D], [D, D, C, C])
-        self.responses_test([D], [C, C, D, D, C], [D, D, C, C, D])
-
-    def test_soft(self):
-        pass
-
-    def test_name(self):
-        self.assertEqual(self.player().name, "Hard Go By Majority")
-
-    def test_repr(self):
-        name = str(self.player())
         self.assertEqual(name, "Hard Go By Majority")
 
 

--- a/axelrod/tests/strategies/test_gobymajority.py
+++ b/axelrod/tests/strategies/test_gobymajority.py
@@ -74,10 +74,15 @@ class TestHardGoByMajority(TestGoByMajority):
         self.responses_test([D], [C, D, D, D], [D, D, C, C])
         self.responses_test([D], [C, C, D, D, C], [D, D, C, C, D])
 
-        # Test tie break rule for soft=True
-        player = self.player(soft=True)
-        opponent = axelrod.Cooperator()
-        self.assertEqual('C', player.strategy(opponent))
+    def test_soft(self):
+        pass
+
+    def test_name(self):
+        self.assertEqual(self.player().name, "Hard Go By Majority")
+
+    def test_repr(self):
+        name = str(self.player())
+        self.assertEqual(name, "Hard Go By Majority")
 
 
 def factory_TestGoByRecentMajority(L, soft=True):


### PR DESCRIPTION
Axelrod-Python/Axelrod#921
I took more time than I though to correct the tests, since `TestHardGoByMajority` uses `TestGoByMajority`. Tell me if there is a problem with how I changed things.
And I also corrected the type hint of memory_depth which indicated `float` even though, as the docstring says on line 37 :
```
Parameters
        ----------
        memory_depth, int >= 0
```
(default value `float('inf')` must have confused the contributor)