### PR TITLE
Add double resurrection to strategies list.

### DIFF
--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -120,6 +120,7 @@ all_strategies = [
     Desperate,
     DoubleCrosser,
     Doubler,
+    DoubleResurrection,
     EasyGo,
     Eatherley,
     EventualCycleHunter,


### PR DESCRIPTION
We missed this on #876. (Arguably this is a bug)