### PR TITLE
Implement an eq method for players

### DIFF
--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -149,10 +149,17 @@ class Player(object):
                 generator, original_value = itertools.tee(value)
                 other_generator, original_other_value = itertools.tee(other_value)
 
-                setattr(self, attribute,
-                        (ele for ele in original_value))
-                setattr(other, attribute,
-                        (ele for ele in original_other_value))
+
+                if isinstance(value, types.GeneratorType):
+                    setattr(self, attribute,
+                            (ele for ele in original_value))
+                    setattr(other, attribute,
+                            (ele for ele in original_other_value))
+                else:
+                    setattr(self, attribute,
+                            itertools.cycle(original_value))
+                    setattr(other, attribute,
+                            itertools.cycle(original_other_value))
 
                 if not (all(next(generator) == next(other_generator)
                         for _ in range(200))):

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -164,6 +164,12 @@ class Player(object):
                 if not (all(next(generator) == next(other_generator)
                         for _ in range(200))):
                     return False
+
+            # Code for a strange edge case where each strategy points at each
+            # other
+            elif (value is other and other_value is self):
+                    pass
+
             else:
                 if value != other_value:
                     return False

--- a/axelrod/strategies/qlearner.py
+++ b/axelrod/strategies/qlearner.py
@@ -48,8 +48,8 @@ class RiskyQLearner(Player):
         # for any subclasses that do not override methods using random calls.
         self.classifier['stochastic'] = True
 
-        self.prev_action = None
-        self.original_prev_action = None
+        self.prev_action = None # type: Action
+        self.original_prev_action = None # type: Action
         self.history = [] # type: List[Action]
         self.score = 0
         self.Qs = OrderedDict({'':  OrderedDict(zip([C, D], [0, 0]))})

--- a/axelrod/strategies/qlearner.py
+++ b/axelrod/strategies/qlearner.py
@@ -48,8 +48,8 @@ class RiskyQLearner(Player):
         # for any subclasses that do not override methods using random calls.
         self.classifier['stochastic'] = True
 
-        self.prev_action = random_choice()
-        self.original_prev_action = self.prev_action
+        self.prev_action = None
+        self.original_prev_action = None
         self.history = [] # type: List[Action]
         self.score = 0
         self.Qs = OrderedDict({'':  OrderedDict(zip([C, D], [0, 0]))})
@@ -62,6 +62,9 @@ class RiskyQLearner(Player):
 
     def strategy(self, opponent: Player) -> Action:
         """Runs a qlearn algorithm while the tournament is running."""
+        if len(self.history) == 0:
+            self.prev_action = random_choice()
+            self.original_prev_action = self.prev_action
         state = self.find_state(opponent)
         reward = self.find_reward(opponent)
         if state not in self.Qs:
@@ -118,7 +121,8 @@ class RiskyQLearner(Player):
         self.Qs = {'': {C: 0, D: 0}}
         self.Vs = {'': 0}
         self.prev_state = ''
-        self.prev_action = self.original_prev_action
+        self.prev_action = None
+        self.original_prev_action = None
 
 
 class ArrogantQLearner(RiskyQLearner):

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -425,7 +425,11 @@ class ContriteTitForTat(Player):
         'manipulates_source': False,
         'manipulates_state': False
     }
-    contrite = False
+
+    def __init__(self):
+        super().__init__()
+        self.contrite = False
+        self._recorded_history = []
 
     def strategy(self, opponent: Player) -> Action:
 

--- a/axelrod/tests/strategies/test_calculator.py
+++ b/axelrod/tests/strategies/test_calculator.py
@@ -81,11 +81,6 @@ class TestCalculator(TestPlayer):
             axelrod.MockPlayer(actions=opponent_actions),
             expected_actions=uses_tit_for_tat_after_twenty_rounds, seed=seed)
 
-    def attribute_equality_test(self, player, clone):
-        """Overwrite the default test to check Joss instance"""
-        self.assertIsInstance(player.joss_instance, axelrod.Joss)
-        self.assertIsInstance(clone.joss_instance, axelrod.Joss)
-
     def test_get_joss_strategy_actions(self):
         opponent = [C, D, D, C, C]
 

--- a/axelrod/tests/strategies/test_memorytwo.py
+++ b/axelrod/tests/strategies/test_memorytwo.py
@@ -41,16 +41,3 @@ class TestMEM2(TestPlayer):
         # ALLD forever if all D twice
         self.responses_test([D] * 10, [C, D, D, D, D, D], [D, D, D, D, D, D])
         self.responses_test([D] * 9, [C] + [D] * 5 + [C] * 4, [D] * 6 + [C] * 4)
