### PR TITLE
Remove pin of pyparsing.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pyparsing==2.1.1 # Due to https://github.com/Axelrod-Python/Axelrod/issues/584
 numpy>=1.9.2
 matplotlib>=1.4.2
 hypothesis>=3.2

--- a/rtd_environment.yml
+++ b/rtd_environment.yml
@@ -5,7 +5,6 @@ dependencies:
 - matplotlib>=1.4.2
 - pip:
    - docutils==0.12
-   - pyparsing==2.1.1 # Due to https://github.com/Axelrod-Python/Axelrod/issues/584
    - hypothesis>=3.2
    - tqdm==3.4.0
    - prompt-toolkit>=1.0.7


### PR DESCRIPTION
This no longer seems to be necessary. (It fixed a bug related to a version #584)