### PR TITLE
pulled out statice methods and type hinting #974

### DIFF
--- a/axelrod/fingerprint.py
+++ b/axelrod/fingerprint.py
@@ -40,10 +40,11 @@ class AshlockFingerprint(object):
         Parameters
         ----------
         strategy : class or instance
-            Player instance or Player class to be fingerprinted.
+            A class that must be descended from axelrod.Player or an instance of
+            axelrod.Player.
         probe : class or instance
-            Player instance or Player class that is the "canvas" for
-            the fingerprint.
+            A class that must be descended from axelrod.Player or an instance of
+            axelrod.Player.
             Default: Tit For Tat
         """
         self.strategy = strategy
@@ -59,17 +60,8 @@ class AshlockFingerprint(object):
         processes: int = None, filename: str = None, in_memory: bool = False,
         progress_bar: bool = True
     ) -> PointsToFloats:
-        """Creates the data that is the fingerprint of self.strategy.
+        """Build and play the spatial tournament.
 
-        The data is created by running matches of turns (turns) a (repetition)
-        number of times for probes corresponding to each point of a square.
-
-        The square is made of points from Point(0.0, 0.0) to Point(1.0, 1.0)
-        and goes in increments of size:(step) rounded up nearest fraction with
-        numerator=1.  step=0.48 becomes x,y values in [0.0, 1/2, 1.0],
-        step=0.3 values round up to [0.0, 1/3, 2/3, 1.0].
-
-        ??CAN THE TWO PARAGRAPHS ABOVE REPLACE THE PARAGRAPH BELOW??
         Creates the probes and their edges then builds a spatial tournament.
         When the coordinates of the probe sum to more than 1, the dual of the
         probe is taken instead and then the Joss-Ann Transformer is applied. If
@@ -84,7 +76,6 @@ class AshlockFingerprint(object):
             The number of times the each match is repeated
         step : float, optional
             0.0 <= step <= 1.0
-            IF NEW DESCRIPTION IS GOOD, CAN REMOVE THESE TWO LINES.
             The separation between each Point. Smaller steps will
             produce more Points that will be closer together.
         processes : integer, optional
@@ -158,7 +149,7 @@ class AshlockFingerprint(object):
         figure : matplotlib figure
             A heat plot of the results of the spatial tournament
         """
