### PR TITLE
Fix bug in classification of transformers

### DIFF
--- a/axelrod/strategy_transformers.py
+++ b/axelrod/strategy_transformers.py
@@ -6,6 +6,7 @@ See the various Meta strategies for another type of transformation.
 """
 
 import collections
+import copy
 import inspect
 import random
 from numpy.random import choice
@@ -21,7 +22,8 @@ C, D = Actions.C, Actions.D
 # Alternator.
 
 
-def StrategyTransformerFactory(strategy_wrapper, name_prefix=None):
+def StrategyTransformerFactory(strategy_wrapper, name_prefix=None,
+                               reclassifier=None):
     """Modify an existing strategy dynamically by wrapping the strategy
     method with the argument `strategy_wrapper`.
 
@@ -37,6 +39,8 @@ def StrategyTransformerFactory(strategy_wrapper, name_prefix=None):
         Any keyword arguments to pass to the wrapper
     name_prefix: string, "Transformed "
         A string to prepend to the strategy and class name
+    reclassifier: function,
+        A function to use to update the class's classifier.
     """
 
     # Create a class that applies a wrapper function to the strategy method
@@ -52,14 +56,17 @@ def StrategyTransformerFactory(strategy_wrapper, name_prefix=None):
             else:
                 self.name_prefix = name_prefix
 
+            if "reclassifier" in kwargs:
+                self.reclassifier = kwargs["reclassifier"]
+            else:
+                self.reclassifier = reclassifier
+
         def __call__(self, PlayerClass):
             """
             Parameters
             ----------
             PlayerClass: A subclass of axelrod.Player, e.g. Cooperator
                 The Player Class to modify
-            name_prefix: str
-                A string to prepend to the Player and Class name
 
             Returns
             -------
@@ -74,6 +81,10 @@ def StrategyTransformerFactory(strategy_wrapper, name_prefix=None):
                 # If "name_prefix" in kwargs remove as only want decorator
                 # arguments
                 del kwargs["name_prefix"]
+            except KeyError:
+                pass
+            try:
+                del kwargs["reclassifier"]
             except KeyError:
                 pass
 
@@ -109,6 +120,12 @@ def StrategyTransformerFactory(strategy_wrapper, name_prefix=None):
                 # Modify the Player name (class variable inherited from Player)
                 name = ' '.join([name_prefix, PlayerClass.name])
 
+            original_classifier = copy.deepcopy(PlayerClass.classifier) # Copy
+            if reclassifier is not None:
+                classifier = reclassifier(original_classifier, *args, **kwargs,)
+            else:
+                classifier = original_classifier
+
             # Define the new __repr__ method to add the wrapper arguments
             # at the end of the name
             def __repr__(self):
@@ -136,6 +153,7 @@ def StrategyTransformerFactory(strategy_wrapper, name_prefix=None):
                     "strategy": strategy,
                     "__repr__": __repr__,
                     "__module__": PlayerClass.__module__,
+                    "classifier": classifier,
                 })
             return new_class
     return Decorator
@@ -229,9 +247,14 @@ def noisy_wrapper(player, opponent, action, noise=0.05):
         return flip_action(action)
     return action
 
+def noisy_reclassifier(original_classifier, noise):
+    """Function to reclassify the strategy"""
+    if noise not in [0, 1]:
+        original_classifier["stochastic"] = True
+    return original_classifier
 
 NoisyTransformer = StrategyTransformerFactory(
-    noisy_wrapper, name_prefix="Noisy")
+    noisy_wrapper, name_prefix="Noisy", reclassifier=noisy_reclassifier)
 
 
 def forgiver_wrapper(player, opponent, action, p):
@@ -241,9 +264,15 @@ def forgiver_wrapper(player, opponent, action, p):
         return random_choice(p)
     return C
 
+def forgiver_reclassifier(original_classifier, p):
+    """Function to reclassify the strategy"""
+    if p not in [0, 1]:
+        original_classifier["stochastic"] = True
+    return original_classifier
 
 ForgiverTransformer = StrategyTransformerFactory(
-    forgiver_wrapper, name_prefix="Forgiving")
+    forgiver_wrapper, name_prefix="Forgiving",
+    reclassifier=forgiver_reclassifier)
 
 
 def nice_wrapper(player, opponent, action):
