### PR TITLE
844 b and c

### DIFF
--- a/axelrod/_strategy_utils.py
+++ b/axelrod/_strategy_utils.py
@@ -26,18 +26,15 @@ def detect_cycle(history, min_size=1, max_size=12, offset=0):
         The amount of history to skip initially
     """
     history_tail = history[offset:]
-    max_ = min(len(history_tail) // 2, max_size)
-    for i in range(min_size, max_):
+    new_max_size = min(len(history_tail) // 2, max_size)
+    for i in range(min_size, new_max_size + 1):
         has_cycle = True
         cycle = tuple(history_tail[:i])
         for j, elem in enumerate(history_tail):
             if elem != cycle[j % len(cycle)]:
                 has_cycle = False
                 break
-        if has_cycle and (j == len(history_tail) - 1):
-            # We made it to the end, is the cycle itself a cycle?
-            # E.G. CCC is not ok as cycle if min_size is really 2
-            # Since this is the same as C
+        if has_cycle:
             return cycle
     return None
 

--- a/axelrod/actions.py
+++ b/axelrod/actions.py
@@ -1,3 +1,5 @@
+from types import GeneratorType
+
 # Type alias for actions.
 Action = str
 
@@ -16,13 +18,16 @@ def flip_action(action: Action) -> Action:
         raise ValueError("Encountered a invalid action.")
 
 
-def str_to_actions(actions: str):
+def str_to_actions(actions: str) -> GeneratorType:
     """Takes a string like 'cCdD' and returns a generator that yields the appropriate actions."""
-    for character in actions:
-        as_upper = character.upper()
-        if as_upper == 'C':
-            yield Actions.C
-        elif as_upper == 'D':
-            yield Actions.D
-        else:
-            raise ValueError('The characters of action_str may only be "C", "c", "D" and "d"')
+    def make_generator(actions_str):
+        for character in actions_str:
+            as_upper = character.upper()
+            if as_upper == 'C':
+                yield Actions.C
+            elif as_upper == 'D':
+                yield Actions.D
+            else:
+                raise ValueError('The characters of action_str may only be "C", "c", "D" and "d"')
+
+    return make_generator(actions)

--- a/axelrod/actions.py
+++ b/axelrod/actions.py
@@ -1,4 +1,4 @@
-
+from types import GeneratorType
 # Type alias for actions.
 Action = str
 
@@ -15,3 +15,15 @@ def flip_action(action: Action) -> Action:
         return Actions.C
     else:
         raise ValueError("Encountered a invalid action.")
+
+
+def str_to_actions(actions: str) -> GeneratorType:
+    """Takes a string like 'cCdD' and returns a generator that yields the appropriate actions."""
+    for character in actions:
+        as_upper = character.upper()
+        if as_upper == 'C':
+            yield Actions.C
+        elif as_upper == 'D':
+            yield Actions.D
+        else:
+            raise ValueError('The characters of action_str may only be "C", "c", "D" and "d"')

--- a/axelrod/actions.py
+++ b/axelrod/actions.py
@@ -1,5 +1,3 @@
-from types import GeneratorType
-
 # Type alias for actions.
 Action = str
 
@@ -18,16 +16,11 @@ def flip_action(action: Action) -> Action:
         raise ValueError("Encountered a invalid action.")
 
 
-def str_to_actions(actions: str) -> GeneratorType:
-    """Takes a string like 'cCdD' and returns a generator that yields the appropriate actions."""
-    def make_generator(actions_str):
-        for character in actions_str:
-            as_upper = character.upper()
-            if as_upper == 'C':
-                yield Actions.C
-            elif as_upper == 'D':
-                yield Actions.D
-            else:
-                raise ValueError('The characters of action_str may only be "C", "c", "D" and "d"')
-
-    return make_generator(actions)
+def str_to_actions(actions: str) -> tuple:
+    """Takes a string like 'CCDD' and returns a tuple of the appropriate actions."""
+    action_dict = {'C': Actions.C,
+                   'D': Actions.D}
+    try:
+        return tuple(action_dict[action] for action in actions)
+    except KeyError:
+        raise ValueError('The characters of "actions" str may only be "C" or "D"')

--- a/axelrod/actions.py
+++ b/axelrod/actions.py
@@ -1,4 +1,3 @@
-from types import GeneratorType
 # Type alias for actions.
 Action = str
 
@@ -17,7 +16,7 @@ def flip_action(action: Action) -> Action:
         raise ValueError("Encountered a invalid action.")
 
 
-def str_to_actions(actions: str) -> GeneratorType:
+def str_to_actions(actions: str):
     """Takes a string like 'cCdD' and returns a generator that yields the appropriate actions."""
     for character in actions:
         as_upper = character.upper()

--- a/axelrod/strategies/cooperator.py
+++ b/axelrod/strategies/cooperator.py
@@ -37,13 +37,23 @@ class TrickyCooperator(Player):
         'manipulates_state': False
     }
 
-    @staticmethod
-    def strategy(opponent: Player) -> Action:
+    _min_history_required_to_try_trickiness = 3
+    _max_history_depth_for_trickiness = -10
+
+    def strategy(self, opponent: Player) -> Action:
         """Almost always cooperates, but will try to trick the opponent by defecting.
 
-        Defect once in a while in order to get a better payout, when the opponent
-        has not defected in the last ten turns and only cooperated during last 3 turns.
+        Defect once in a while in order to get a better payout.
+        After 3 rounds, if opponent has not defected to a max history depth of 10, Defect.
         """
-        if D not in opponent.history[-10:] and opponent.history[-3:] == [C]*3:
+        if (self._has_played_enough_rounds_to_be_tricky() and
+                self._opponents_has_cooperated_enough_to_be_tricky(opponent)):
             return D
         return C
+
+    def _has_played_enough_rounds_to_be_tricky(self):
+        return len(self.history) >= self._min_history_required_to_try_trickiness
+
+    def _opponents_has_cooperated_enough_to_be_tricky(self, opponent):
+        rounds_to_be_checked = opponent.history[self._max_history_depth_for_trickiness:]
+        return D not in rounds_to_be_checked

--- a/axelrod/strategies/cycler.py
+++ b/axelrod/strategies/cycler.py
@@ -3,11 +3,12 @@ from axelrod.player import Player
 import itertools
 import copy
 
+C, D = Actions.C, Actions.D
 
 class AntiCycler(Player):
     """
     A player that follows a sequence of plays that contains no cycles:
-    C CD CCD CCCD CCCCD CCCCCD ...
+    CDD  CD  CCD CCCD CCCCD ...
     """
 
     name = 'AntiCycler'
@@ -25,20 +26,28 @@ class AntiCycler(Player):
         super().__init__()
         self.cycle_length = 1
         self.cycle_counter = 0
+        self.first_three = self._get_first_three()
+
+    @staticmethod
+    def _get_first_three():
+        return [C, D, D]
 
     def strategy(self, opponent: Player) -> Action:
+        while self.first_three:
+            return self.first_three.pop(0)
         if self.cycle_counter < self.cycle_length:
             self.cycle_counter += 1
-            return Actions.C
+            return C
         else:
             self.cycle_length += 1
             self.cycle_counter = 0
-            return Actions.D
+            return D
 
     def reset(self):
         super().reset()
         self.cycle_length = 1
         self.cycle_counter = 0
+        self.first_three = self._get_first_three()
 
 
 class Cycler(Player):

--- a/axelrod/strategies/cycler.py
+++ b/axelrod/strategies/cycler.py
@@ -5,6 +5,7 @@ import copy
 
 C, D = Actions.C, Actions.D
 
+
 class AntiCycler(Player):
     """
     A player that follows a sequence of plays that contains no cycles:

--- a/axelrod/strategies/cycler.py
+++ b/axelrod/strategies/cycler.py
@@ -1,6 +1,6 @@
-from axelrod.actions import Actions, Action
+from axelrod.actions import Actions, Action, str_to_actions
 from axelrod.player import Player
-
+import itertools
 import copy
 
 
@@ -55,7 +55,7 @@ class Cycler(Player):
         'manipulates_state': False
     }
 
-    def __init__(self, cycle="CCD") -> None:
+    def __init__(self, cycle_str="CCD") -> None:
         """This strategy will repeat the parameter `cycle` endlessly,
         e.g. C C D C C D C C D ...
 
@@ -67,16 +67,20 @@ class Cycler(Player):
 
         """
         super().__init__()
-        self.cycle = cycle
-        self.name = "Cycler {}".format(cycle)
-        self.classifier['memory_depth'] = len(cycle) - 1
+        self.cycle_str = cycle_str
+        self.cycle = self.get_new_itertools_cycle()
+        self.name = "Cycler {}".format(cycle_str)
+        self.classifier['memory_depth'] = len(cycle_str) - 1
+
+    def get_new_itertools_cycle(self):
+        return itertools.cycle(str_to_actions(self.cycle_str))
 
     def strategy(self, opponent: Player) -> Action:
-        actions = {'C': Actions.C, 'D': Actions.D}
-        curent_round = len(self.history)
-        index = curent_round % len(self.cycle)
-        action_str = self.cycle[index]
-        return actions[action_str]
+        return next(self.cycle)
+
+    def reset(self):
+        super(Cycler, self).reset()
+        self.cycle = self.get_new_itertools_cycle()
 
 
 class CyclerDC(Cycler):
@@ -85,8 +89,8 @@ class CyclerDC(Cycler):
     classifier = copy.copy(Cycler.classifier)
     classifier['memory_depth'] = 1
 
-    def __init__(self, cycle="DC") -> None:
-        super().__init__(cycle=cycle)
+    def __init__(self, cycle_str="DC") -> None:
+        super().__init__(cycle_str=cycle_str)
 
 
 class CyclerCCD(Cycler):
@@ -95,8 +99,8 @@ class CyclerCCD(Cycler):
     classifier = copy.copy(Cycler.classifier)
     classifier['memory_depth'] = 2
 
-    def __init__(self, cycle="CCD") -> None:
-        super().__init__(cycle=cycle)
+    def __init__(self, cycle_str="CCD") -> None:
+        super().__init__(cycle_str=cycle_str)
 
 
 class CyclerDDC(Cycler):
@@ -105,8 +109,8 @@ class CyclerDDC(Cycler):
     classifier = copy.copy(Cycler.classifier)
     classifier['memory_depth'] = 2
 
-    def __init__(self, cycle="DDC") -> None:
-        super().__init__(cycle=cycle)
+    def __init__(self, cycle_str="DDC") -> None:
+        super().__init__(cycle_str=cycle_str)
 
 
 class CyclerCCCD(Cycler):
@@ -115,8 +119,8 @@ class CyclerCCCD(Cycler):
     classifier = copy.copy(Cycler.classifier)
     classifier['memory_depth'] = 3
 
-    def __init__(self, cycle="CCCD") -> None:
-        super().__init__(cycle=cycle)
+    def __init__(self, cycle_str="CCCD") -> None:
+        super().__init__(cycle_str=cycle_str)
 
 
 class CyclerCCCCCD(Cycler):
@@ -125,8 +129,8 @@ class CyclerCCCCCD(Cycler):
     classifier = copy.copy(Cycler.classifier)
     classifier['memory_depth'] = 5
 
-    def __init__(self, cycle="CCCCCD") -> None:
-        super().__init__(cycle=cycle)
+    def __init__(self, cycle_str="CCCCCD") -> None:
+        super().__init__(cycle_str=cycle_str)
 
 
 class CyclerCCCDCD(Cycler):
@@ -135,5 +139,5 @@ class CyclerCCCDCD(Cycler):
     classifier = copy.copy(Cycler.classifier)
     classifier['memory_depth'] = 5
 
-    def __init__(self, cycle="CCCDCD") -> None:
-        super().__init__(cycle=cycle)
+    def __init__(self, cycle_str="CCCDCD") -> None:
+        super().__init__(cycle_str=cycle_str)

--- a/axelrod/strategies/cycler.py
+++ b/axelrod/strategies/cycler.py
@@ -46,7 +46,7 @@ class Cycler(Player):
 
     name = 'Cycler'
     classifier = {
-        'memory_depth': 1,
+        'memory_depth': 2,
         'stochastic': False,
         'makes_use_of': set(),
         'long_run_time': False,

--- a/axelrod/strategies/cycler.py
+++ b/axelrod/strategies/cycler.py
@@ -55,7 +55,7 @@ class Cycler(Player):
         'manipulates_state': False
     }
 