-
-    def attribute_equality_test(self, player, clone):
-        """Overwrite specific test to be able to test self.players"""
-        for p in [player, clone]:
-            self.assertEqual(p.play_as, "TFT")
-            self.assertEqual(p.shift_counter, 3)
-            self.assertEqual(p.alld_counter, 0)
-
-        for key, value in [("TFT", axelrod.TitForTat),
-                           ("TFTT", axelrod.TitFor2Tats),
-                           ("ALLD", axelrod.Defector)]:
-            self.assertEqual(p.players[key].history, [])
-            self.assertIsInstance(p.players[key], value)

--- a/axelrod/tests/strategies/test_meta.py
+++ b/axelrod/tests/strategies/test_meta.py
@@ -46,16 +46,6 @@ class TestMetaPlayer(TestPlayer):
                              msg="%s - Behaviour: %s != Expected Behaviour: %s" %
                                  (key, player.classifier[key], classifier[key]))
 
-    def attribute_equality_test(self, player, clone):
-        """Overwriting this specific method to check team."""
-        for p1, p2 in zip(player.team, clone.team):
-            self.assertEqual(len(p1.history), 0)
-            self.assertEqual(len(p2.history), 0)
-
-        team_player_names = [p.__repr__() for p in player.team]
-        team_clone_names = [p.__repr__() for p in clone.team]
-        self.assertEqual(team_player_names, team_clone_names)
-
     def test_repr(self):
         player = self.player()
         team_size = len(player.team)

--- a/axelrod/tests/strategies/test_player.py
+++ b/axelrod/tests/strategies/test_player.py
@@ -207,6 +207,9 @@ class TestPlayerClass(unittest.TestCase):
         self.assertEqual(list(p1.generator), list(range(10)))
         self.assertEqual(list(p2.generator), list(range(1, 10)))
 
+        # Check that type is generator
+        self.assertIsInstance(p2.generator, types.GeneratorType)
+
     def test_equality_for_cycle(self):
         """Test equality works with cycle attribute and that the cycle attribute
         is not altered during checking of equality"""
@@ -231,11 +234,15 @@ class TestPlayerClass(unittest.TestCase):
         self.assertEqual(next(p1.cycle), 0)
         self.assertEqual(next(p2.cycle), 1)
 
+        # Check that type is cycle
+        self.assertIsInstance(p2.cycle, itertools.cycle)
+
     def test_equaity_on_init(self):
         """Test all instances of a strategy are equal on init"""
         for s in axelrod.strategies:
             p1, p2 = s(), s()
-            # Check twice (so testing equality doesn't change anything)
+            # Check three times (so testing equality doesn't change anything)
+            self.assertEqual(p1, p2)
             self.assertEqual(p1, p2)
             self.assertEqual(p1, p2)
 

--- a/axelrod/tests/strategies/test_player.py
+++ b/axelrod/tests/strategies/test_player.py
@@ -187,7 +187,7 @@ class TestPlayerClass(unittest.TestCase):
         self.assertEqual(p1, p2)
 
     def test_equality_for_numpy_array(self):
-        # Check numpy array attribute (a special case)
+        """Check numpy array attribute (a special case)"""
         p1 = axelrod.Cooperator()
         p2 = axelrod.Cooperator()
 
@@ -251,8 +251,8 @@ class TestPlayerClass(unittest.TestCase):
         # Check that type is cycle
         self.assertIsInstance(p2.cycle, itertools.cycle)
 
-    def test_equaity_on_init(self):
-        """Test all instances of a strategy are equal on init"""
+    def test_equality_on_init(self):
+        """Test instances of all strategies are equal on init"""
         for s in axelrod.strategies:
             p1, p2 = s(), s()
             # Check three times (so testing equality doesn't change anything)
@@ -260,7 +260,7 @@ class TestPlayerClass(unittest.TestCase):
             self.assertEqual(p1, p2)
             self.assertEqual(p1, p2)
 
-    def test_equaity_on_with_player_attributes(self):
+    def test_equality_with_player_as_attributes(self):
         """Test for a strange edge case where players have pointers to each
         other"""
         p1 = axelrod.Cooperator()

--- a/axelrod/tests/strategies/test_player.py
+++ b/axelrod/tests/strategies/test_player.py
@@ -172,6 +172,20 @@ class TestPlayerClass(unittest.TestCase):
         p2.test = "29"
         self.assertNotEqual(p1, p2)
 
+        p1.test = "29"
+        self.assertEqual(p1, p2)
+
+        # Check that attributes of both players are tested.
+        p1.another_attribute = [1, 2, 3]
+        self.assertNotEqual(p1, p2)
+        p2.another_attribute = [1, 2, 3]
+        self.assertEqual(p1, p2)
+
+        p2.another_attribute_2 = {1: 2}
+        self.assertNotEqual(p1, p2)
+        p1.another_attribute_2 = {1: 2}
+        self.assertEqual(p1, p2)
+
     def test_equality_for_numpy_array(self):
         # Check numpy array attribute (a special case)
         p1 = axelrod.Cooperator()
