### PR TITLE
842 - Approximate Moran Process

### DIFF
--- a/axelrod/__init__.py
+++ b/axelrod/__init__.py
@@ -15,7 +15,7 @@ from .player import (
     update_history, update_state_distribution, Player)
 from .mock_player import MockPlayer, simulate_play
 from .match import Match
-from .moran import MoranProcess, MoranProcessGraph
+from .moran import MoranProcess, MoranProcessGraph, ApproximateMoranProcess
 from .strategies import *
 from .deterministic_cache import DeterministicCache
 from .match_generator import *

--- a/axelrod/__init__.py
+++ b/axelrod/__init__.py
@@ -7,7 +7,7 @@ from .version import __version__
 from .load_data_ import load_pso_tables, load_weights
 from . import graph
 from .actions import Actions, flip_action
-from .random_ import random_choice, seed
+from .random_ import random_choice, seed, Pdf
 from .plot import Plot
 from .game import DefaultGame, Game
 from .player import (

--- a/axelrod/moran.py
+++ b/axelrod/moran.py
@@ -379,23 +379,6 @@ class MoranProcessGraph(MoranProcess):
         return counter
 
 
-class Pdf(object):
-    """A class for a probability distribution"""
-    def __init__(self, counter):
-        """Take as an instance of collections.counter"""
-        self.sample_space, self.counts = zip(*counter.items())
-        self.size = len(self.sample_space)
-        self.total = sum(self.counts)
-        self.probability = list([v / self.total for v in self.counts])
-
-    def sample(self):
-        """Sample from the pdf"""
-        index = np.random.choice(a=range(self.size), p=self.probability)
-        # Numpy cannot sample from a list of n dimensional objects for n > 1,
-        # need to sample an index
-        return self.sample_space[index]
-
-
 class ApproximateMoranProcess(MoranProcess):
     """
     A class to approximate a Moran process based

--- a/axelrod/random_.py
+++ b/axelrod/random_.py
@@ -43,3 +43,20 @@ def seed(seed_):
     """Sets a seed"""
     random.seed(seed_)
     numpy.random.seed(seed_)
+
+
+class Pdf(object):
+    """A class for a probability distribution"""
+    def __init__(self, counter):
+        """Take as an instance of collections.counter"""
+        self.sample_space, self.counts = zip(*counter.items())
+        self.size = len(self.sample_space)
+        self.total = sum(self.counts)
+        self.probability = list([v / self.total for v in self.counts])
+
+    def sample(self):
+        """Sample from the pdf"""
+        index = numpy.random.choice(a=range(self.size), p=self.probability)
+        # Numpy cannot sample from a list of n dimensional objects for n > 1,
+        # need to sample an index
+        return self.sample_space[index]

--- a/axelrod/tests/unit/test_moran.py
+++ b/axelrod/tests/unit/test_moran.py
@@ -376,11 +376,11 @@ class TestApproximateMoranProcess(unittest.TestCase):
 
     def test_next(self):
         """Test the next function of the Moran process"""
-        scores = self.amp._play_next_round()
+        scores = self.amp.score_all()
         self.assertEqual(scores, [0, 5])
-        scores = self.amp._play_next_round()
+        scores = self.amp.score_all()
         self.assertEqual(scores, [0, 5])
-        scores = self.amp._play_next_round()
+        scores = self.amp.score_all()
         self.assertEqual(scores, [0, 5])
 
     def test_getting_scores_from_cache(self):

--- a/axelrod/tests/unit/test_moran.py
+++ b/axelrod/tests/unit/test_moran.py
@@ -7,8 +7,8 @@ from hypothesis import given, example, settings
 
 import axelrod
 from axelrod import (Match, MoranProcess,
-                     ApproximateMoranProcess, MoranProcessGraph)
-from axelrod.moran import fitness_proportionate_selection, Pdf
+                     ApproximateMoranProcess, MoranProcessGraph, Pdf)
+from axelrod.moran import fitness_proportionate_selection
 from axelrod.tests.property import strategy_lists
 
 
@@ -309,40 +309,6 @@ class GraphMoranProcess(unittest.TestCase):
             mp.play()
             winner2 = mp.winning_strategy_name
             self.assertEqual((winner == winner2), outcome)
-
-
-class TestPdf(unittest.TestCase):
-    """A suite of tests for the Pdf class"""
-    observations = [('C', 'D')] * 4 + [('C', 'C')] * 12 + \
-                   [('D', 'C')] * 2 + [('D', 'D')] * 15
-    counter = Counter(observations)
-    pdf = Pdf(counter)
-
-    def test_init(self):
-        self.assertEqual(set(self.pdf.sample_space), set(self.counter.keys()))
-        self.assertEqual(set(self.pdf.counts), set([4, 12, 2, 15]))
-        self.assertEqual(self.pdf.total, sum([4, 12, 2, 15]))
-        self.assertAlmostEqual(sum(self.pdf.probability), 1)
-
-    def test_sample(self):
-        """Test that sample maps to correct domain"""
-        all_samples = []
-
-        axelrod.seed(0)
-        for sample in range(100):
-            all_samples.append(self.pdf.sample())
-
-        self.assertEqual(len(all_samples), 100)
-        self.assertEqual(set(all_samples), set(self.observations))
-
-    def test_seed(self):
-        """Test that numpy seeds the sample properly"""
-
-        for seed in range(10):
-            axelrod.seed(seed)
-            sample = self.pdf.sample()
-            axelrod.seed(seed)
-            self.assertEqual(sample, self.pdf.sample())
 
 
 class TestApproximateMoranProcess(unittest.TestCase):

--- a/axelrod/tests/unit/test_random_.py
+++ b/axelrod/tests/unit/test_random_.py
@@ -1,8 +1,9 @@
 """Tests for the random functions."""
+from collections import Counter
 import random
 import unittest
 import numpy
-from axelrod import random_choice, seed, Actions
+from axelrod import random_choice, seed, Actions, Pdf
 
 C, D = Actions.C, Actions.D
 
@@ -39,3 +40,37 @@ class TestRandom_(unittest.TestCase):
             seed(0)
             random_choice(p)
             self.assertEqual(r, random.random())
+
+
+class TestPdf(unittest.TestCase):
+    """A suite of tests for the Pdf class"""
+    observations = [('C', 'D')] * 4 + [('C', 'C')] * 12 + \
+                   [('D', 'C')] * 2 + [('D', 'D')] * 15
+    counter = Counter(observations)
+    pdf = Pdf(counter)
+
+    def test_init(self):
+        self.assertEqual(set(self.pdf.sample_space), set(self.counter.keys()))
+        self.assertEqual(set(self.pdf.counts), set([4, 12, 2, 15]))
+        self.assertEqual(self.pdf.total, sum([4, 12, 2, 15]))
+        self.assertAlmostEqual(sum(self.pdf.probability), 1)
+
+    def test_sample(self):
+        """Test that sample maps to correct domain"""
+        all_samples = []
+
+        seed(0)
+        for sample in range(100):
+            all_samples.append(self.pdf.sample())
+
+        self.assertEqual(len(all_samples), 100)
+        self.assertEqual(set(all_samples), set(self.observations))
+
+    def test_seed(self):
+        """Test that numpy seeds the sample properly"""
+
+        for s in range(10):
+            seed(s)
+            sample = self.pdf.sample()
+            seed(s)
+            self.assertEqual(sample, self.pdf.sample())

--- a/axelrod/tests/unit/test_random_.py
+++ b/axelrod/tests/unit/test_random_.py
@@ -44,8 +44,8 @@ class TestRandom_(unittest.TestCase):
 
 class TestPdf(unittest.TestCase):
     """A suite of tests for the Pdf class"""
-    observations = [('C', 'D')] * 4 + [('C', 'C')] * 12 + \
-                   [('D', 'C')] * 2 + [('D', 'D')] * 15
+    observations = [(C, D)] * 4 + [(C, C)] * 12 + \
+                   [(D, C)] * 2 + [(D, D)] * 15
     counter = Counter(observations)
     pdf = Pdf(counter)
 

--- a/docs/tutorials/getting_started/moran.rst
+++ b/docs/tutorials/getting_started/moran.rst
@@ -59,7 +59,7 @@ The scores in each round::
 The :code:`MoranProcess` class also accepts an argument for a mutation rate.
 Nonzero mutation changes the Markov process so that it no longer has absorbing
 states, and will iterate forever. To prevent this, iterate with a loop (or
-function like :code:`takewhile` from :code:`itertools`):
+function like :code:`takewhile` from :code:`itertools`)::
 
     >>> import axelrod as axl
     >>> axl.seed(4) # for reproducible example
@@ -101,10 +101,9 @@ one graph is supplied to the process, the two graphs are assumed to be the same.
 
 To create a graph-based Moran process, use a graph as follows::
 
-    >>> import axelrod
     >>> from axelrod import Cooperator, Defector, MoranProcessGraph
     >>> from axelrod.graph import Graph
-    >>> axelrod.seed(40)
+    >>> axl.seed(40)
     >>> edges = [(0, 1), (1, 2), (2, 3), (3, 1)]
     >>> graph = Graph(edges)
     >>> players = [Cooperator(), Cooperator(), Cooperator(), Defector()]
@@ -118,3 +117,28 @@ You can supply the `reproduction_graph` as a keyword argument. The standard Mora
 process is equivalent to using a complete graph for both graphs.
 
 
+Approximate Moran Process
+-------------------------
+
+Due to the high computational cost of a single Moran process, an approximate
+Moran process is implemented that can make use of cached outcomes of games. The
+following code snippet will generate a Moran process in which a `Defector`
+cooperates (gets a high score) against another `Defector` (note that the
+opposite is in fact true). First the cache is built by passing counter objects
+of outcomes::
+
+    >>> from collections import Counter
+    >>> from axelrod import Pdf
+    >>> cached_outcomes = {}
+    >>> cached_outcomes[("Cooperator", "Defector")] = Pdf(Counter([(0, 5)]))
+    >>> cached_outcomes[("Cooperator", "Cooperator")] = Pdf(Counter([(3, 3)]))
+    >>> cached_outcomes[("Defector", "Defector")] = Pdf(Counter([(10, 10), (9, 9)]))
+
+Now let us create an Approximate Moran Process::
+
+    >>> axl.seed(0)
+    >>> players = [Cooperator(), Defector(), Defector(), Defector()]
+    >>> amp = axl.ApproximateMoranProcess(players, cached_outcomes)
+    >>> results = amp.play()
+    >>> amp.population_distribution()
+    Counter({'Defector': 4})

--- a/docs/tutorials/getting_started/moran.rst
+++ b/docs/tutorials/getting_started/moran.rst
@@ -22,38 +22,56 @@ type. That type is declared the winner. To run an instance of the process with
 the library, proceed as follows::
 
     >>> import axelrod as axl
+    >>> axl.seed(0)
     >>> players = [axl.Cooperator(), axl.Defector(),
     ...               axl.TitForTat(), axl.Grudger()]
     >>> mp = axl.MoranProcess(players)
     >>> populations = mp.play()
-    >>> mp.winning_strategy_name   # doctest: +SKIP
-    Defector
+    >>> mp.winning_strategy_name
+    'Grudger'
 
 You can access some attributes of the process, such as the number of rounds::
 
-    >>> len(mp)  # doctest: +SKIP
-    6
+    >>> len(mp)
+    14
 
 The sequence of populations::
 
     >>> import pprint
     >>> pprint.pprint(populations)  # doctest: +SKIP
-    [Counter({'Defector': 1, 'Cooperator': 1, 'Grudger': 1, 'Tit For Tat': 1}),
-    Counter({'Defector': 1, 'Cooperator': 1, 'Grudger': 1, 'Tit For Tat': 1}),
-    Counter({'Defector': 2, 'Cooperator': 1, 'Grudger': 1}),
-    Counter({'Defector': 3, 'Grudger': 1}),
-    Counter({'Defector': 3, 'Grudger': 1}),
-    Counter({'Defector': 4})]
+    [Counter({'Grudger': 1, 'Cooperator': 1, 'Defector': 1, 'Tit For Tat': 1}),
+     Counter({'Grudger': 1, 'Cooperator': 1, 'Defector': 1, 'Tit For Tat': 1}),
+     Counter({'Grudger': 1, 'Cooperator': 1, 'Defector': 1, 'Tit For Tat': 1}),
+     Counter({'Tit For Tat': 2, 'Grudger': 1, 'Cooperator': 1}),
+     Counter({'Grudger': 2, 'Cooperator': 1, 'Tit For Tat': 1}),
+     Counter({'Grudger': 3, 'Cooperator': 1}),
+     Counter({'Grudger': 3, 'Cooperator': 1}),
+     Counter({'Grudger': 3, 'Cooperator': 1}),
+     Counter({'Grudger': 3, 'Cooperator': 1}),
+     Counter({'Grudger': 3, 'Cooperator': 1}),
+     Counter({'Grudger': 3, 'Cooperator': 1}),
+     Counter({'Grudger': 3, 'Cooperator': 1}),
+     Counter({'Grudger': 3, 'Cooperator': 1}),
+     Counter({'Grudger': 4})]
+
 
 The scores in each round::
 
-    >>> for row in mp.score_history: # doctest: +SKIP
+    >>> for row in mp.score_history:
     ...     print([round(element, 1) for element in row])
-    [[6.0, 7.08, 6.99, 6.99],
-    [6.0, 7.08, 6.99, 6.99],
-    [3.0, 7.04, 7.04, 4.98],
-    [3.04, 3.04, 3.04, 2.97],
-    [3.04, 3.04, 3.04, 2.97]]
+    [6.0, 7.1, 7.0, 7.0]
+    [6.0, 7.1, 7.0, 7.0]
+    [6.0, 7.1, 7.0, 7.0]
+    [9.0, 9.0, 9.0, 9.0]
+    [9.0, 9.0, 9.0, 9.0]
+    [9.0, 9.0, 9.0, 9.0]
+    [9.0, 9.0, 9.0, 9.0]
+    [9.0, 9.0, 9.0, 9.0]
+    [9.0, 9.0, 9.0, 9.0]
+    [9.0, 9.0, 9.0, 9.0]
+    [9.0, 9.0, 9.0, 9.0]
+    [9.0, 9.0, 9.0, 9.0]
+    [9.0, 9.0, 9.0, 9.0]
 
 
 The :code:`MoranProcess` class also accepts an argument for a mutation rate.
@@ -77,8 +95,8 @@ Moran Process on Graphs
 -----------------------
 
 The library also provides a graph-based Moran process [Shakarian2013]_ with
-`MoranProcessGraph`.  To use this class you must supply at least one
-`Axelrod.graph.Graph` object, which can be initialized with just a list of
+:code:`MoranProcessGraph`.  To use this class you must supply at least one
+:code:`Axelrod.graph.Graph` object, which can be initialized with just a list of
 edges::
 
     edges = [(source_1, target1), (source2, target2), ...]
@@ -101,17 +119,15 @@ one graph is supplied to the process, the two graphs are assumed to be the same.
 
 To create a graph-based Moran process, use a graph as follows::
 
-    >>> from axelrod import Cooperator, Defector, MoranProcessGraph
     >>> from axelrod.graph import Graph
     >>> axl.seed(40)
     >>> edges = [(0, 1), (1, 2), (2, 3), (3, 1)]
     >>> graph = Graph(edges)
-    >>> players = [Cooperator(), Cooperator(), Cooperator(), Defector()]
-    >>> mp = MoranProcessGraph(players, interaction_graph=graph)
+    >>> players = [axl.Cooperator(), axl.Cooperator(), axl.Cooperator(), axl.Defector()]
+    >>> mp = axl.MoranProcessGraph(players, interaction_graph=graph)
     >>> results = mp.play()
     >>> mp.population_distribution()
     Counter({'Cooperator': 4})
-
 
 You can supply the `reproduction_graph` as a keyword argument. The standard Moran
 process is equivalent to using a complete graph for both graphs.
@@ -123,21 +139,19 @@ Approximate Moran Process
 Due to the high computational cost of a single Moran process, an approximate
 Moran process is implemented that can make use of cached outcomes of games. The
 following code snippet will generate a Moran process in which a `Defector`
-cooperates (gets a high score) against another `Defector` (note that the
-opposite is in fact true). First the cache is built by passing counter objects
-of outcomes::
+cooperates (gets a high score) against another `Defector`. First the cache is
+built by passing counter objects of outcomes::
 
     >>> from collections import Counter
-    >>> from axelrod import Pdf
     >>> cached_outcomes = {}
-    >>> cached_outcomes[("Cooperator", "Defector")] = Pdf(Counter([(0, 5)]))
-    >>> cached_outcomes[("Cooperator", "Cooperator")] = Pdf(Counter([(3, 3)]))
-    >>> cached_outcomes[("Defector", "Defector")] = Pdf(Counter([(10, 10), (9, 9)]))
+    >>> cached_outcomes[("Cooperator", "Defector")] = axl.Pdf(Counter([(0, 5)]))
+    >>> cached_outcomes[("Cooperator", "Cooperator")] = axl.Pdf(Counter([(3, 3)]))
+    >>> cached_outcomes[("Defector", "Defector")] = axl.Pdf(Counter([(10, 10), (9, 9)]))
 
 Now let us create an Approximate Moran Process::
 
     >>> axl.seed(0)
-    >>> players = [Cooperator(), Defector(), Defector(), Defector()]
+    >>> players = [axl.Cooperator(), axl.Defector(), axl.Defector(), axl.Defector()]
     >>> amp = axl.ApproximateMoranProcess(players, cached_outcomes)
     >>> results = amp.play()
     >>> amp.population_distribution()


### PR DESCRIPTION
Closes #842 

Adds an approximate Moran process that can take a sample of match outcomes (so that these are not rerun every time).

This also makes a `random_.Pdf` class available, which is a generic probability distribution function with a `sample` method (could be useful elsewhere).