-    def __init__(self, cycle_str="CCD") -> None:
+    def __init__(self, cycle: str = "CCD") -> None:
         """This strategy will repeat the parameter `cycle` endlessly,
         e.g. C C D C C D C C D ...
 
@@ -67,10 +67,10 @@ class Cycler(Player):
 
         """
         super().__init__()
-        self.cycle_str = cycle_str
+        self.cycle_str = cycle
         self.cycle = self.get_new_itertools_cycle()
-        self.name = "Cycler {}".format(cycle_str)
-        self.classifier['memory_depth'] = len(cycle_str) - 1
+        self.name = "Cycler {}".format(cycle)
+        self.classifier['memory_depth'] = len(cycle) - 1
 
     def get_new_itertools_cycle(self):
         return itertools.cycle(str_to_actions(self.cycle_str))
@@ -89,8 +89,8 @@ class CyclerDC(Cycler):
     classifier = copy.copy(Cycler.classifier)
     classifier['memory_depth'] = 1
 
-    def __init__(self, cycle_str="DC") -> None:
-        super().__init__(cycle_str=cycle_str)
+    def __init__(self, cycle="DC") -> None:
+        super().__init__(cycle=cycle)
 
 
 class CyclerCCD(Cycler):
@@ -99,8 +99,8 @@ class CyclerCCD(Cycler):
     classifier = copy.copy(Cycler.classifier)
     classifier['memory_depth'] = 2
 
-    def __init__(self, cycle_str="CCD") -> None:
-        super().__init__(cycle_str=cycle_str)
+    def __init__(self, cycle="CCD") -> None:
+        super().__init__(cycle=cycle)
 
 
 class CyclerDDC(Cycler):
@@ -109,8 +109,8 @@ class CyclerDDC(Cycler):
     classifier = copy.copy(Cycler.classifier)
     classifier['memory_depth'] = 2
 
-    def __init__(self, cycle_str="DDC") -> None:
-        super().__init__(cycle_str=cycle_str)
+    def __init__(self, cycle="DDC") -> None:
+        super().__init__(cycle=cycle)
 
 
 class CyclerCCCD(Cycler):
@@ -119,8 +119,8 @@ class CyclerCCCD(Cycler):
     classifier = copy.copy(Cycler.classifier)
     classifier['memory_depth'] = 3
 
-    def __init__(self, cycle_str="CCCD") -> None:
-        super().__init__(cycle_str=cycle_str)
+    def __init__(self, cycle="CCCD") -> None:
+        super().__init__(cycle=cycle)
 
 
 class CyclerCCCCCD(Cycler):
@@ -129,8 +129,8 @@ class CyclerCCCCCD(Cycler):
     classifier = copy.copy(Cycler.classifier)
     classifier['memory_depth'] = 5
 
-    def __init__(self, cycle_str="CCCCCD") -> None:
-        super().__init__(cycle_str=cycle_str)
+    def __init__(self, cycle="CCCCCD") -> None:
+        super().__init__(cycle=cycle)
 
 
 class CyclerCCCDCD(Cycler):
@@ -139,5 +139,5 @@ class CyclerCCCDCD(Cycler):
     classifier = copy.copy(Cycler.classifier)
     classifier['memory_depth'] = 5
 
-    def __init__(self, cycle_str="CCCDCD") -> None:
-        super().__init__(cycle_str=cycle_str)
+    def __init__(self, cycle="CCCDCD") -> None:
+        super().__init__(cycle=cycle)

--- a/axelrod/strategies/cycler.py
+++ b/axelrod/strategies/cycler.py
@@ -72,9 +72,11 @@ class Cycler(Player):
         self.classifier['memory_depth'] = len(cycle) - 1
 
     def strategy(self, opponent: Player) -> Action:
+        actions = {'C': Actions.C, 'D': Actions.D}
         curent_round = len(self.history)
         index = curent_round % len(self.cycle)
-        return self.cycle[index]
+        action_str = self.cycle[index]
+        return actions[action_str]
 
 
 class CyclerDC(Cycler):

--- a/axelrod/tests/strategies/test_better_and_better.py
+++ b/axelrod/tests/strategies/test_better_and_better.py
@@ -23,5 +23,14 @@ class TestBetterAndBetter(TestPlayer):
     def test_strategy(self):
         """Tests that the strategy gives expected behaviour."""
         self.first_play_test(D, seed=3)  # D is very unlikely
-        self.responses_test([D, D, D, D, C, D, D, D, D, D], seed=6)
-        self.responses_test([D, D, D, D, D, D, D, D, D, D], seed=8)
+        self.versus_test(axelrod.Defector(), [(D, D), (D, D), (D, D), (D, D), (C, D), (D, D), (D, D), (D, D), (D, D)],
+                         seed=6)
+        self.versus_test(axelrod.Cooperator(), [(D, C), (D, C), (D, C), (D, C), (D, C), (D, C), (D, C), (D, C), (D, C)],
+                         seed=8)
+        actions = []
+        for index in range(200):
+            if index in [64, 79, 91, 99, 100, 107, 111, 119, 124, 127, 137, 141, 144, 154, 192, 196]:
+                actions.append((C, D))
+            else:
+                actions.append((D, D))
+        self.versus_test(axelrod.Defector(), expected_actions=actions, seed=8)

--- a/axelrod/tests/strategies/test_better_and_better.py
+++ b/axelrod/tests/strategies/test_better_and_better.py
@@ -22,7 +22,9 @@ class TestBetterAndBetter(TestPlayer):
 
     def test_strategy(self):
         """Tests that the strategy gives expected behaviour."""
