### PR TITLE
884-inverse

### DIFF
--- a/axelrod/strategies/inverse.py
+++ b/axelrod/strategies/inverse.py
@@ -27,8 +27,9 @@ class Inverse(Player):
         If so, player defection is inversely proportional to when this occurred.
         """
 
+        # calculate how many turns ago the opponent defected
         index = next((index for index, value in
-                      enumerate(opponent.history, start=1) if value == D), None)
+                      enumerate(opponent.history[::-1], start=1) if value == D), None)
 
         if index is None:
             return C

--- a/axelrod/tests/strategies/test_inverse.py
+++ b/axelrod/tests/strategies/test_inverse.py
@@ -23,16 +23,23 @@ class TestInverse(TestPlayer):
     def test_strategy(self):
         # Cooperate initially.
         self.first_play_test(C)
+
         # Test that as long as the opponent has not defected the player will
         # cooperate.
-        self.responses_test([C], [C] * 4, [C] * 4)
-        self.responses_test([C], [C] * 5, [C] * 5)
+        self.versus_test(axelrod.Cooperator(), expected_actions=[(C, C)])
+
         # Tests that if opponent has played all D then player chooses D.
-        self.responses_test([D], [C], [D], seed=5)
-        self.responses_test([D], [C], [D, D])
-        self.responses_test([D], [C] * 8, [D] * 8)
-        # Tests that if opponent has played all D then player chooses D.
-        self.responses_test([C], [C] * 4, [C, D, C, D], seed=6)
-        self.responses_test([C], [C] * 6, [C, C, C, C, D, D])
-        self.responses_test([D], [C] * 9, [D] * 8 + [C])
-        self.responses_test([D], [C] * 9, [D] * 8 + [C], seed=6)
+        self.versus_test(
+            axelrod.Defector(),
+            expected_actions=[(C, D)] + [(D, D)] * 9
+        )
+
+        expected_actions = [
+            (C, D), (D, C), (D, C), (D, D), (D, C),
+            (C, C), (C, C), (C, C), (C, D), (D, D),
+        ]
+        self.versus_test(
+            axelrod.MockPlayer([a[1] for a in expected_actions]),
+            expected_actions=expected_actions,
+            seed=0,
+        )


### PR DESCRIPTION
https://github.com/Axelrod-Python/Axelrod/issues/884

**Changes**
- move test_inverse.py to versus_test testing strategy
- fix last defect computation - I believe this was incorrectly calculating the index of the opponent's first defect and never changing. I've changed this logic to traverse the opponent's history beginning at the end of the array moving backwards instead of the front. 