@@ -278,7 +307,6 @@ def final_sequence(player, opponent, action, seq):
     list is exhausted."""
 
     length = player.match_attributes["length"]
-    player.classifier["makes_use_of"].update(["length"])
 
     if length < 0:  # default is -1
         return action
@@ -294,9 +322,15 @@ def final_sequence(player, opponent, action, seq):
         return seq[-index]
     return action
 
+def final_reclassifier(original_classifier, seq):
+    """Reclassify the strategy"""
+    original_classifier["makes_use_of"].update(["length"])
+    return original_classifier
+
 
 FinalTransformer = StrategyTransformerFactory(final_sequence,
-                                              name_prefix="Final")
+                                              name_prefix="Final",
+                                              reclassifier=final_reclassifier)
 
 
 def history_track_wrapper(player, opponent, action):
@@ -391,9 +425,13 @@ def mixed_wrapper(player, opponent, action, probability, m_player):
 
     return action
 
+def mixed_reclassifier(original_classifier, probability, m_player):
+    """Function to reclassify the strategy"""
+    original_classifier["stochastic"] = True
+    return original_classifier
 
 MixedTransformer = StrategyTransformerFactory(
-    mixed_wrapper, name_prefix="Mutated")
+    mixed_wrapper, name_prefix="Mutated", reclassifier=mixed_reclassifier)
 
 
 def joss_ann_wrapper(player, opponent, proposed_action, probability):
@@ -424,15 +462,33 @@ def joss_ann_wrapper(player, opponent, proposed_action, probability):
     if sum(probability) > 1:
         probability = tuple([i / sum(probability) for i in probability])
 
+    if 1 not in probability or max(probability) == 0:
+        player.classifier["stochastric"] = True
+
     remaining_probability = max(0, 1 - probability[0] - probability[1])
     probability += (remaining_probability,)
     options = [C, D, proposed_action]
     action = choice(options, p=probability)
     return action
 
+def jossann_reclassifier(original_classifier, probability):
+    """
+    Reclassify: note that if probabilities are (0, 1) or (1, 0) then we override
+    the original classifier.
+    """
+    if sum(probability) > 1:
+        probability = tuple([i / sum(probability) for i in probability])
+
+    if probability in [(1, 0), (0, 1)]:
+        original_classifier["stochastic"] = False
+    elif sum(probability) != 0:
+        original_classifier["stochastic"] = True
+
+    return original_classifier
+
 
 JossAnnTransformer = StrategyTransformerFactory(
-    joss_ann_wrapper, name_prefix="Joss-Ann")
+    joss_ann_wrapper, name_prefix="Joss-Ann", reclassifier=jossann_reclassifier)
 
 
 # Strategy wrappers as classes

--- a/axelrod/strategy_transformers.py
+++ b/axelrod/strategy_transformers.py
@@ -40,7 +40,8 @@ def StrategyTransformerFactory(strategy_wrapper, name_prefix=None,
     name_prefix: string, "Transformed "
         A string to prepend to the strategy and class name
     reclassifier: function,
-        A function to use to update the class's classifier.
+        A function which will update the classifier of the strategy being
+        transformed
     """
 
     # Create a class that applies a wrapper function to the strategy method
@@ -244,7 +245,7 @@ def noisy_wrapper(player, opponent, action, noise=0.05):
 
 def noisy_reclassifier(original_classifier, noise):
     """Function to reclassify the strategy"""
-    if noise not in [0, 1]:
+    if noise not in (0, 1):
         original_classifier["stochastic"] = True
     return original_classifier
 
@@ -261,7 +262,7 @@ def forgiver_wrapper(player, opponent, action, p):
 
 def forgiver_reclassifier(original_classifier, p):
     """Function to reclassify the strategy"""
-    if p not in [0, 1]:
+    if p not in (0, 1):
         original_classifier["stochastic"] = True
     return original_classifier
 