-        self.first_play_test(D, seed=3)  # D is very unlikely
+
+        self.first_play_test(D, seed=3)  # C is very unlikely
+        self.first_play_test(C, seed=1514)  # first seed (starting from seed=0) that cooperates on first round
         self.versus_test(axelrod.Defector(), [(D, D), (D, D), (D, D), (D, D), (C, D), (D, D), (D, D), (D, D), (D, D)],
                          seed=6)
         self.versus_test(axelrod.Cooperator(), [(D, C), (D, C), (D, C), (D, C), (D, C), (D, C), (D, C), (D, C), (D, C)],

--- a/axelrod/tests/strategies/test_calculator.py
+++ b/axelrod/tests/strategies/test_calculator.py
@@ -37,38 +37,64 @@ class TestCalculator(TestPlayer):
         self.assertEqual(C, P1.strategy(P2))
 
     def test_twenty_rounds_joss_then_defects_for_cyclers(self):
-        first_twenty = []
-        for index in range(20):
-            if index in [18, 19]:
-                first_twenty.append((D, C))
-            else:
-                first_twenty.append((C, C))
-        expected_actions = first_twenty + [(D, C), (D, C)]
-        self.versus_test(axelrod.Cooperator(), expected_actions, seed=1)
+        """uses axelrod.strategies.axelrod.Joss strategy for first 20 rounds"""
+        seed = 2
+        seed_two_flip_indices = [1, 3]
+        twenty_alternator_actions = [C, D] * 10
+        twenty_test_actions = get_joss_strategy_actions(twenty_alternator_actions, seed_two_flip_indices)
+
+        expected_actions = twenty_test_actions + [(D, C), (D, D), (D, C), (D, D)]
+        self.versus_test(axelrod.Alternator(), twenty_test_actions, seed=seed)
+        self.versus_test(axelrod.Alternator(), expected_actions, seed=seed)
 
     def test_twenty_rounds_joss_then_tit_for_tat_for_non_cyclers(self):
+        """uses axelrod.strategies.axelrod.Joss strategy for first 20 rounds"""
         seed = 2
-        twenty_round_non_cycle = [C, C, D, C, C, D, C, C, C, D, C, C, C, C, D, C, C, C, C, C]
+        seed_two_flip_indices = [1, 2]
 
-        first_twenty = []
-        for index, action in enumerate(twenty_round_non_cycle):
-            previous_action = twenty_round_non_cycle[index - 1]
-            if index == 0:
-                first_twenty.append((C, action))
-            elif index in [1, 2]:
-                first_twenty.append((flip_action(previous_action), action))
-            else:
-                first_twenty.append((previous_action, action))
+        twenty_non_cyclical_actions = [C, C, D, C, C, D, C, C, C, D, C, C, C, C, D, C, C, C, C, C]
+        twenty_test_actions = get_joss_strategy_actions(twenty_non_cyclical_actions, seed_two_flip_indices)
 
-        self.versus_test(axelrod.MockPlayer(twenty_round_non_cycle), first_twenty, seed=seed)
+        subsequent_opponent_actions = [D, C, D, C, D, C, D, C]
+        subsequent_test_actions = [(C, D), (D, C), (C, D), (D, C), (C, D), (D, C), (C, D), (D, C)]
 
-        after_twenty_round_non_cycle = [D, C, D, C, D, C, D, C]
-        after_first_twenty = [(C, D), (D, C), (C, D), (D, C), (C, D), (D, C), (C, D), (D, C)]
-        opponent_actions = twenty_round_non_cycle + after_twenty_round_non_cycle
-        test_actions = first_twenty + after_first_twenty
+        opponent_actions = twenty_non_cyclical_actions + subsequent_opponent_actions
+        test_actions = twenty_test_actions + subsequent_test_actions
+        self.versus_test(axelrod.MockPlayer(twenty_non_cyclical_actions), twenty_test_actions, seed=seed)
         self.versus_test(axelrod.MockPlayer(opponent_actions), test_actions, seed=seed)
 
     def attribute_equality_test(self, player, clone):
         """Overwrite the default test to check Joss instance"""
         self.assertIsInstance(player.joss_instance, axelrod.Joss)
         self.assertIsInstance(clone.joss_instance, axelrod.Joss)
+
+    def test_get_joss_strategy_actions(self):
+        opponent = [C, D, D, C, C]
+
+        flip_never_occurs_at_index_zero = [0]
+        flip_indices = [1, 2]
+
+        without_flip = [(C, C), (C, D), (D, D), (D, C), (C, C)]
+        with_flip = [(C, C), (D, D), (C, D), (D, C), (C, C)]
+
+        self.assertEqual(get_joss_strategy_actions(opponent, []), without_flip)
+        self.assertEqual(get_joss_strategy_actions(opponent, flip_never_occurs_at_index_zero), without_flip)
+        self.assertEqual(get_joss_strategy_actions(opponent, flip_indices), with_flip)
+
+
+def get_joss_strategy_actions(opponent_moves: list, indices_to_flip: list) -> list:
+    """
+    take a list of opponent moves and returns a tuple list of [(Joss moves, opponent moves)]
+    indices_to_flip are the indices where Joss differs from it's expected TitForTat.
+    Joss is from axelrod.strategies.axelrod_first.
+    """
+    out = []
+    for index, action in enumerate(opponent_moves):
+        previous_action = opponent_moves[index - 1]
+        if index == 0:
+            out.append((C, action))
+        elif index in indices_to_flip:
+            out.append((flip_action(previous_action), action))
+        else:
+            out.append((previous_action, action))
+    return out

--- a/axelrod/tests/strategies/test_calculator.py
+++ b/axelrod/tests/strategies/test_calculator.py
@@ -37,7 +37,7 @@ class TestCalculator(TestPlayer):
         self.assertEqual(C, P1.strategy(P2))
 
     def test_twenty_rounds_joss_then_defects_for_cyclers(self):
-        """uses axelrod.strategies.axelrod.Joss strategy for first 20 rounds"""
+        """uses axelrod.strategies.axelrod_first.Joss strategy for first 20 rounds"""
         seed = 2
         seed_two_flip_indices = [1, 3]
         twenty_alternator_actions = [C, D] * 10
@@ -48,7 +48,7 @@ class TestCalculator(TestPlayer):
         self.versus_test(axelrod.Alternator(), expected_actions, seed=seed)
 
     def test_twenty_rounds_joss_then_tit_for_tat_for_non_cyclers(self):
-        """uses axelrod.strategies.axelrod.Joss strategy for first 20 rounds"""
+        """uses axelrod.strategies.axelrod_first.Joss strategy for first 20 rounds"""
         seed = 2
         seed_two_flip_indices = [1, 2]
 

--- a/axelrod/tests/strategies/test_calculator.py
+++ b/axelrod/tests/strategies/test_calculator.py
@@ -25,7 +25,7 @@ class TestCalculator(TestPlayer):
         self.first_play_test(C)
 
     def test_twenty_rounds_joss_then_defects_for_cyclers(self):
-        """uses axelrod.strategies.axelrod_first.Joss strategy for first 20 rounds"""
+        """Uses axelrod.strategies.axelrod_first.Joss strategy for first 20 rounds"""
         seed = 2
         flip_indices = [1, 3]
         twenty_alternator_actions = [C, D] * 10
@@ -36,7 +36,7 @@ class TestCalculator(TestPlayer):
         self.versus_test(axelrod.Alternator(), expected_actions, seed=seed)
 
     def test_twenty_rounds_joss_then_tit_for_tat_for_non_cyclers(self):
-        """uses axelrod.strategies.axelrod_first.Joss strategy for first 20 rounds"""
+        """Uses axelrod.strategies.axelrod_first.Joss strategy for first 20 rounds"""
         seed = 2
         flip_indices = [1, 2]
 
@@ -94,8 +94,8 @@ class TestCalculator(TestPlayer):
 
 def get_joss_strategy_actions(opponent_moves: list, indices_to_flip: list) -> list:
     """
-    take a list of opponent moves and returns a tuple list of [(Joss moves, opponent moves)]
-    indices_to_flip are the indices where Joss differs from it's expected TitForTat.
+    Takes a list of opponent moves and returns a tuple list of [(Joss moves, opponent moves)].
+    "indices_to_flip" are the indices where Joss differs from it's expected TitForTat.
     Joss is from axelrod.strategies.axelrod_first.
     """
     out = []

--- a/axelrod/tests/strategies/test_calculator.py
+++ b/axelrod/tests/strategies/test_calculator.py
@@ -24,24 +24,24 @@ class TestCalculator(TestPlayer):
     def test_strategy(self):
         self.first_play_test(C)
 
-        P1 = axelrod.Calculator()
-        P1.history = [C] * 20
-        P2 = axelrod.Player()
-        P2.history = [C, D] * 10
+        p1 = axelrod.Calculator()
+        p1.history = [C] * 20
+        p2 = axelrod.Player()
+        p2.history = [C, D] * 10
         # Defects on cycle detection
-        self.assertEqual(D, P1.strategy(P2))
+        self.assertEqual(D, p1.strategy(p2))
 
         # Test non-cycle response
         history = [C, C, D, C, C, D, C, C, C, D, C, C, C, C, D, C, C, C, C, C]
-        P2.history = history
-        self.assertEqual(C, P1.strategy(P2))
+        p2.history = history
+        self.assertEqual(C, p1.strategy(p2))
 
     def test_twenty_rounds_joss_then_defects_for_cyclers(self):
         """uses axelrod.strategies.axelrod_first.Joss strategy for first 20 rounds"""
         seed = 2
-        seed_two_flip_indices = [1, 3]
+        flip_indices = [1, 3]
         twenty_alternator_actions = [C, D] * 10
-        twenty_test_actions = get_joss_strategy_actions(twenty_alternator_actions, seed_two_flip_indices)
+        twenty_test_actions = get_joss_strategy_actions(twenty_alternator_actions, flip_indices)
 
         expected_actions = twenty_test_actions + [(D, C), (D, D), (D, C), (D, D)]
         self.versus_test(axelrod.Alternator(), twenty_test_actions, seed=seed)
@@ -50,10 +50,10 @@ class TestCalculator(TestPlayer):
     def test_twenty_rounds_joss_then_tit_for_tat_for_non_cyclers(self):
         """uses axelrod.strategies.axelrod_first.Joss strategy for first 20 rounds"""
         seed = 2
-        seed_two_flip_indices = [1, 2]
+        flip_indices = [1, 2]
 
         twenty_non_cyclical_actions = [C, C, D, C, C, D, C, C, C, D, C, C, C, C, D, C, C, C, C, C]
-        twenty_test_actions = get_joss_strategy_actions(twenty_non_cyclical_actions, seed_two_flip_indices)
+        twenty_test_actions = get_joss_strategy_actions(twenty_non_cyclical_actions, flip_indices)
 
         subsequent_opponent_actions = [D, C, D, C, D, C, D, C]
         subsequent_test_actions = [(C, D), (D, C), (C, D), (D, C), (C, D), (D, C), (C, D), (D, C)]

--- a/axelrod/tests/strategies/test_cooperator.py
+++ b/axelrod/tests/strategies/test_cooperator.py
@@ -52,26 +52,7 @@ class TestTrickyCooperator(TestPlayer):
         expected_actions = [(C, C), (C, C), (C, C), (D, C)] + [(D, D), (C, D)] + [(C, C)] * 10
         self.versus_test(axelrod.MockPlayer(opponent_actions), expected_actions=expected_actions)
 
-    def test_defects_if_last_ten_has_no_D_and_last_three_are_C(self):
-        """according to doc string on strategy"""
-        opponent_actions = [D] + [C] * 7 + [C] * 3 + [C]
-        actions = [(C, D)] + [(C, C)] * 7 + [(C, C)] * 3 + [(D, C)]
-        self.versus_test(axelrod.MockPlayer(opponent_actions), actions)
-
-    def test_cooperates_if_last_ten_has_D(self):
-        """according to doc string on strategy"""
-        opponent_actions = [D] + [C] * 6 + [C] * 3 + [C]
-        actions = [(C, D)] + [(C, C)] * 6 + [(C, C)] * 3 + [(C, C)]
-        self.versus_test(axelrod.MockPlayer(opponent_actions), actions)
-
-    def test_cooperates_if_last_three_are_not_C(self):
-        """according to doc string on strategy"""
-        opponent_actions = [D] + [C] * 7 + [C, D, C] + [C]
-        actions = [(C, D)] + [(C, C)] * 7 + [(C, C), (C, D), (C, C)] + [(C, C)]
-        self.versus_test(axelrod.MockPlayer(opponent_actions), actions)
-
     def test_cooperates_in_first_three_rounds(self):
-        """according to code meaning"""
         against_defector = [(C, D)] * 3
         against_cooperator = [(C, C)] * 3
         against_alternator = [(C, C), (C, D), (C, C)]
@@ -80,12 +61,10 @@ class TestTrickyCooperator(TestPlayer):
         self.versus_test(axelrod.Alternator(), against_alternator)
 
     def test_defects_after_three_rounds_if_opponent_only_cooperated_in_max_history_depth_ten(self):
-        """according to code meaning"""
         against_cooperator = [(C, C)] * 3 + [(D, C)] * 20
         self.versus_test(axelrod.Cooperator(), against_cooperator)
 
     def test_defects_when_opponent_has_no_defections_to_history_depth_ten(self):
-        """according to code meaning"""
         opponent_actions = [D] + [C] * 10 + [D, C]
         expected_actions = [(C, D)] + [(C, C)] * 10 + [(D, D), (C, C)]
         self.versus_test(axelrod.MockPlayer(opponent_actions), expected_actions)

--- a/axelrod/tests/strategies/test_cooperator.py
+++ b/axelrod/tests/strategies/test_cooperator.py
@@ -42,8 +42,14 @@ class TestTrickyCooperator(TestPlayer):
         # Starts by cooperating.
         self.first_play_test(C)
         # Test if it tries to trick opponent.
-        self.responses_test([D], [C, C, C], [C, C, C])
-        self.responses_test([C], [C, C, C, D, D], [C, C, C, C, D])
-        history = [C, C, C, D, D] + [C] * 11
-        opponent_history = [C, C, C, C, D] + [D] + [C] * 10
-        self.responses_test([D], history, opponent_history)
+        self.versus_test(axelrod.Cooperator(), [(C, C), (C, C), (C, C), (D, C), (D, C)])
+
+        opponent_actions = [C, C, C, C, D, D]
+        expected_actions = [(C, C), (C, C), (C, C), (D, C), (D, D), (C, D)]
+        self.versus_test(axelrod.MockPlayer(opponent_actions), expected_actions=expected_actions)
+
+        opponent_actions = [C, C, C, C, D] + [D] + [C] * 10
+        expected_actions = [(C, C), (C, C), (C, C), (D, C), (D, D), (C, D), (C, C), (C, C), (C, C), (C, C), (C, C),
+                            (C, C), (C, C), (C, C), (C, C), (C, C)]
+        self.versus_test(axelrod.MockPlayer(opponent_actions), expected_actions=expected_actions)
+

--- a/axelrod/tests/strategies/test_cooperator.py
+++ b/axelrod/tests/strategies/test_cooperator.py
@@ -48,7 +48,44 @@ class TestTrickyCooperator(TestPlayer):
         expected_actions = [(C, C), (C, C), (C, C), (D, C), (D, D), (C, D)]
         self.versus_test(axelrod.MockPlayer(opponent_actions), expected_actions=expected_actions)
 
-        opponent_actions = [C, C, C, C, D] + [D] + [C] * 10
-        expected_actions = [(C, C), (C, C), (C, C), (D, C), (D, D), (C, D), (C, C), (C, C), (C, C), (C, C), (C, C),
-                            (C, C), (C, C), (C, C), (C, C), (C, C)]
+        opponent_actions = [C, C, C, C] + [D, D] + [C] * 10
+        expected_actions = [(C, C), (C, C), (C, C), (D, C)] + [(D, D), (C, D)] + [(C, C)] * 10
         self.versus_test(axelrod.MockPlayer(opponent_actions), expected_actions=expected_actions)
+
+    def test_defects_if_last_ten_has_no_D_and_last_three_are_C(self):
+        """according to doc string on strategy"""
+        opponent_actions = [D] + [C] * 7 + [C] * 3 + [C]
+        actions = [(C, D)] + [(C, C)] * 7 + [(C, C)] * 3 + [(D, C)]
+        self.versus_test(axelrod.MockPlayer(opponent_actions), actions)
+
+    def test_cooperates_if_last_ten_has_D(self):
+        """according to doc string on strategy"""
+        opponent_actions = [D] + [C] * 6 + [C] * 3 + [C]
+        actions = [(C, D)] + [(C, C)] * 6 + [(C, C)] * 3 + [(C, C)]
+        self.versus_test(axelrod.MockPlayer(opponent_actions), actions)
+
+    def test_cooperates_if_last_three_are_not_C(self):
+        """according to doc string on strategy"""
+        opponent_actions = [D] + [C] * 7 + [C, D, C] + [C]
+        actions = [(C, D)] + [(C, C)] * 7 + [(C, C), (C, D), (C, C)] + [(C, C)]
+        self.versus_test(axelrod.MockPlayer(opponent_actions), actions)
+
+    def test_cooperates_in_first_three_rounds(self):
+        """according to code meaning"""
+        against_defector = [(C, D)] * 3
+        against_cooperator = [(C, C)] * 3
+        against_alternator = [(C, C), (C, D), (C, C)]
+        self.versus_test(axelrod.Defector(), against_defector)
+        self.versus_test(axelrod.Cooperator(), against_cooperator)
+        self.versus_test(axelrod.Alternator(), against_alternator)
+
+    def test_defects_after_three_rounds_if_opponent_only_cooperated_in_max_history_depth_ten(self):
+        """according to code meaning"""
+        against_cooperator = [(C, C)] * 3 + [(D, C)] * 20
+        self.versus_test(axelrod.Cooperator(), against_cooperator)
+
+    def test_defects_when_opponent_has_no_defections_to_history_depth_ten(self):
+        """according to code meaning"""
+        opponent_actions = [D] + [C] * 10 + [D, C]
+        expected_actions = [(C, D)] + [(C, C)] * 10 + [(D, D), (C, C)]
+        self.versus_test(axelrod.MockPlayer(opponent_actions), expected_actions)

--- a/axelrod/tests/strategies/test_cooperator.py
+++ b/axelrod/tests/strategies/test_cooperator.py
@@ -52,4 +52,3 @@ class TestTrickyCooperator(TestPlayer):
         expected_actions = [(C, C), (C, C), (C, C), (D, C), (D, D), (C, D), (C, C), (C, C), (C, C), (C, C), (C, C),
                             (C, C), (C, C), (C, C), (C, C), (C, C)]
         self.versus_test(axelrod.MockPlayer(opponent_actions), expected_actions=expected_actions)
-

--- a/axelrod/tests/strategies/test_cycler.py
+++ b/axelrod/tests/strategies/test_cycler.py
@@ -58,9 +58,9 @@ class TestBasicCycler(TestPlayer):
         'manipulates_state': False
     }
 