-        size = int((1 / self.step) // 1) + 1
+        size = int(1 / self.step) + 1
         plotting_data = reshape_data(self.data, self.points, size)
         fig, ax = plt.subplots()
         cax = ax.imshow(
@@ -244,7 +235,7 @@ def create_points(step: float, progress_bar: bool = True) -> PointList:
     points : list
         of Point objects with coordinates (x, y)
     """
-    num = int((1 / step) // 1) + 1
+    num = int(1 / step) + 1
 
     p_bar = None
     if progress_bar:
@@ -265,7 +256,10 @@ def create_points(step: float, progress_bar: bool = True) -> PointList:
 
 
 def create_edges(points: PointList, progress_bar: bool = True) -> EdgeList:
-    """Each Point corresponds to a probe Player. Returns
+    """Creates a set of edges for a spatial tournament.
+
+    Constructs edges that correspond to `points`. All edges begin at 0, and
+    connect to the index +1 of the probe.
 
     Parameters
     ----------

--- a/axelrod/fingerprint.py
+++ b/axelrod/fingerprint.py
@@ -1,3 +1,23 @@
+"""
+changelog:
+
+added/changed docstring
+
+- AshlockFingerprint - added summary
+- fingerprint - step added one line
+- fingerprint - added missing params
+- construct_tournament_elements - step added one sentence
+- create_jossann - probe param now class or instance not class
+
+code:
+
+create_points - `num = int((1 / step) // 1) + 1` to `num = int(1 / step) + 1`
+plot - `size = int((1 / self.step)) // 1 + 1` to `size = int(1 / self.step) + 1`
+__init__ - explicitly created all the class values and assigned to None.
+
+"""
+
+
 from collections import namedtuple
 from tempfile import NamedTemporaryFile
 from typing import Tuple, List, Dict, Union, Any
@@ -24,10 +44,7 @@ PointList = List[Point]
 PlayerList = List[Player]
 
 EdgesToMatches = Dict[Edge, Matches]
-PointsToPlayers = Dict[Point, Player]
 PointsToFloats = Dict[Point, float]
-PointsToEdges = Dict[Point, Edge]
-PointsToMatches = Dict[Point, Matches]
 
 
 class AshlockFingerprint(object):
@@ -75,7 +92,7 @@ class AshlockFingerprint(object):
         repetitions : integer, optional
             The number of times the each match is repeated
         step : float, optional
-            0.0 <= step <= 1.0
+            0.0 < step <= 1.0
             The separation between each Point. Smaller steps will
             produce more Points that will be closer together.
         processes : integer, optional
@@ -182,8 +199,9 @@ class AshlockFingerprint(object):
         Parameters
         ----------
         step : float
+            0.0 < step <= 1.0.
             The separation between each Point. Smaller steps will
-            produce more Points that will be closer together. 0.0 <= step <= 1.0
+            produce more Points that will be closer together.
         progress_bar : bool
             Whether or not to show a progress bar while building the player
             list.
@@ -320,8 +338,8 @@ def create_jossann(point: Point, probe: Any) -> Player:
     Parameters
     ----------
     point : Point
-    probe : class
-        A class that must be descended from axelrod.strategies
+    probe : class or Player
+        A class or instance that must be descended from axelrod.strategies
 
     Returns
     ----------

--- a/axelrod/fingerprint.py
+++ b/axelrod/fingerprint.py
@@ -90,7 +90,7 @@ class AshlockFingerprint(object):
         turns : integer, optional
             The number of turns per match
         repetitions : integer, optional
-            The number of times the each match is repeated
+            The number of times the round robin should be repeated
         step : float, optional
             0.0 < step <= 1.0
             The separation between each Point. Smaller steps will
@@ -103,13 +103,13 @@ class AshlockFingerprint(object):
             True=tournament.interactions_dict is stored only in memory
             False=tournament.interactions_dict is stored only on file
         progress_bar : bool
-            Whether or not to show progress bars during steps of data creation.
+            Whether or not to create a progress bar which will be updated
 
         Returns
         ----------
         self.data : dictionary(Point, float)
-            The mean score for all matches against the probe corresponding to
-            each Point
+            A dictionary where the keys are coordinates of the form (x, y) and
+            the values are the mean score for the corresponding interactions.
         """
 
         if on_windows and (filename is None):  # pragma: no cover

--- a/axelrod/fingerprint.py
+++ b/axelrod/fingerprint.py
@@ -26,7 +26,7 @@ import numpy as np
 import tqdm
 import axelrod as axl
 
-from axelrod import on_windows, Player, SpatialTournament
+from axelrod import Player, SpatialTournament
 from axelrod.actions import Action
 from axelrod.strategy_transformers import JossAnnTransformer, DualTransformer
 from axelrod.interaction_utils import (
@@ -112,7 +112,7 @@ class AshlockFingerprint(object):
             the values are the mean score for the corresponding interactions.
         """
 
-        if on_windows and (filename is None):  # pragma: no cover
+        if axl.on_windows and (filename is None):  # pragma: no cover
             in_memory = True
         elif filename is None:
             output_file = NamedTemporaryFile(mode='w')

--- a/axelrod/tests/unit/test_fingerprint.py
+++ b/axelrod/tests/unit/test_fingerprint.py
@@ -417,21 +417,21 @@ class TestFingerprint(unittest.TestCase):
         """
         strategy, probe = strategy_pair
         af = AshlockFingerprint(strategy, probe)
-        data = af.fingerprint(turns=2, repetitions=2, step=1.0,
+        data = af.fingerprint(turns=2, repetitions=2, step=0.5,
                               progress_bar=False)
         self.assertIsInstance(data, dict)
 
         af = AshlockFingerprint(strategy(), probe)
-        data = af.fingerprint(turns=2, repetitions=2, step=1.0,
+        data = af.fingerprint(turns=2, repetitions=2, step=0.5,
                               progress_bar=False)
         self.assertIsInstance(data, dict)
 
         af = AshlockFingerprint(strategy, probe())
-        data = af.fingerprint(turns=2, repetitions=2, step=1.0,
+        data = af.fingerprint(turns=2, repetitions=2, step=0.5,
                               progress_bar=False)
         self.assertIsInstance(data, dict)
 
         af = AshlockFingerprint(strategy(), probe())
-        data = af.fingerprint(turns=2, repetitions=2, step=1.0,
+        data = af.fingerprint(turns=2, repetitions=2, step=0.5,
                               progress_bar=False)
         self.assertIsInstance(data, dict)

--- a/axelrod/tests/unit/test_fingerprint.py
+++ b/axelrod/tests/unit/test_fingerprint.py
@@ -4,12 +4,144 @@ from axelrod.fingerprint import *
 from axelrod.tests.property import strategy_lists
 import axelrod as axl
 
+C, D = axl.Actions.C, axl.Actions.D
+
 
 matplotlib_installed = True
 try:
     import matplotlib.pyplot
 except ImportError:  # pragma: no cover
     matplotlib_installed = False
+
+
+class TestFingerPrintHelpers(unittest.TestCase):
+
+    def test_create_points_progress_bar_true(self):
+        expected = [Point(0.0, 0.0), Point(0.0, 1.0),
+                    Point(1.0, 0.0), Point(1.0, 1.0)]
+        self.assertEqual(expected, create_points(1.0, progress_bar=True))
+
+    def test_create_points_rounds_up_to_fraction_with_numerator_eq_one(self):
+        step_one = [Point(0.0, 0.0), Point(0.0, 1.0),
+                    Point(1.0, 0.0), Point(1.0, 1.0)]
+        step_half = [Point(0.0, 0.0), Point(0.0, 0.5), Point(0.0, 1.0),
+                     Point(0.5, 0.0), Point(0.5, 0.5), Point(0.5, 1.0),
+                     Point(1.0, 0.0), Point(1.0, 0.5), Point(1.0, 1.0)]
+        self.assertEqual(step_one, create_points(0.51, progress_bar=False))
+        self.assertEqual(step_half, create_points(0.5, progress_bar=False))
+
+    def test_create_point_with_fraction_that_is_not_finite_decimal(self):
+        points = create_points(0.3, progress_bar=False)
+        self.assertEqual(points[7][1], 1.0)
+        self.assertAlmostEqual(points[7][0], 0.33333333, places=7)
+
+    def test_create_edges(self):
+        points = [(0.0, 0.0), (0.0, 0.5), (0.0, 1.0),
+                  (0.5, 0.0), (0.5, 0.5), (0.5, 1.0),
+                  (1.0, 0.0), (1.0, 0.5), (1.0, 1.0)]
+        expected_edges = [(0, 1), (0, 2), (0, 3),
+                          (0, 4), (0, 5), (0, 6),
+                          (0, 7), (0, 8), (0, 9)]
+        edges = create_edges(points, progress_bar=False)
+        self.assertEqual(edges, expected_edges)
+
+    def test_create_jossann(self):
+        probe = axl.TitForTat
+        # x + y < 1
+        ja = create_jossann((.5, .4), probe)
+        self.assertEqual(str(ja), "Joss-Ann Tit For Tat: (0.5, 0.4)")
+
+        # x + y = 1
+        ja = create_jossann((.4, .6), probe)
+        self.assertEqual(str(ja), "Dual Joss-Ann Tit For Tat: (0.6, 0.4)")
+
+        # x + y > 1
+        ja = create_jossann((.5, .6), probe)
+        self.assertEqual(str(ja), "Dual Joss-Ann Tit For Tat: (0.5, 0.4)")
+
+    def test_create_jossann_parametrised_player(self):
+        probe = axl.Random(p=0.1)
+
+        # x + y < 1
+        ja = create_jossann((.5, .4), probe)
+        self.assertEqual(str(ja), "Joss-Ann Random: 0.1: (0.5, 0.4)")
+
+        # x + y = 1
+        ja = create_jossann((.4, .6), probe)
+        self.assertEqual(str(ja), "Dual Joss-Ann Random: 0.1: (0.6, 0.4)")
+
+        # x + y > 1
+        ja = create_jossann((.5, .6), probe)
+        self.assertEqual(str(ja), "Dual Joss-Ann Random: 0.1: (0.5, 0.4)")
+
+    def test_create_probes_progress_bar_true(self):
+        nine_points = create_points(0.5, progress_bar=False)
+        probes = create_probes(axl.TitForTat, nine_points, progress_bar=True)
+        self.assertEqual(len(probes), 9)
+
+    def test_create_probes(self):
+        expected_probe_str = ['Joss-Ann Tit For Tat: (0.0, 0.0)',
+                              'Dual Joss-Ann Tit For Tat: (1.0, 0.0)',
+                              'Dual Joss-Ann Tit For Tat: (0.0, 1.0)',
+                              'Dual Joss-Ann Tit For Tat: (0.0, 0.0)']
+        points = create_points(1.0, progress_bar=False)
+        probes = create_probes(axl.TitForTat, points, progress_bar=False)
+        self.assertEqual([str(probe) for probe in probes], expected_probe_str)
+
+    def test_generate_data(self):
+        interactions = {
+            (0, 1): [[(C, C)], [(C, C)]],
+            (0, 2): [[(C, C), (C, C)], [(C, D)]],
+            (0, 3): [[(C, C), (D, C)]],
+            (0, 4): [[(C, C), (D, D)]],
+            (0, 5): [[(C, D), (D, C)]],
+            (0, 6): [[(C, D), (C, D)]],
+            (0, 7): [[(C, D), (D, D)]],
+            (0, 8): [[(D, D), (D, D)]],
+            (0, 9): [[(D, C), (D, C)]],
+        }
+
+        expected = {
+            Point(0.0, 0.0): 3.0,
+            Point(0.0, 0.5): 1.5,
+            Point(0.0, 1.0): 4.0,
+            Point(0.5, 0.0): 2.0,
+            Point(0.5, 0.5): 2.5,
+            Point(0.5, 1.0): 0.0,
+            Point(1.0, 0.0): 0.5,
+            Point(1.0, 0.5): 1.0,
+            Point(1.0, 1.0): 5.0,
+        }
+        points = create_points(0.5, progress_bar=False)
+        edges = create_edges(points, progress_bar=False)
+        data = generate_data(interactions, points, edges)
+        self.assertEqual(data, expected)
+
+    def test_reshape_data(self):
+        test_points = [Point(x=0.0, y=0.0),
+                       Point(x=0.0, y=0.5),
+                       Point(x=0.0, y=1.0),
+                       Point(x=0.5, y=0.0),
+                       Point(x=0.5, y=0.5),
+                       Point(x=0.5, y=1.0),
+                       Point(x=1.0, y=0.0),
+                       Point(x=1.0, y=0.5),
+                       Point(x=1.0, y=1.0)]
+        test_data = {Point(x=0.0, y=0.0): 5,
+                     Point(x=0.0, y=0.5): 9,
+                     Point(x=0.0, y=1.0): 3,
+                     Point(x=0.5, y=0.0): 8,
+                     Point(x=0.5, y=0.5): 2,
+                     Point(x=0.5, y=1.0): 4,
+                     Point(x=1.0, y=0.0): 2,
+                     Point(x=1.0, y=0.5): 1,
+                     Point(x=1.0, y=1.0): 9}
+        test_shaped_data = [[3, 4, 9],
+                            [9, 2, 1],
+                            [5, 8, 2]]
+        plotting_data = reshape_data(test_data, test_points, 3)
+        for i in range(len(plotting_data)):
+            self.assertEqual(list(plotting_data[i]), test_shaped_data[i])
 
 
 class TestFingerprint(unittest.TestCase):
@@ -50,57 +182,10 @@ class TestFingerprint(unittest.TestCase):
         self.assertEqual(fingerprint.strategy, player)
         self.assertEqual(fingerprint.probe, probe_player)
 
-    def test_create_jossann(self):
-        fingerprint = AshlockFingerprint(self.strategy)
-
-        # x + y < 1
-        ja = create_jossann((.5, .4), self.probe)
-        self.assertEqual(str(ja), "Joss-Ann Tit For Tat: (0.5, 0.4)")
-
-        # x + y = 1
-        ja = create_jossann((.4, .6), self.probe)
-        self.assertEqual(str(ja), "Dual Joss-Ann Tit For Tat: (0.6, 0.4)")
-
-        # x + y > 1
-        ja = create_jossann((.5, .6), self.probe)
-        self.assertEqual(str(ja), "Dual Joss-Ann Tit For Tat: (0.5, 0.4)")
-
-    def test_create_jossann_parametrised_player(self):
-        fingerprint = AshlockFingerprint(self.strategy)
-
-        probe = axl.Random(p=0.1)
-
-        # x + y < 1
-        ja = create_jossann((.5, .4), probe)
-        self.assertEqual(str(ja), "Joss-Ann Random: 0.1: (0.5, 0.4)")
-
-        # x + y = 1
-        ja = create_jossann((.4, .6), probe)
-        self.assertEqual(str(ja), "Dual Joss-Ann Random: 0.1: (0.6, 0.4)")
-
-        # x + y > 1
-        ja = create_jossann((.5, .6), probe)
-        self.assertEqual(str(ja), "Dual Joss-Ann Random: 0.1: (0.5, 0.4)")
-
-    def test_create_points(self):
-        test_points = create_points(0.5, progress_bar=False)
-        self.assertEqual(test_points, self.expected_points)
-
-    def test_create_probes(self):
+    def test_construct_tournament_elements(self):
         af = AshlockFingerprint(self.strategy, self.probe)
-        probes = create_probes(self.probe, self.expected_points,
-                                  progress_bar=False)
-        self.assertEqual(len(probes), 9)
-
-    def test_create_edges(self):
-        af = AshlockFingerprint(self.strategy, self.probe)
-        edges = create_edges(self.expected_points, progress_bar=False)
-        self.assertEqual(edges, self.expected_edges)
-
-    def test_construct_tournament_elemets(self):
-        af = AshlockFingerprint(self.strategy, self.probe)
-        edges, tournament_players = af.construct_tournament_elements(0.5,
-                                                            progress_bar=False)
+        edges, tournament_players = af.construct_tournament_elements(
+            0.5, progress_bar=False)
         self.assertEqual(edges, self.expected_edges)
         self.assertEqual(len(tournament_players), 10)
         self.assertEqual(tournament_players[0].__class__, af.strategy)
@@ -120,6 +205,19 @@ class TestFingerprint(unittest.TestCase):
             data = out.read()
             self.assertEqual(len(data.split("\n")), 10)
 
+    def test_fingerprint_with_filename_none_and_in_memory_false(self):
+        af = AshlockFingerprint(self.strategy, self.probe)
+        af.fingerprint(turns=1, repetitions=1, step=0.5, progress_bar=False,
+                       filename=None, in_memory=False)
+
+        edge_keys = sorted(list(af.interactions.keys()))
+        coord_keys = sorted(list(af.data.keys()))
+        self.assertEqual(af.step, 0.5)
+        self.assertEqual(af.spatial_tournament.interactions_dict,
+                         af.interactions)
+        self.assertEqual(edge_keys, self.expected_edges)
+        self.assertEqual(coord_keys, self.expected_points)
+
     def test_in_memory_fingerprint(self):
         af = AshlockFingerprint(self.strategy, self.probe)
         af.fingerprint(turns=10, repetitions=2, step=0.5, progress_bar=False,
@@ -134,7 +232,8 @@ class TestFingerprint(unittest.TestCase):
 
     def test_serial_fingerprint(self):
         af = AshlockFingerprint(self.strategy, self.probe)
-        data = af.fingerprint(turns=10, repetitions=2, step=0.5, progress_bar=False)
+        data = af.fingerprint(turns=10, repetitions=2, step=0.5,
+                              progress_bar=False)
         edge_keys = sorted(list(af.interactions.keys()))
         coord_keys = sorted(list(data.keys()))
         self.assertEqual(af.step, 0.5)
@@ -152,49 +251,6 @@ class TestFingerprint(unittest.TestCase):
         self.assertEqual(af.step, 0.5)
         self.assertEqual(edge_keys, self.expected_edges)
         self.assertEqual(coord_keys, self.expected_points)
-
-    def test_generate_data(self):
-        af = AshlockFingerprint(self.strategy, self.probe)
-        edges, players = af.construct_tournament_elements(0.5)
-        spatial_tournament = axl.SpatialTournament(players,
-                                                   turns=10,
-                                                   repetitions=2,
-                                                   edges=edges)
-        results = spatial_tournament.play(progress_bar=False,
-                                          keep_interactions=True)
-        data = generate_data(results.interactions, self.expected_points,
-                                self.expected_edges)
-        keys = sorted(list(data.keys()))
-        values = [0 < score < 5 for score in data.values()]
-        self.assertEqual(sorted(keys), self.expected_points)
-        self.assertEqual(all(values), True)
-
-    def test_reshape_data(self):
-        test_points = [Point(x=0.0, y=0.0),
-                       Point(x=0.0, y=0.5),
-                       Point(x=0.0, y=1.0),
-                       Point(x=0.5, y=0.0),
-                       Point(x=0.5, y=0.5),
-                       Point(x=0.5, y=1.0),
-                       Point(x=1.0, y=0.0),
-                       Point(x=1.0, y=0.5),
-                       Point(x=1.0, y=1.0)]
-        test_data = {Point(x=0.0, y=0.0): 5,
-                     Point(x=0.0, y=0.5): 9,
-                     Point(x=0.0, y=1.0): 3,
-                     Point(x=0.5, y=0.0): 8,
-                     Point(x=0.5, y=0.5): 2,
-                     Point(x=0.5, y=1.0): 4,
-                     Point(x=1.0, y=0.0): 2,
-                     Point(x=1.0, y=0.5): 1,
-                     Point(x=1.0, y=1.0): 9}
-        test_shaped_data = [[3, 4, 9],
-                            [9, 2, 1],
-                            [5, 8, 2]]
-        af = AshlockFingerprint(self.strategy, self.probe)
-        plotting_data = reshape_data(test_data, test_points, 3)
-        for i in range(len(plotting_data)):
-            self.assertEqual(list(plotting_data[i]), test_shaped_data[i])
 
     def test_plot(self):
         af = AshlockFingerprint(self.strategy, self.probe)
@@ -275,7 +331,6 @@ class TestFingerprint(unittest.TestCase):
                      Point(x=0.25, y=0.75): 1.62,
                      Point(x=1.0, y=1.0): 2.18}
 
-
         af = axl.AshlockFingerprint(axl.TitForTat, self.probe)
         data = af.fingerprint(turns=50, repetitions=2, step=0.25,
                               progress_bar=False)
@@ -326,21 +381,21 @@ class TestFingerprint(unittest.TestCase):
         """
         strategy, probe = strategy_pair
         af = AshlockFingerprint(strategy, probe)
-        data = af.fingerprint(turns=2, repetitions=2, step=0.5,
+        data = af.fingerprint(turns=2, repetitions=2, step=1.0,
                               progress_bar=False)
         self.assertIsInstance(data, dict)
 
         af = AshlockFingerprint(strategy(), probe)
-        data = af.fingerprint(turns=2, repetitions=2, step=0.5,
+        data = af.fingerprint(turns=2, repetitions=2, step=1.0,
                               progress_bar=False)
         self.assertIsInstance(data, dict)
 
         af = AshlockFingerprint(strategy, probe())
-        data = af.fingerprint(turns=2, repetitions=2, step=0.5,
+        data = af.fingerprint(turns=2, repetitions=2, step=1.0,
                               progress_bar=False)
         self.assertIsInstance(data, dict)
 
         af = AshlockFingerprint(strategy(), probe())
-        data = af.fingerprint(turns=2, repetitions=2, step=0.5,
+        data = af.fingerprint(turns=2, repetitions=2, step=1.0,
                               progress_bar=False)
         self.assertIsInstance(data, dict)

--- a/axelrod/tests/unit/test_fingerprint.py
+++ b/axelrod/tests/unit/test_fingerprint.py
@@ -1,19 +1,4 @@
-"""
-added or modified tests
-
-line
-
-- 38 to 62
-- 95
-- 105
-- 110
-- 211
-- 235
-
-"""
-
 import unittest
-from unittest.mock import patch
 from hypothesis import given
 from axelrod.fingerprint import *
 from axelrod.tests.property import strategy_lists
@@ -233,27 +218,6 @@ class TestFingerprint(unittest.TestCase):
             data = out.read()
             self.assertEqual(len(data.split("\n")), 10)
 
-    @unittest.skipIf(axl.on_windows,
-                     "Windows has issues with NamedTemporaryFile.")
-    def test_fingerprint_not_on_windows_filename_none_and_in_memory_false(self):
-        af = AshlockFingerprint(axl.Cooperator, axl.Cooperator)
-        af.fingerprint(turns=1, repetitions=1, step=1.0, progress_bar=False,
-                       filename=None, in_memory=False)
-        interactions = {(0, 1): [[(C, C)]], (0, 2): [[(C, D)]],
-                        (0, 3): [[(C, C)]], (0, 4): [[(C, D)]]}
-        self.assertEqual(af.interactions, interactions)
-        self.assertFalse(hasattr(af.spatial_tournament, 'interactions_dict'))
-
-    @patch("axelrod.on_windows", True)
-    def test_fingerprint_on_windows_filename_none_and_in_memory_false(self):
-        af = AshlockFingerprint(axl.Cooperator, axl.Cooperator)
-        af.fingerprint(turns=1, repetitions=1, step=1.0, progress_bar=False,
-                       filename=None, in_memory=False)
-        interactions = {(0, 1): [[(C, C)]], (0, 2): [[(C, D)]],
-                        (0, 3): [[(C, C)]], (0, 4): [[(C, D)]]}
-        self.assertEqual(af.interactions, interactions)
-        self.assertEqual(af.spatial_tournament.interactions_dict, interactions)
-
     def test_in_memory_fingerprint(self):
         af = AshlockFingerprint(self.strategy, self.probe)
         af.fingerprint(turns=10, repetitions=2, step=0.5, progress_bar=False,
@@ -299,7 +263,7 @@ class TestFingerprint(unittest.TestCase):
         self.assertIsInstance(r, matplotlib.pyplot.Figure)
         t = af.plot(title='Title')
         self.assertIsInstance(t, matplotlib.pyplot.Figure)
-        u = af.plot(color_bar=False)
+        u = af.plot(colorbar=False)
         self.assertIsInstance(u, matplotlib.pyplot.Figure)
         v = af.plot(labels=False)
         self.assertIsInstance(v, matplotlib.pyplot.Figure)

--- a/axelrod/tests/unit/test_fingerprint.py
+++ b/axelrod/tests/unit/test_fingerprint.py
@@ -233,17 +233,12 @@ class TestFingerprint(unittest.TestCase):
             self.assertEqual(len(data.split("\n")), 10)
 
     def test_fingerprint_with_filename_none_and_in_memory_false(self):
-        af = AshlockFingerprint(self.strategy, self.probe)
-        af.fingerprint(turns=1, repetitions=1, step=0.5, progress_bar=False,
+        af = AshlockFingerprint(axl.Cooperator, axl.Cooperator)
+        af.fingerprint(turns=1, repetitions=1, step=1.0, progress_bar=False,
                        filename=None, in_memory=False)
-
-        edge_keys = sorted(list(af.interactions.keys()))
-        coord_keys = sorted(list(af.data.keys()))
-        self.assertEqual(af.step, 0.5)
-        self.assertEqual(af.spatial_tournament.interactions_dict,
-                         af.interactions)
-        self.assertEqual(edge_keys, self.expected_edges)
-        self.assertEqual(coord_keys, self.expected_points)
+        interactions = {(0, 1): [[(C, C)]], (0, 2): [[(C, D)]],
+                        (0, 3): [[(C, C)]], (0, 4): [[(C, D)]]}
+        self.assertEqual(af.interactions, interactions)
 
     def test_in_memory_fingerprint(self):
         af = AshlockFingerprint(self.strategy, self.probe)

--- a/axelrod/tests/unit/test_fingerprint.py
+++ b/axelrod/tests/unit/test_fingerprint.py
@@ -2,6 +2,7 @@ import unittest
 from hypothesis import given
 from axelrod.fingerprint import *
 from axelrod.tests.property import strategy_lists
+import axelrod as axl
 
 
 matplotlib_installed = True
@@ -53,15 +54,15 @@ class TestFingerprint(unittest.TestCase):
         fingerprint = AshlockFingerprint(self.strategy)
 
         # x + y < 1
-        ja = fingerprint.create_jossann((.5, .4), self.probe)
+        ja = create_jossann((.5, .4), self.probe)
         self.assertEqual(str(ja), "Joss-Ann Tit For Tat: (0.5, 0.4)")
 
         # x + y = 1
-        ja = fingerprint.create_jossann((.4, .6), self.probe)
+        ja = create_jossann((.4, .6), self.probe)
         self.assertEqual(str(ja), "Dual Joss-Ann Tit For Tat: (0.6, 0.4)")
 
         # x + y > 1
-        ja = fingerprint.create_jossann((.5, .6), self.probe)
+        ja = create_jossann((.5, .6), self.probe)
         self.assertEqual(str(ja), "Dual Joss-Ann Tit For Tat: (0.5, 0.4)")
 
     def test_create_jossann_parametrised_player(self):
@@ -70,15 +71,15 @@ class TestFingerprint(unittest.TestCase):
         probe = axl.Random(p=0.1)
 
         # x + y < 1
-        ja = fingerprint.create_jossann((.5, .4), probe)
+        ja = create_jossann((.5, .4), probe)
         self.assertEqual(str(ja), "Joss-Ann Random: 0.1: (0.5, 0.4)")
 
         # x + y = 1
-        ja = fingerprint.create_jossann((.4, .6), probe)
+        ja = create_jossann((.4, .6), probe)
         self.assertEqual(str(ja), "Dual Joss-Ann Random: 0.1: (0.6, 0.4)")
 
         # x + y > 1
-        ja = fingerprint.create_jossann((.5, .6), probe)
+        ja = create_jossann((.5, .6), probe)
         self.assertEqual(str(ja), "Dual Joss-Ann Random: 0.1: (0.5, 0.4)")
 
     def test_create_points(self):
@@ -87,13 +88,13 @@ class TestFingerprint(unittest.TestCase):
 
     def test_create_probes(self):
         af = AshlockFingerprint(self.strategy, self.probe)
-        probes = af.create_probes(self.probe, self.expected_points,
+        probes = create_probes(self.probe, self.expected_points,
                                   progress_bar=False)
         self.assertEqual(len(probes), 9)
 
     def test_create_edges(self):
         af = AshlockFingerprint(self.strategy, self.probe)
-        edges = af.create_edges(self.expected_points, progress_bar=False)
+        edges = create_edges(self.expected_points, progress_bar=False)
         self.assertEqual(edges, self.expected_edges)
 
     def test_construct_tournament_elemets(self):
@@ -161,7 +162,7 @@ class TestFingerprint(unittest.TestCase):
                                                    edges=edges)
         results = spatial_tournament.play(progress_bar=False,
                                           keep_interactions=True)
-        data = af.generate_data(results.interactions, self.expected_points,
+        data = generate_data(results.interactions, self.expected_points,
                                 self.expected_edges)
         keys = sorted(list(data.keys()))
         values = [0 < score < 5 for score in data.values()]
@@ -191,7 +192,7 @@ class TestFingerprint(unittest.TestCase):
                             [9, 2, 1],
                             [5, 8, 2]]
         af = AshlockFingerprint(self.strategy, self.probe)
-        plotting_data = af.reshape_data(test_data, test_points, 3)
+        plotting_data = reshape_data(test_data, test_points, 3)
         for i in range(len(plotting_data)):
             self.assertEqual(list(plotting_data[i]), test_shaped_data[i])
 
@@ -206,7 +207,7 @@ class TestFingerprint(unittest.TestCase):
         self.assertIsInstance(r, matplotlib.pyplot.Figure)
         t = af.plot(title='Title')
         self.assertIsInstance(t, matplotlib.pyplot.Figure)
-        u = af.plot(colorbar=False)
+        u = af.plot(color_bar=False)
         self.assertIsInstance(u, matplotlib.pyplot.Figure)
         v = af.plot(labels=False)
         self.assertIsInstance(v, matplotlib.pyplot.Figure)

--- a/axelrod/tests/unit/test_fingerprint.py
+++ b/axelrod/tests/unit/test_fingerprint.py
@@ -1,3 +1,17 @@
+"""
+added or modified tests
+
+line
+
+- 38 to 62
+- 95
+- 105
+- 110
+- 211
+- 235
+
+"""
+
 import unittest
 from hypothesis import given
 from axelrod.fingerprint import *
@@ -44,6 +58,11 @@ class TestFingerPrintHelpers(unittest.TestCase):
                           (0, 7), (0, 8), (0, 9)]
         edges = create_edges(points, progress_bar=False)
         self.assertEqual(edges, expected_edges)
+
+    def test_create_edges_progress_bar_true(self):
+        points = [(0.0, 0.0), (0.0, 0.5)]
+        edges = create_edges(points, progress_bar=True)
+        self.assertEqual(edges, [(0, 1), (0, 2)])
 
     def test_create_jossann(self):
         probe = axl.TitForTat
@@ -186,6 +205,14 @@ class TestFingerprint(unittest.TestCase):
         af = AshlockFingerprint(self.strategy, self.probe)
         edges, tournament_players = af.construct_tournament_elements(
             0.5, progress_bar=False)
+        self.assertEqual(edges, self.expected_edges)
+        self.assertEqual(len(tournament_players), 10)
+        self.assertEqual(tournament_players[0].__class__, af.strategy)
+
+    def test_construct_tournament_elements_progress_bar_true(self):
+        af = AshlockFingerprint(self.strategy, self.probe)
+        edges, tournament_players = af.construct_tournament_elements(
+            0.5, progress_bar=True)
         self.assertEqual(edges, self.expected_edges)
         self.assertEqual(len(tournament_players), 10)
         self.assertEqual(tournament_players[0].__class__, af.strategy)


### PR DESCRIPTION
when i pulled out methods i needed to organize.  so i did:

1) main methods of main object
2) implementation details

this PR is almost entirely moving things around.  

because the act of changing position might make it hard to notice any changes, there are notes to myself on any additions/changes (very minor).  i'll be using those to comment every line that isn't exactly like the original (minus automatic chnages like removing `@staticmethod`).  and then those can be removed later.  

I'm new to type hinting and not sure the best way to go about it.  I tried making aliases for the different types at the top.  this looked nice in the code, but when i called up a docstring on my IDE, 
`EdgesToMatches` became `Dict[Tuple[int, int], List[List[Tuple[str, str]]]]`  which looks fugly.  should i just stick to very basic types?  should i set aliases to very basic types, like `EdgesToMatches = dict; PointsToFloats = dict` ?  