@@ -245,6 +259,40 @@ class TestPlayerClass(unittest.TestCase):
             self.assertEqual(p1, p2)
             self.assertEqual(p1, p2)
             self.assertEqual(p1, p2)
+
+    def test_equaity_on_with_player_attributes(self):
+        """Test for a strange edge case where players have pointers to each
+        other"""
+        p1 = axelrod.Cooperator()
+        p2 = axelrod.Cooperator()
+
+        # If pointing at each other
+        p1.player = p2
+        p2.player = p1
+        self.assertEqual(p1, p2)
+
+        # Still checking other attributes.
+        p1.test_attribute = "29"
+        self.assertNotEqual(p1, p2)
+
+        # If pointing at same strategy instances
+        p1.player = axelrod.Cooperator()
+        p2.player = axelrod.Cooperator()
+        p2.test_attribute = "29"
+        self.assertEqual(p1, p2)
+
+
+        # If pointing at different strategy instances
+        p1.player = axelrod.Cooperator()
+        p2.player = axelrod.Defector()
+        self.assertNotEqual(p1, p2)
+
+        # If different strategies pointing at same strategy instances
+        p3 = axelrod.Defector()
+        p1.player = axelrod.Cooperator()
+        p3.player = axelrod.Cooperator()
+        self.assertNotEqual(p1, p3)
+
 
     def test_init_params(self):
         """Tests player correct parameters signature detection."""

--- a/axelrod/tests/strategies/test_player.py
+++ b/axelrod/tests/strategies/test_player.py
@@ -185,34 +185,49 @@ class TestPlayerClass(unittest.TestCase):
         self.assertNotEqual(p1, p2)
 
     def test_equality_for_generator(self):
-        # Check generator attribute (a special case)
+        """Test equality works with generator attribute and that the generator
+        attribute is not altered during checking of equality"""
         p1 = axelrod.Cooperator()
         p2 = axelrod.Cooperator()
-        # Check that the generator is still the same
+
+        # Check that players are equal with generator
         p1.generator = (i for i in range(10))
         p2.generator = (i for i in range(10))
         self.assertEqual(p1, p2)
 
-        _ = next(p2.generator)
+        # Check state of one generator (ensure it hasn't changed)
+        n = next(p2.generator)
+        self.assertEqual(n, 0)
+
+        # Players are no longer equal (one generator has changed)
         self.assertNotEqual(p1, p2)
 
-        # Check that internal generator object has not been changed
+        # Check that internal generator object has not been changed for either
+        # player after latest equal check.
         self.assertEqual(list(p1.generator), list(range(10)))
         self.assertEqual(list(p2.generator), list(range(1, 10)))
 
     def test_equality_for_cycle(self):
+        """Test equality works with cycle attribute and that the cycle attribute
+        is not altered during checking of equality"""
         # Check cycle attribute (a special case)
         p1 = axelrod.Cooperator()
         p2 = axelrod.Cooperator()
-        # Check that the cycle is still the same
+
+        # Check that players are equal with cycle
         p1.cycle = itertools.cycle(range(10))
         p2.cycle = itertools.cycle(range(10))
         self.assertEqual(p1, p2)
 
-        _ = next(p2.cycle)
+        # Check state of one generator (ensure it hasn't changed)
+        n = next(p2.cycle)
+        self.assertEqual(n, 0)
+
+        # Players are no longer equal (one generator has changed)
         self.assertNotEqual(p1, p2)
 
-        # Check that internal generator object has not been changed
+        # Check that internal cycle object has not been changed for either
+        # player after latest not equal check.
         self.assertEqual(next(p1.cycle), 0)
         self.assertEqual(next(p2.cycle), 1)
 

--- a/axelrod/tests/strategies/test_player.py
+++ b/axelrod/tests/strategies/test_player.py
@@ -158,7 +158,7 @@ class TestPlayerClass(unittest.TestCase):
         p1 = axelrod.Cooperator()
         p2 = axelrod.Cooperator()
         self.assertEqual(p1, p2)
-        p1.__repr__ = lambda :"John Nash"
+        p1.__repr__ = lambda: "John Nash"
         self.assertNotEqual(p1, p2)
 
         # Check attributes

--- a/axelrod/tests/strategies/test_qlearner.py
+++ b/axelrod/tests/strategies/test_qlearner.py
@@ -70,18 +70,6 @@ class TestRiskyQLearner(TestPlayer):
         p2 = axelrod.Cooperator()
         test_responses(self, p1, p2, [C, D, C, C, D, C, C])
 