-    def test_repr(self):
+    def test_name(self):
         cycle_str = 'DDCCDDCDCDCDC'
-        self.assertEqual(repr(Cycler(cycle_str)), 'Cycler {}'.format(cycle_str))
+        self.assertEqual(Cycler(cycle_str).name, 'Cycler {}'.format(cycle_str))
 
     def test_memory_depth_is_len_cycle_minus_one(self):
         len_ten = 'DCDCDDCDCD'

--- a/axelrod/tests/strategies/test_cycler.py
+++ b/axelrod/tests/strategies/test_cycler.py
@@ -35,7 +35,7 @@ class TestAntiCycler(TestPlayer):
             self.assertIsNone(detect_cycle(contains_no_cycles[:slice_at]))
 
     def test_strategy(self):
-        """rounds are CDD  CD  CCD CCCD CCCCD ..."""
+        """Rounds are CDD  CD  CCD CCCD CCCCD ..."""
         anticycler_rounds = [C, D, D, C, D, C, C, D, C, C, C, D, C, C, C, C, D, C, C, C, C, C, D]
         num_elements = len(anticycler_rounds)
         against_defector = list(zip(anticycler_rounds, [D] * num_elements))
@@ -105,7 +105,7 @@ def test_cycler_factory(cycle_str):
 
 
 def _get_actions_cycle_against_cooperator(cycle_string: str):