--- a/axelrod/strategy_transformers.py
+++ b/axelrod/strategy_transformers.py
@@ -293,9 +293,19 @@ def initial_sequence(player, opponent, action, initial_seq):
         return initial_seq[index]
     return action
 
+def initial_reclassifier(original_classifier, initial_seq):
+    """
+    If needed this extends the memory depth to be the length of the initial
+    sequence
+    """
+    original_classifier["memory_depth"] = max(len(initial_seq),
+                                            original_classifier["memory_depth"])
+    return original_classifier
+
 
 InitialTransformer = StrategyTransformerFactory(initial_sequence,
-                                                name_prefix="Initial")
+                                            name_prefix="Initial",
+                                            reclassifier=initial_reclassifier)
 
 
 def final_sequence(player, opponent, action, seq):
@@ -321,6 +331,8 @@ def final_sequence(player, opponent, action, seq):
 def final_reclassifier(original_classifier, seq):
     """Reclassify the strategy"""
     original_classifier["makes_use_of"].update(["length"])
+    original_classifier["memory_depth"] = max(len(seq),
+                                            original_classifier["memory_depth"])
     return original_classifier
 
 

--- a/axelrod/strategy_transformers.py
+++ b/axelrod/strategy_transformers.py
@@ -422,6 +422,20 @@ def mixed_wrapper(player, opponent, action, probability, m_player):
 
 def mixed_reclassifier(original_classifier, probability, m_player):
     """Function to reclassify the strategy"""
+    # If a single probability, player is passed
+    if isinstance(probability, float) or isinstance(probability, int):
+        m_player = [m_player]
+        probability = [probability]
+
+    if min(probability) == max(probability) == 0:  # No probability given
+        return original_classifier
+
+    if 1 in probability:  # If all probability  given to one player
+        player = m_player[probability.index(1)]
+        original_classifier["stochastic"] = player.classifier["stochastic"]
+        return original_classifier
+
+    # Otherwise: stochastic.
     original_classifier["stochastic"] = True
     return original_classifier
 