-    def test_reset_method(self):
-        """Test the reset method."""
-        P1 = axelrod.RiskyQLearner()
-        P1.Qs = {'': {C: 0, D: -0.9}, '0.0': {C: 0, D: 0}}
-        P1.Vs = {'': 0, '0.0': 0}
-        P1.history = [C, D, D, D]
-        P1.prev_state = C
-        P1.reset()
-        self.assertEqual(P1.prev_state, '')
-        self.assertEqual(P1.Vs, {'': 0})
-        self.assertEqual(P1.Qs, {'': {C: 0, D: 0}})
-
 
 class TestArrogantQLearner(TestPlayer):
 

--- a/axelrod/tests/strategies/test_titfortat.py
+++ b/axelrod/tests/strategies/test_titfortat.py
@@ -407,6 +407,11 @@ class TestContriteTitForTat(TestPlayer):
     deterministic_strategies = [s for s in axelrod.strategies
                                 if not s().classifier['stochastic']]
 
+    def test_init(self):
+        ctft = self.player()
+        self.assertFalse(ctft.contrite, False)
+        self.assertEqual(ctft._recorded_history, [])
+
     @given(strategies=strategy_lists(strategies=deterministic_strategies,
                                      max_size=1),
            turns=integers(min_value=1, max_value=20))
@@ -452,13 +457,6 @@ class TestContriteTitForTat(TestPlayer):
         self.assertEqual(ctft._recorded_history, [C, C, C, D])
         self.assertEqual(opponent.history, [C, D, D, D])
         self.assertFalse(ctft.contrite)
-
-    def test_reset_history_and_attributes(self):
-        """Overwrite reset test because of decorator"""
-        p = self.player()
-        p.contrite = True
-        p.reset()
-        self.assertFalse(p.contrite)
 
 
 class TestSlowTitForTwoTats(TestPlayer):

--- a/axelrod/tests/unit/test_match_generator.py
+++ b/axelrod/tests/unit/test_match_generator.py
@@ -28,14 +28,12 @@ class TestTournamentType(unittest.TestCase):
     def test_init_with_clone(self):
         tt = axelrod.MatchGenerator(
             self.players, test_turns, test_game, test_repetitions)
-        self.assertEqual(tt.players, self.players)
         self.assertEqual(tt.turns, test_turns)
         player = tt.players[0]
         opponent = tt.opponents[0]
-        self.assertEqual(player.name, opponent.name)
-        self.assertNotEqual(player, opponent)
+        self.assertEqual(player, opponent)
         # Check that the two player instances are wholly independent
-        opponent.name = 'Test'
+        opponent.name = 'John Nash'
         self.assertNotEqual(player.name, opponent.name)
 
     def test_len(self):

--- a/docs/tutorials/advanced/index.rst
+++ b/docs/tutorials/advanced/index.rst
@@ -16,3 +16,4 @@ Contents:
    parallel_processing.rst
    using_the_cache.rst
    setting_a_seed.rst
+   player_equality.rst

--- a/docs/tutorials/advanced/player_equality.rst
+++ b/docs/tutorials/advanced/player_equality.rst
@@ -1,0 +1,27 @@
+Player equality
+===============
+
+It is possible to test for player equality using :code:`==`::
+
+    >>> import axelrod as axl
+    >>> p1, p2, p3 = axl.Alternator(), axl.Alternator(), axl.TitForTat()
+    >>> p1 == p2
+    True
+    >>> p1 == p3
+    False
+
+Note that this checks all the attributes of an instance::
+
+    >>> p1.name = "John Nash"
+    >>> p1 == p2
+    False
+
+This however does not check if the players will behave in the same way. For
+example here are two equivalent players::
+
+    >>> p1 = axl.Alternator()
+    >>> p2 = axl.Cycler((axl.Actions.C, axl.Actions.D))
+    >>> p1 == p2
+    False
+
+To check if player strategies are equivalent you can use :ref:`fingerprinting`.


### PR DESCRIPTION
- Add equality method and tests to player.
- Add documentation for player equality.
- Refactored some other tests to make use of this method
- Refactor a match generator test which was failing as a result of the
eq method. Previously this was testing equality of instance.

Some other minor changes I've made as a result of this:

- Change when qlearner makes random choice. I've also removed the reset
  test. This is now being tested by the parent test class for all
  strategies.
- Fix small bug in contrite. Without this, contrite was not resetting
  correctly (the recorded history was being maintained in the class
  attribute).

This closes #885 but also closes #940 which was worked on a while ago
but which has not seen any progress.