-    """converts str like 'CCDC' to an itertools.cycle against Cooperator [(C, C), (C, C), (D, C), (C, C)]
+    """Converts str like 'CCDC' to an itertools.cycle against Cooperator [(C, C), (C, C), (D, C), (C, C)]
     (Where C=Actions.C, D=Actions.D)"""
     cooperator_opponent_action = C
     action_iterator = str_to_actions(cycle_string)

--- a/axelrod/tests/strategies/test_cycler.py
+++ b/axelrod/tests/strategies/test_cycler.py
@@ -2,9 +2,10 @@
 
 import itertools
 import axelrod
+from axelrod import Actions
 from .test_player import TestPlayer
 
-C, D = axelrod.Actions.C, axelrod.Actions.D
+C, D = Actions.C, Actions.D
 
 
 class TestAntiCycler(TestPlayer):
@@ -45,11 +46,29 @@ def test_cycler_factory(cycle):
 
         def test_strategy(self):
             """Starts by cooperating"""
-            for i in range(20):
-                responses = itertools.islice(itertools.cycle(cycle), i)
-            self.responses_test(responses)
+            match_len = 20
+            actions_cycle = _get_actions_cycle_against_cooperator(cycle)
+            test_actions = list(itertools.islice(itertools.cycle(actions_cycle), match_len))
+            self.versus_test(axelrod.Cooperator(), test_actions)
 
     return TestCycler
+
+
+def _get_actions_cycle_against_cooperator(cycle_string: str) -> [(Actions, Actions)]:
+    """converts str like 'CCDC' to set of actions against Cooperator [(C, C), (C, C), (D, C), (C, C)]
+    (Where C=Actions.C, D=Actions.D)"""
+    cooperator_opponent_action = C
+    out = []
+    for action_str in cycle_string:
+        action = _get_action(action_str)
+        out.append((action, cooperator_opponent_action))
+    return out
+
+
+def _get_action(action_str: str) -> Actions:
+    """takes a string and returns appropriate Actions class."""
+    actions = {'C': C, 'D': D}
+    return actions[action_str]
 
 
 TestCyclerDC = test_cycler_factory("DC")

--- a/axelrod/tests/strategies/test_cycler.py
+++ b/axelrod/tests/strategies/test_cycler.py
@@ -55,7 +55,7 @@ def test_cycler_factory(cycle_str):
 
 
 def _get_actions_cycle_against_cooperator(cycle_string: str):
-    """converts str like 'CCDC' to set of actions against Cooperator [(C, C), (C, C), (D, C), (C, C)]
+    """converts str like 'CCDC' to an itertools.cycle against Cooperator [(C, C), (C, C), (D, C), (C, C)]
     (Where C=Actions.C, D=Actions.D)"""
     cooperator_opponent_action = C
     action_iterator = str_to_actions(cycle_string)

