### PR TITLE
Implement a minimal prob end for property test

### DIFF
--- a/axelrod/tests/unit/test_property.py
+++ b/axelrod/tests/unit/test_property.py
@@ -233,7 +233,8 @@ class TestProbEndSpatialTournament(unittest.TestCase):
             self.assertIn(str(p), basic_player_names)
 
     @given(tournament=prob_end_spatial_tournaments(strategies=stochastic_strategies,
-                                          max_size=3))
+                                                   max_size=3,
+                                                   min_prob_end=0.2))
     @settings(max_examples=10, timeout=0)
     def test_decorator_with_stochastic_strategies(self, tournament):
         self.assertIsInstance(tournament, axelrod.ProbEndSpatialTournament)


### PR DESCRIPTION
This should hopefully stop sporadic failures on travis (due to
timeouts) - mentioned on #935