--- a/axelrod/strategy_transformers.py
+++ b/axelrod/strategy_transformers.py
@@ -56,11 +56,6 @@ def StrategyTransformerFactory(strategy_wrapper, name_prefix=None,
             else:
                 self.name_prefix = name_prefix
 
-            if "reclassifier" in kwargs:
-                self.reclassifier = kwargs["reclassifier"]
-            else:
-                self.reclassifier = reclassifier
-
         def __call__(self, PlayerClass):
             """
             Parameters

--- a/axelrod/strategy_transformers.py
+++ b/axelrod/strategy_transformers.py
@@ -462,9 +462,6 @@ def joss_ann_wrapper(player, opponent, proposed_action, probability):
     if sum(probability) > 1:
         probability = tuple([i / sum(probability) for i in probability])
 
-    if 1 not in probability or max(probability) == 0:
-        player.classifier["stochastric"] = True
-
     remaining_probability = max(0, 1 - probability[0] - probability[1])
     probability += (remaining_probability,)
     options = [C, D, proposed_action]

--- a/axelrod/tests/unit/test_fingerprint.py
+++ b/axelrod/tests/unit/test_fingerprint.py
@@ -213,103 +213,109 @@ class TestFingerprint(unittest.TestCase):
 
     def test_wsls_fingerprint(self):
         axl.seed(0)  # Fingerprinting is a random process
-        test_data = {Point(x=0.0, y=0.0): 3.0,
-                     Point(x=0.0, y=0.25): 1.46,
-                     Point(x=0.0, y=0.5): 1.54,
-                     Point(x=0.0, y=0.75): 1.12,
-                     Point(x=0.0, y=1.0): 0.5,
-                     Point(x=0.25, y=0.0): 3.0,
-                     Point(x=0.25, y=0.25): 2.04,
-                     Point(x=0.25, y=0.5): 2.0,
-                     Point(x=0.25, y=0.75): 1.34,
-                     Point(x=0.25, y=1.0): 0.9,
-                     Point(x=0.5, y=0.0): 3.0,
-                     Point(x=0.5, y=0.25): 3.0,
-                     Point(x=0.5, y=0.5): 2.06,
-                     Point(x=0.5, y=0.75): 1.36,
-                     Point(x=0.5, y=1.0): 1.0,
-                     Point(x=0.75, y=0.0): 3.0,
-                     Point(x=0.75, y=0.25): 3.56,
-                     Point(x=0.75, y=0.5): 2.06,
-                     Point(x=0.75, y=0.75): 3.0,
-                     Point(x=0.75, y=1.0): 1.04,
+        test_data = {Point(x=0.25, y=1.0): 0.84,
+                     Point(x=0.25, y=0.5): 1.85,
+                     Point(x=0.75, y=0.5): 3.01,
+                     Point(x=0.25, y=0.25): 2.23,
+                     Point(x=0.0, y=0.75): 1.08,
+                     Point(x=0.75, y=1.0): 1.14,
+                     Point(x=0.5, y=0.25): 2.66,
+                     Point(x=0.0, y=0.0): 3.0,
+                     Point(x=0.75, y=0.25): 3.12,
+                     Point(x=1.0, y=0.75): 3.57,
+                     Point(x=1.0, y=0.5): 3.94,
                      Point(x=1.0, y=0.0): 3.0,
-                     Point(x=1.0, y=0.25): 4.86,
-                     Point(x=1.0, y=0.5): 4.9,
-                     Point(x=1.0, y=0.75): 4.9,
+                     Point(x=1.0, y=0.25): 4.78,
+                     Point(x=0.0, y=1.0): 0.5,
+                     Point(x=0.5, y=0.0): 3.0,
+                     Point(x=0.25, y=0.0): 3.0,
+                     Point(x=0.0, y=0.25): 1.71,
+                     Point(x=0.0, y=0.5): 1.44,
+                     Point(x=0.5, y=0.75): 1.62,
+                     Point(x=0.5, y=0.5): 2.77,
+                     Point(x=0.75, y=0.75): 2.27,
+                     Point(x=0.5, y=1.0): 1.02,
+                     Point(x=0.75, y=0.0): 3.0,
+                     Point(x=0.25, y=0.75): 1.27,
                      Point(x=1.0, y=1.0): 1.3}
 
         af = axl.AshlockFingerprint(self.strategy, self.probe)
-        data = af.fingerprint(turns=50, repetitions=2, step=0.25)
+        data = af.fingerprint(turns=50, repetitions=2, step=0.25,
+                              progress_bar=False)
 
         for key, value in data.items():
-            self.assertAlmostEqual(value, test_data[key])
+            self.assertAlmostEqual(value, test_data[key], places=2)
 
     def test_tft_fingerprint(self):
         axl.seed(0)  # Fingerprinting is a random process
-        test_data = {Point(x=0.0, y=0.0): 3.0,
-                     Point(x=0.0, y=0.25): 1.1,
-                     Point(x=0.0, y=0.5): 1.08,
-                     Point(x=0.0, y=0.75): 1.04,
-                     Point(x=0.0, y=1.0): 0.98,
-                     Point(x=0.25, y=0.0): 3.0,
-                     Point(x=0.25, y=0.25): 2.26,
-                     Point(x=0.25, y=0.5): 2.1,
-                     Point(x=0.25, y=0.75): 1.66,
-                     Point(x=0.25, y=1.0): 1.64,
-                     Point(x=0.5, y=0.0): 3.0,
-                     Point(x=0.5, y=0.25): 2.5,
-                     Point(x=0.5, y=0.5): 2.12,
-                     Point(x=0.5, y=0.75): 1.86,
-                     Point(x=0.5, y=1.0): 1.88,
-                     Point(x=0.75, y=0.0): 3.0,
-                     Point(x=0.75, y=0.25): 2.84,
-                     Point(x=0.75, y=0.5): 2.36,
-                     Point(x=0.75, y=0.75): 2.28,
-                     Point(x=0.75, y=1.0): 1.98,
+        test_data = {Point(x=0.25, y=1.0): 1.63,
+                     Point(x=0.25, y=0.5): 1.92,
+                     Point(x=0.75, y=0.5): 2.33,
+                     Point(x=0.25, y=0.25): 2.31,
+                     Point(x=0.0, y=0.75): 1.05,
+                     Point(x=0.75, y=1.0): 2.07,
+                     Point(x=0.5, y=0.25): 2.6,
+                     Point(x=0.0, y=0.0): 3.0,
+                     Point(x=0.75, y=0.25): 2.76,
+                     Point(x=1.0, y=0.75): 2.38,
+                     Point(x=1.0, y=0.5): 2.58,
                      Point(x=1.0, y=0.0): 3.0,
-                     Point(x=1.0, y=0.25): 2.78,
-                     Point(x=1.0, y=0.5): 2.56,
-                     Point(x=1.0, y=0.75): 2.44,
+                     Point(x=1.0, y=0.25): 2.72,
+                     Point(x=0.0, y=1.0): 0.98,
+                     Point(x=0.5, y=0.0): 3.0,
+                     Point(x=0.25, y=0.0): 3.0,
+                     Point(x=0.0, y=0.25): 1.82,
+                     Point(x=0.0, y=0.5): 1.13,
+                     Point(x=0.5, y=0.75): 1.93,
+                     Point(x=0.5, y=0.5): 2.46,
+                     Point(x=0.75, y=0.75): 2.3,
+                     Point(x=0.5, y=1.0): 1.91,
+                     Point(x=0.75, y=0.0): 3.0,
+                     Point(x=0.25, y=0.75): 1.62,
                      Point(x=1.0, y=1.0): 2.18}
+
+
         af = axl.AshlockFingerprint(axl.TitForTat, self.probe)
-        data = af.fingerprint(turns=50, repetitions=2, step=0.25)
+        data = af.fingerprint(turns=50, repetitions=2, step=0.25,
+                              progress_bar=False)
 
         for key, value in data.items():
-            self.assertAlmostEqual(value, test_data[key])
+            self.assertAlmostEqual(value, test_data[key], places=2)
 
     def test_majority_fingerprint(self):
         axl.seed(0)  # Fingerprinting is a random process
-        test_data = {Point(x=0.0, y=0.0): 3.0,
-                     Point(x=0.0, y=0.25): 1.18,
-                     Point(x=0.0, y=0.5): 1.98,
-                     Point(x=0.0, y=0.75): 1.04,
-                     Point(x=0.0, y=1.0): 0.98,
-                     Point(x=0.25, y=0.0): 3.0,
-                     Point(x=0.25, y=0.25): 2.16,
-                     Point(x=0.25, y=0.5): 1.74,
-                     Point(x=0.25, y=0.75): 1.96,
-                     Point(x=0.25, y=1.0): 2.24,
-                     Point(x=0.5, y=0.0): 3.0,
-                     Point(x=0.5, y=0.25): 2.46,
-                     Point(x=0.5, y=0.5): 2.44,
-                     Point(x=0.5, y=0.75): 2.24,
-                     Point(x=0.5, y=1.0): 2.74,
-                     Point(x=0.75, y=0.0): 3.0,
-                     Point(x=0.75, y=0.25): 2.52,
-                     Point(x=0.75, y=0.5): 2.16,
-                     Point(x=0.75, y=0.75): 2.1,
-                     Point(x=0.75, y=1.0): 2.44,
+        test_data = {Point(x=0.25, y=1.0): 2.179,
+                     Point(x=0.25, y=0.5): 1.9,
+                     Point(x=0.75, y=0.5): 1.81,
+                     Point(x=0.25, y=0.25): 2.31,
+                     Point(x=0.0, y=0.75): 1.03,
+                     Point(x=0.75, y=1.0): 2.58,
+                     Point(x=0.5, y=0.25): 2.34,
+                     Point(x=0.0, y=0.0): 3.0,
+                     Point(x=0.75, y=0.25): 2.4,
+                     Point(x=1.0, y=0.75): 2.0,
+                     Point(x=1.0, y=0.5): 1.74,
                      Point(x=1.0, y=0.0): 3.0,
-                     Point(x=1.0, y=0.25): 2.22,
-                     Point(x=1.0, y=0.5): 1.64,
-                     Point(x=1.0, y=0.75): 2.08,
+                     Point(x=1.0, y=0.25): 2.219,
+                     Point(x=0.0, y=1.0): 0.98,
+                     Point(x=0.5, y=0.0): 3.0,
+                     Point(x=0.25, y=0.0): 3.0,
+                     Point(x=0.0, y=0.25): 1.94,
+                     Point(x=0.0, y=0.5): 1.13,
+                     Point(x=0.5, y=0.75): 2.6,
+                     Point(x=0.5, y=0.5): 1.89,
+                     Point(x=0.75, y=0.75): 2.13,
+                     Point(x=0.5, y=1.0): 2.7,
+                     Point(x=0.75, y=0.0): 3.0,
+                     Point(x=0.25, y=0.75): 1.859,
                      Point(x=1.0, y=1.0): 2.26}
+
         af = axl.AshlockFingerprint(axl.GoByMajority, self.probe)
-        data = af.fingerprint(turns=50, repetitions=2, step=0.25)
+        data = af.fingerprint(turns=50, repetitions=2, step=0.25,
+                              progress_bar=False)
 
         for key, value in data.items():
-            self.assertAlmostEqual(value, test_data[key])
+            self.assertAlmostEqual(value, test_data[key], places=2)
 
     @given(strategy_pair=strategy_lists(min_size=2, max_size=2))
     def test_pair_fingerprints(self, strategy_pair):

--- a/axelrod/tests/unit/test_strategy_transformers.py
+++ b/axelrod/tests/unit/test_strategy_transformers.py
@@ -423,7 +423,7 @@ class TestTransformers(unittest.TestCase):
         self.assertFalse(MD.classifier["stochastic"])
 
         p1 = MD()
-        # Against a cooperator we see that we only cooperate
+        # Against a cooperator we see that we only defect
         p2 = axelrod.Cooperator()
         for _ in range(5):
             p1.play(p2)

--- a/axelrod/tests/unit/test_strategy_transformers.py
+++ b/axelrod/tests/unit/test_strategy_transformers.py
@@ -183,6 +183,22 @@ class TestTransformers(unittest.TestCase):
         self.assertTrue(p1.classifier["stochastic"])
         self.assertTrue(p1().classifier["stochastic"])
 
+        probability = (0, .5)
+        p1 = JossAnnTransformer(probability)(axelrod.TitForTat)
+        self.assertTrue(p1.classifier["stochastic"])
+        self.assertTrue(p1().classifier["stochastic"])
+
+        probability = (0, 0)
+        p1 = JossAnnTransformer(probability)(axelrod.TitForTat)
+        self.assertFalse(p1.classifier["stochastic"])
+        self.assertFalse(p1().classifier["stochastic"])
+
+        probability = (0, 0)
+        p1 = JossAnnTransformer(probability)(axelrod.Random)
+        self.assertTrue(p1.classifier["stochastic"])
+        self.assertTrue(p1().classifier["stochastic"])
+
+
     def test_noisy_transformer(self):
         """Tests that the noisy transformed does flip some moves."""
         random.seed(5)
@@ -251,6 +267,7 @@ class TestTransformers(unittest.TestCase):
         p1 = axelrod.Cooperator()
         p2 = FinalTransformer([D, D, D])(axelrod.Cooperator)()
         self.assertEqual(p2.classifier['makes_use_of'], set(["length"]))
+        self.assertEqual(axelrod.Cooperator.classifier['makes_use_of'], set([]))
 
         p2.match_attributes["length"] = 6
         for _ in range(6):

--- a/axelrod/tests/unit/test_strategy_transformers.py
+++ b/axelrod/tests/unit/test_strategy_transformers.py
@@ -250,7 +250,9 @@ class TestTransformers(unittest.TestCase):
     def test_initial_transformer(self):
         """Tests the InitialTransformer."""
         p1 = axelrod.Cooperator()
+        self.assertEqual(p1.classifier["memory_depth"], 0)
         p2 = InitialTransformer([D, D])(axelrod.Cooperator)()
+        self.assertEqual(p2.classifier["memory_depth"], 2)
         for _ in range(5):
             p1.play(p2)
         self.assertEqual(p2.history, [D, D, C, C, C])
@@ -261,18 +263,25 @@ class TestTransformers(unittest.TestCase):
             p1.play(p2)
         self.assertEqual(p2.history, [D, D, C, D, C])
 
+        p3 = InitialTransformer([D, D])(axelrod.Grudger)()
+        self.assertEqual(p3.classifier["memory_depth"], float('inf'))
+
     def test_final_transformer(self):
         """Tests the FinalTransformer when tournament length is known."""
         # Final play transformer
         p1 = axelrod.Cooperator()
         p2 = FinalTransformer([D, D, D])(axelrod.Cooperator)()
         self.assertEqual(p2.classifier['makes_use_of'], set(["length"]))
+        self.assertEqual(p2.classifier['memory_depth'], 3)
         self.assertEqual(axelrod.Cooperator.classifier['makes_use_of'], set([]))
 
         p2.match_attributes["length"] = 6
-        for _ in range(6):
+        for _ in range(8):
             p1.play(p2)
-        self.assertEqual(p2.history, [C, C, C, D, D, D])
+        self.assertEqual(p2.history, [C, C, C, D, D, D, C, C])
+
+        p3 = FinalTransformer([D, D])(axelrod.Grudger)()
+        self.assertEqual(p3.classifier["memory_depth"], float('inf'))
 
     def test_final_transformer2(self):
         """Tests the FinalTransformer when tournament length is not known."""

--- a/axelrod/tests/unit/test_strategy_transformers.py
+++ b/axelrod/tests/unit/test_strategy_transformers.py
@@ -383,7 +383,7 @@ class TestTransformers(unittest.TestCase):
         """Tests the MixedTransformer."""
         probability = 1
         MD = MixedTransformer(probability, axelrod.Cooperator)(axelrod.Defector)
-        self.assertTrue(MD.classifier["stochastic"])
+        self.assertFalse(MD.classifier["stochastic"])
 
         p1 = MD()
         p2 = axelrod.Cooperator()
@@ -393,6 +393,7 @@ class TestTransformers(unittest.TestCase):
 
         probability = 0
         MD = MixedTransformer(probability, axelrod.Cooperator)(axelrod.Defector)
+        self.assertFalse(MD.classifier["stochastic"])
 
         p1 = MD()
         p2 = axelrod.Cooperator()
@@ -406,6 +407,7 @@ class TestTransformers(unittest.TestCase):
         probability = [.3, .2, 0]
         strategies = [axelrod.TitForTat, axelrod.Grudger, axelrod.Defector]
         MD = MixedTransformer(probability, strategies)(axelrod.Cooperator)
+        self.assertTrue(MD.classifier["stochastic"])
 
         p1 = MD()
         # Against a cooperator we see that we only cooperate
@@ -418,6 +420,7 @@ class TestTransformers(unittest.TestCase):
         probability = (0, 0, 1)  # Note can also pass tuple
         strategies = [axelrod.TitForTat, axelrod.Grudger, axelrod.Defector]
         MD = MixedTransformer(probability, strategies)(axelrod.Cooperator)
+        self.assertFalse(MD.classifier["stochastic"])
 
         p1 = MD()
         # Against a cooperator we see that we only cooperate


### PR DESCRIPTION
Our transformers were not reclassifying the strategies (mostly we weren't trying but in one case we were but it was not tested and not working). See #971 

This implements the ability to pass a `reclassifier` function to the strategy transformer factory so that we can reclassify based on input parameters (for example if using the Noisy transformer but passing noise of `0` or `1` then the classifier does not change). 

I've also written such reclassifiers for all relevant transformers EDIT: ~~although technically the Mixed strategy transformer isn't as smart as it could be but I suggest this gets merged under the bug fix rule and an issue gets opened for that transformer. (I've set it to blankly say that it make strategies stochastic which is what we want for any sensible use case).~~ I've done that one too now.

Closes #971