### PR TITLE
Mute the warnings for the player tests.

### DIFF
--- a/axelrod/tests/strategies/test_player.py
+++ b/axelrod/tests/strategies/test_player.py
@@ -395,6 +395,7 @@ class TestPlayer(unittest.TestCase):
         init_kwargs: dictionary
             A list of keyword arguments to instantiate player with
         """
+        warnings.simplefilter("ignore")
         if init_args is None:
             init_args = ()
         if init_kwargs is None:


### PR DESCRIPTION
Thought of this because of conversation on #816.

As we are actively working on #884 to refactor the tests I thought we
could mute the warnings now.

Not at all insistent on this.