### PR TITLE
Add SlowTitForTwoTats2 Strategy

### DIFF
--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -75,7 +75,7 @@ from .titfortat import (
     TitForTat, TitFor2Tats, TwoTitsForTat, Bully, SneakyTitForTat,
     SuspiciousTitForTat, AntiTitForTat, HardTitForTat, HardTitFor2Tats,
     OmegaTFT, Gradual, ContriteTitForTat, SlowTitForTwoTats, AdaptiveTitForTat,
-    SpitefulTitForTat)
+    SpitefulTitForTat, SlowTitForTwoTats2)
 from .verybad import VeryBad
 from .worse_and_worse import (WorseAndWorse, KnowledgeableWorseAndWorse,
                               WorseAndWorse2, WorseAndWorse3)

--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -219,6 +219,7 @@ all_strategies = [
     ShortMem,
     Shubik,
     SlowTitForTwoTats,
+    SlowTitForTwoTats2,
     SneakyTitForTat,
     SoftGrudger,
     SoftJoss,

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -634,5 +634,5 @@ class SlowTitForTwoTats2(Player):
         if opponent.history[-2] == opponent.history[-1]:
             return opponent.history[-1]
 
-        # Otherwise cooperate
+        # Otherwise play previous move
         return self.history[-1]

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -602,3 +602,37 @@ class SpitefulTitForTat(Player):
     def reset(self):
         super().reset()
         self.retaliating = False
+
+class SlowTitForTwoTats2(Player):
+    """
+    A player plays C twice, then if the opponent plays the same move twice,
+    plays that move, otherwise plays previous move.
+
+    Names:
+
+    - Slow Tit For Tat [PRISON1998]_
+    """
+
+    name = 'Slow Tit For Two Tats 2'
+    classifier = {
+        'memory_depth': 2,
+        'stochastic': False,
+        'makes_use_of': set(),
+        'long_run_time': False,
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+
+    def strategy(self, opponent: Player) -> Action:
+
+        # Start with two cooperations
+        if len(self.history) < 2:
+            return C
+
+        # Mimic if opponent plays the same move twice
+        if opponent.history[-2] == opponent.history[-1]:
+            return opponent.history[-1]
+
+        # Otherwise cooperate
+        return self.history[-1]

--- a/axelrod/tests/strategies/test_titfortat.py
+++ b/axelrod/tests/strategies/test_titfortat.py
@@ -541,3 +541,26 @@ class TestSpitefulTitForTat(TestPlayer):
         actions = [(C, C), (C, C), (C, D), (D, D), (D, C)]
         self.versus_test(opponent, expected_actions=actions,
                          attrs={"retaliating": True})
+
+class TestSlowTitForTwoTats2(TestPlayer):
+
+    name = "Slow Tit For Two Tats 2"
+    player = axelrod.SlowTitForTwoTats2
+    expected_classifier = {
+        'memory_depth': 2,
+        'stochastic': False,
+        'makes_use_of': set(),
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+
+    def test_strategy(self):
+        # Starts by cooperating.
+        self.first_play_test(C)
+        # If opponent plays the same move twice, repeats last action of
+        # opponent history, otherwise repeats previous move.
+        opponent = axelrod.MockPlayer([C, C, D, D, C, D, D, C, C, D, D])
+        actions = [(C, C), (C, C), (C, D), (C, D), (D, C), (D, D), (D, D),
+                    (D, C), (D, C), (C, D), (C, D)]
+        self.versus_test(opponent, expected_actions=actions)

--- a/docs/tutorials/advanced/classification_of_strategies.rst
+++ b/docs/tutorials/advanced/classification_of_strategies.rst
@@ -69,7 +69,7 @@ range of memory_depth values, we can use the 'min_memory_depth' and
     ... }
     >>> strategies = axl.filtered_strategies(filterset)
     >>> len(strategies)
-    49
+    50
 
 We can also identify strategies that make use of particular properties of the
 tournament. For example, here is the number of strategies that  make use of the


### PR DESCRIPTION
Strategy from PRISON(1998) that plays C twice for opening. If opponent plays same move twice in a row, the player mimics that move, otherwise just plays it's previous move.

'slow_tft' from PRISON list in #379 