### PR TITLE
Add scipy to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ matplotlib>=1.4.2
 hypothesis>=3.2
 tqdm==3.4.0
 prompt-toolkit>=1.0.7
+scipy>=0.18.0


### PR DESCRIPTION
The PR adds scipy dependency for Axelrod's Stein and Rapoport Strategy.

Would it make sense to add ``scipy`` as an optional dependency, since we require it for only one strategy (so far)?