### PR TITLE
Add GeneralSoftGrudger Strategy

### DIFF
--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -34,7 +34,7 @@ from .gobymajority import (GoByMajority,
     HardGoByMajority5)
 from .gradualkiller import GradualKiller
 from .grudger import (Grudger, ForgetfulGrudger, OppositeGrudger, Aggravater,
-    SoftGrudger, GrudgerAlternator, EasyGo)
+    SoftGrudger, GrudgerAlternator, EasyGo, GeneralSoftGrudger)
 from .grumpy import Grumpy
 from .handshake import Handshake
 from .hmm import HMMPlayer, EvolvedHMM5
@@ -146,6 +146,7 @@ all_strategies = [
     Geller,
     GellerCooperator,
     GellerDefector,
+    GeneralSoftGrudger,
     GoByMajority,
     GoByMajority10,
     GoByMajority20,

--- a/axelrod/strategies/grudger.py
+++ b/axelrod/strategies/grudger.py
@@ -247,6 +247,10 @@ class GeneralSoftGrudger(Player):
     only punishes after its opponent defects a specified amount of times consecutively.
     The punishment is in the form of a series of defections followed by a 'penance' of
     a series of consecutive cooperations.
+
+    Names:
+
+    - General Soft Grudger: Original Name by J. Taylor Smith
     """
 
     name = 'General Soft Grudger'
@@ -279,7 +283,7 @@ class GeneralSoftGrudger(Player):
         self.n = n
         self.d = d
         self.c = c
-        self.grudge = [D]*(d-1)+[C]*c
+        self.grudge = [D] * (d - 1) + [C] * c
         self.grudged = False
         self.grudge_memory = 0
 
@@ -296,7 +300,7 @@ class GeneralSoftGrudger(Player):
                 self.grudged = False
                 self.grudge_memory = 0
             return strategy
-        elif [D]*self.n == opponent.history[-self.n:]:
+        elif [D] * self.n == opponent.history[-self.n:]:
             self.grudged = True
             return D
         return C

--- a/axelrod/tests/strategies/test_grudger.py
+++ b/axelrod/tests/strategies/test_grudger.py
@@ -220,3 +220,38 @@ class TestEasyGo(TestPlayer):
         # forever.
         self.responses_test([D], [C, D, D, D], [C, C, C, C])
         self.responses_test([C], [C, C, D, D, D], [C, D, C, C, C])
+
+class TestGeneralSoftGrudger(TestPlayer):
+
+    name = "General Soft Grudger: n=1,d=4,c=2"
+    player = axelrod.GeneralSoftGrudger
+    expected_classifier = {
+        'memory_depth': float('inf'),
+        'stochastic': False,
+        'makes_use_of': set(),
+        'long_run_time': False,
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+
+    def test_strategy(self):
+        """Test strategy with multiple initial parameters"""
+
+        # Starts by cooperating.
+        self.first_play_test(C)
+
+        # Testing default parameters of n=1, d=4, c=2 (same as Soft Grudger)
+        actions = [(C, D), (D, D), (D, C), (D, C), (D, D), (C, D), (C, C), (C, C)]
+        self.versus_test(axelrod.MockPlayer([D, D, C, C]), expected_actions=actions)
+
+        # Testing n=2, d=4, c=2
+        actions = [(C, D), (C, D), (D, C), (D, C), (D, D), (D, D), (C, C), (C, C)]
+        self.versus_test(axelrod.MockPlayer([D, D, C, C]), expected_actions=actions,
+                         init_kwargs={"n": 2})
+
+        # Testing n=1, d=1, c=1
+        actions = [(C, D), (D, D), (C, C), (C, C), (C, D), (D, D), (C, C), (C, C)]
+        self.versus_test(axelrod.MockPlayer([D, D, C, C]), expected_actions=actions,
+                         init_kwargs={"n": 1, "d": 1, "c": 1})
+


### PR DESCRIPTION
A generalization of the SoftGrudger strategy. SoftGrudger punishes by playing: D, D, D, D, C, C. after a defection by the opponent.  GeneralSoftGrudger only punishes after its opponent defects a specified amount of times consecutively (parameter "n"). The punishment is in the form of a series of defections (parameter "d") followed by a 'penance' of a series of consecutive cooperations (parameter "c").

SoftGrudger (already existed) is "soft spiteful" from the PRISON list in #379 and this is a generalization of that strategy.  