--- a/axelrod/tests/strategies/test_cycler.py
+++ b/axelrod/tests/strategies/test_cycler.py
@@ -2,7 +2,7 @@
 
 import itertools
 import axelrod
-from axelrod import Actions
+from axelrod.actions import Action, Actions
 from .test_player import TestPlayer
 
 C, D = Actions.C, Actions.D
@@ -54,7 +54,7 @@ def test_cycler_factory(cycle):
     return TestCycler
 
 
-def _get_actions_cycle_against_cooperator(cycle_string: str) -> [(Actions, Actions)]:
+def _get_actions_cycle_against_cooperator(cycle_string: str) -> list:
     """converts str like 'CCDC' to set of actions against Cooperator [(C, C), (C, C), (D, C), (C, C)]
     (Where C=Actions.C, D=Actions.D)"""
     cooperator_opponent_action = C
@@ -65,7 +65,7 @@ def _get_actions_cycle_against_cooperator(cycle_string: str) -> [(Actions, Actio
     return out
 
 
-def _get_action(action_str: str) -> Actions:
+def _get_action(action_str: str) -> Action:
     """takes a string and returns appropriate Actions class."""
     actions = {'C': C, 'D': D}
     return actions[action_str]

--- a/axelrod/tests/strategies/test_player.py
+++ b/axelrod/tests/strategies/test_player.py
@@ -2,7 +2,7 @@ import random
 import unittest
 import warnings
 import types
-
+import itertools
 import numpy as np
 
 import axelrod
@@ -260,7 +260,7 @@ class TestPlayer(unittest.TestCase):
                 self.assertTrue(np.array_equal(reset_value, original_value),
                                 msg=attribute)
 
-            elif isinstance(reset_value, types.GeneratorType):
+            elif isinstance(reset_value, types.GeneratorType) or isinstance(reset_value, itertools.cycle):
                 for _ in range(10):
                     self.assertEqual(next(reset_value),
                                      next(original_value), msg=attribute)

--- a/axelrod/tests/unit/test_actions.py
+++ b/axelrod/tests/unit/test_actions.py
@@ -1,7 +1,6 @@
 import unittest
 from axelrod import Actions, flip_action
 from axelrod.actions import str_to_actions
-from types import GeneratorType
 
 C, D = Actions.C, Actions.D
 
@@ -24,19 +23,9 @@ class TestAction(unittest.TestCase):
     def test_error(self):
         self.assertRaises(ValueError, flip_action, 'R')
 
-    def test_str_to_actions_is_generator(self):
-        to_test = str_to_actions('c')
-        self.assertIsInstance(to_test, GeneratorType)
+    def test_str_to_actions(self):
+        self.assertEqual(str_to_actions('C'), (C, ))
+        self.assertEqual(str_to_actions('CDDC'), (C, D, D, C))
 
-    def test_str_to_actions_upper_and_lower(self):
-        to_test = str_to_actions('cDdC')
-        self.assertEqual(next(to_test), Actions.C)
-        self.assertEqual(next(to_test), Actions.D)
-        self.assertEqual(next(to_test), Actions.D)
-        self.assertEqual(next(to_test), Actions.C)
-        self.assertRaises(StopIteration, next, to_test)
-
-    def test_str_to_actions_only_raises_value_error_once_offending_letter_is_reached(self):
-        to_test = str_to_actions('cAc')
-        self.assertEqual(next(to_test), Actions.C)
-        self.assertRaises(ValueError, next, to_test)
+    def test_str_to_actions_fails_fast_and_raises_value_error(self):
+        self.assertRaises(ValueError, str_to_actions, 'Cc')

--- a/axelrod/tests/unit/test_actions.py
+++ b/axelrod/tests/unit/test_actions.py
@@ -1,6 +1,7 @@
 import unittest
 from axelrod import Actions, flip_action
-
+from axelrod.actions import str_to_actions
+from types import GeneratorType
 
 C, D = Actions.C, Actions.D
 
@@ -22,3 +23,20 @@ class TestAction(unittest.TestCase):
 
     def test_error(self):
         self.assertRaises(ValueError, flip_action, 'R')
+
+    def test_str_to_actions_is_generator(self):
+        to_test = str_to_actions('c')
+        self.assertIsInstance(to_test, GeneratorType)
+
+    def test_str_to_actions_upper_and_lower(self):
+        to_test = str_to_actions('cDdC')
+        self.assertEqual(next(to_test), Actions.C)
+        self.assertEqual(next(to_test), Actions.D)
+        self.assertEqual(next(to_test), Actions.D)
+        self.assertEqual(next(to_test), Actions.C)
+        self.assertRaises(StopIteration, next, to_test)
+
+    def test_str_to_actions_only_raises_value_error_once_offending_letter_is_reached(self):
+        to_test = str_to_actions('cAc')
+        self.assertEqual(next(to_test), Actions.C)
+        self.assertRaises(ValueError, next, to_test)

--- a/axelrod/tests/unit/test_strategy_transformers.py
+++ b/axelrod/tests/unit/test_strategy_transformers.py
@@ -451,7 +451,7 @@ class TestTransformers(unittest.TestCase):
         FlipTransformer is applied to Alternator and CyclerCD. In other words,
         the implementation matters, not just the outcomes."""
         # Difference between Alternator and CyclerCD
-        p1 = axelrod.Cycler(cycle="CD")
+        p1 = axelrod.Cycler(cycle_str="CD")
         p2 = FlipTransformer()(axelrod.Cycler)(cycle="CD")
         for _ in range(5):
             p1.play(p2)

--- a/axelrod/tests/unit/test_strategy_transformers.py
+++ b/axelrod/tests/unit/test_strategy_transformers.py
@@ -451,7 +451,7 @@ class TestTransformers(unittest.TestCase):
         FlipTransformer is applied to Alternator and CyclerCD. In other words,
         the implementation matters, not just the outcomes."""
         # Difference between Alternator and CyclerCD
-        p1 = axelrod.Cycler(cycle_str="CD")
+        p1 = axelrod.Cycler(cycle="CD")
         p2 = FlipTransformer()(axelrod.Cycler)(cycle="CD")
         for _ in range(5):
             p1.play(p2)

--- a/axelrod/tests/unit/test_strategy_utils.py
+++ b/axelrod/tests/unit/test_strategy_utils.py
@@ -25,3 +25,26 @@ class TestDetectCycle(unittest.TestCase):
 
         history = [D, D, C, C, C]
         self.assertIsNone(detect_cycle(history))
+
+    def test_regression_test_can_detect_cycle_that_is_repeated_exactly_once(self):
+        self.assertEqual(detect_cycle([C, D, C, D]), (C, D))
+        self.assertEqual(detect_cycle([C, D, C, D, C]), (C, D))
+
+    def test_cycle_will_be_at_least_min_size(self):
+        self.assertEqual(detect_cycle([C, C, C, C], min_size=1), (C, ))
+        self.assertEqual(detect_cycle([C, C, C, C], min_size=2), (C, C))
+
+    def test_cycle_that_never_fully_repeats_returns_none(self):
+        cycle = [C, D, D]
+        to_test = cycle + cycle[:-1]
+        self.assertIsNone(detect_cycle(to_test))
+
+    def test_min_size_greater_than_two_times_history_tail_returns_none(self):
+        self.assertIsNone(detect_cycle([C, C, C], min_size=2))
+
+    def test_min_size_greater_than_two_times_max_size_has_no_effect(self):
+        self.assertEqual(detect_cycle([C, C, C, C, C, C, C, C], min_size=2, max_size=3), (C, C))
+
+    def test_cycle_greater_than_max_size_returns_none(self):
+        self.assertEqual(detect_cycle([C, C, D] * 2, min_size=1, max_size=3), (C, C, D))
+        self.assertIsNone(detect_cycle([C, C, D] * 2, min_size=1, max_size=2))


### PR DESCRIPTION
#884 

Cycler depended on knowing that Actions.C and Actions.D were 'C' and 'D'. I wrote a few lines to refactor that and can remove them with ease.