### PR TITLE
Add strategy index test to travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ script:
   - python doctests.py
   # Run the type checker
   - python run_mypy.py
+  # Check that all strategies are in the index
+  - python run_strategy_indexer.py
 after_success:
   - coveralls
 notifications:

--- a/docs/reference/all_strategies.rst
+++ b/docs/reference/all_strategies.rst
@@ -81,6 +81,9 @@ Here are the docstrings of all the strategies in the library.
 .. automodule:: axelrod.strategies.handshake
    :members:
    :undoc-members:
+.. automodule:: axelrod.strategies.hmm
+   :members:
+   :undoc-members:
 .. automodule:: axelrod.strategies.hunter
    :members:
    :undoc-members:

--- a/docs/reference/all_strategies.rst
+++ b/docs/reference/all_strategies.rst
@@ -96,6 +96,9 @@ Here are the docstrings of all the strategies in the library.
 .. automodule:: axelrod.strategies.mathematicalconstants
    :members:
    :undoc-members:
+.. automodule:: axelrod.strategies.memorytwo
+   :members:
+   :undoc-members:
 .. automodule:: axelrod.strategies.memoryone
    :members:
    :undoc-members:

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
-modules = ["axelrod/actions.py",
+modules = ["run_strategy_indexer.py",
+           "axelrod/actions.py",
            "axelrod/deterministic_cache.py",
            "axelrod/ecosystem.py",
            "axelrod/game.py",

--- a/run_strategy_indexer.py
+++ b/run_strategy_indexer.py
@@ -2,80 +2,45 @@
 A script to check that all strategy modules have been included in
 `./docs/reference/all_strategies.rst`
 """
-import glob
 import sys
-import os
+import pathlib
 
-def read_index(index_path: str) -> str:
-    """
-    Read the index of strategies
+default_index_path = pathlib.Path("./docs/reference/all_strategies.rst")
+excluded_modules = ("_strategies", "__init__", "_filters", "human")
 
-    Parameters
-    ----------
-    index_path : str
-        A file path for the index file where all strategies are auto documented
-
-    Returns
-    -------
-    strategies_reference : str
-        The string value of the contents of the index file.
-    """
-    with open(index_path, "r") as f:
-        strategies_reference = f.read()
-    return strategies_reference
-
-def get_module_name(module_path: str) -> str:
-    """
-    Take string of the form `./axelrod/strategies/titfortat.py` and returns
-    `titfortat`.
-
-    Parameters
-    ----------
-    module_path : str
-        A file path for a module file.
-
-    Returns
-    -------
-    module_name : str
-        The name of the module
-    """
-    filename = os.path.basename(module_path)
-    module_name = os.path.splitext(filename)[0]
-    return module_name
-
-def check_module(module_path: str,
-                 index_path: str="./docs/reference/all_strategies.rst",
-                 excluded: tuple=("_strategies", "__init__",
-                                  "_filters", "human")) -> bool:
+def check_module(module_path: pathlib.Path,
+                 index_path: pathlib.Path=default_index_path,
+                 excluded: tuple=excluded_modules) -> bool:
     """
     Check if a module name is written in the index of strategies.
 
     Parameters
     ----------
-    module_path : str
+    module_path :
         A file path for a module file.
-    index_path : str
+    index_path :
         A file path for the index file where all strategies are auto documented
-    excluded : tuple
+    excluded :
         A collection of module names to be ignored
 
     Returns
     -------
-    boolean : bool
+    boolean :
         True/False if module is referenced.
 
     """
-    strategies_index = read_index(index_path)
-    module_name = get_module_name(module_path)
+    strategies_index = index_path.read_text()
+    module_name = module_path.stem
     if module_name not in excluded and module_name not in strategies_index:
-            print("{} not in index".format(module_name))
-            return False
+        print("{} not in index".format(module_name))
+        return False
     return True
 
 
 if __name__ == "__main__":
 
-    modules = glob.glob("./axelrod/strategies/*.py")
+    p = pathlib.Path('.')
+    modules = p.glob("./axelrod/strategies/*.py")
     exit_codes = []
 
     for module_path in modules:

--- a/run_strategy_indexer.py
+++ b/run_strategy_indexer.py
@@ -1,0 +1,49 @@
+"""
+A script to check that all strategy modules have been included in
+`./docs/reference/all_strategies.rst`
+"""
+import glob
+import sys
+import os
+
+def read_index(index_path):
+    """Read the index of strategies"""
+    with open(index_path, "r") as f:
+        strategies_reference = f.read()
+    return strategies_reference
+
+def get_module_name(module_path):
+    """
+    Take string of the form `./axelrod/strategies/titfortat.py` and returns
+    `titfortat`.
+    """
+    filename = os.path.basename(module_path)
+    module_name = os.path.splitext(filename)[0]
+    return module_name
+
+def check_module(module_path,
+                 index_path="./docs/reference/all_strategies.rst",
+                 excluded=("_strategies", "__init__", "_filters", "human")):
+    """
+    Check if a module is contained in the index of strategies
+
+    Returns boolean: True/False if module is referenced.
+    """
+    strategies_reference = read_index(index_path)
+    module_name = get_module_name(module_path)
+    if module_name not in excluded:
+        if module_name not in strategies_reference:
+            print("{} not in index".format(module_name))
+            return False
+    return True
+
+
+if __name__ == "__main__":
+
+    modules = glob.glob("./axelrod/strategies/*py")
+    exit_codes = []
+
+    for module_path in modules:
+        exit_codes.append(int(not check_module(module_path)))
+
+    sys.exit(max(exit_codes))

--- a/run_strategy_indexer.py
+++ b/run_strategy_indexer.py
@@ -74,7 +74,7 @@ def check_module(module_path,
 
 if __name__ == "__main__":
 
-    modules = glob.glob("./axelrod/strategies/*py")
+    modules = glob.glob("./axelrod/strategies/*.py")
     exit_codes = []
 
     for module_path in modules:

--- a/run_strategy_indexer.py
+++ b/run_strategy_indexer.py
@@ -6,7 +6,7 @@ import glob
 import sys
 import os
 
-def read_index(index_path):
+def read_index(index_path: str) -> str:
     """
     Read the index of strategies
 
@@ -24,7 +24,7 @@ def read_index(index_path):
         strategies_reference = f.read()
     return strategies_reference
 
-def get_module_name(module_path):
+def get_module_name(module_path: str) -> str:
     """
     Take string of the form `./axelrod/strategies/titfortat.py` and returns
     `titfortat`.
@@ -43,9 +43,10 @@ def get_module_name(module_path):
     module_name = os.path.splitext(filename)[0]
     return module_name
 
-def check_module(module_path,
-                 index_path="./docs/reference/all_strategies.rst",
-                 excluded=("_strategies", "__init__", "_filters", "human")):
+def check_module(module_path: str,
+                 index_path: str="./docs/reference/all_strategies.rst",
+                 excluded: tuple=("_strategies", "__init__",
+                                  "_filters", "human")) -> bool:
     """
     Check if a module name is written in the index of strategies.
 

--- a/run_strategy_indexer.py
+++ b/run_strategy_indexer.py
@@ -7,7 +7,19 @@ import sys
 import os
 
 def read_index(index_path):
-    """Read the index of strategies"""
+    """
+    Read the index of strategies
+
+    Parameters
+    ----------
+    index_path : str
+        A file path for the index file where all strategies are auto documented
+
+    Returns
+    -------
+    strategies_reference : str
+        The string value of the contents of the index file.
+    """
     with open(index_path, "r") as f:
         strategies_reference = f.read()
     return strategies_reference
@@ -16,6 +28,16 @@ def get_module_name(module_path):
     """
     Take string of the form `./axelrod/strategies/titfortat.py` and returns
     `titfortat`.
+
+    Parameters
+    ----------
+    module_path : str
+        A file path for a module file.
+
+    Returns
+    -------
+    module_name : str
+        The name of the module
     """
     filename = os.path.basename(module_path)
     module_name = os.path.splitext(filename)[0]
@@ -25,11 +47,24 @@ def check_module(module_path,
                  index_path="./docs/reference/all_strategies.rst",
                  excluded=("_strategies", "__init__", "_filters", "human")):
     """
-    Check if a module is contained in the index of strategies
+    Check if a module name is written in the index of strategies.
 
-    Returns boolean: True/False if module is referenced.
+    Parameters
+    ----------
+    module_path : str
+        A file path for a module file.
+    index_path : str
+        A file path for the index file where all strategies are auto documented
+    excluded : tuple
+        A collection of module names to be ignored
+
+    Returns
+    -------
+    boolean : bool
+        True/False if module is referenced.
+
     """
-    strategies_reference = read_index(index_path)
+    strategies_index = read_index(index_path)
     module_name = get_module_name(module_path)
     if module_name not in excluded:
         if module_name not in strategies_reference:

--- a/run_strategy_indexer.py
+++ b/run_strategy_indexer.py
@@ -66,8 +66,7 @@ def check_module(module_path,
     """
     strategies_index = read_index(index_path)
     module_name = get_module_name(module_path)
-    if module_name not in excluded:
-        if module_name not in strategies_reference:
+    if module_name not in excluded and module_name not in strategies_index:
             print("{} not in index".format(module_name))
             return False
     return True


### PR DESCRIPTION
Closes #957. I am expecting this to fail on travis: two modules are not currently indexed (`hmm` and `memorytwo`). Using that as a test that this script works (once travis fails, will push the fix).