### PR TITLE
Add tqdm to mocking for docs.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ import mock
 
 MOCK_MODULES = [
     'scipy', 'scipy.stats','numpy', 'numpy.linalg', 'numpy.random',
-    'matplotlib.pyplot', 'matplotlib','matplotlib.transforms',
+    'matplotlib.pyplot', 'matplotlib','matplotlib.transforms', 'tqdm',
     'mpl_toolkits.axes_grid1', 'dill', 'multiprocess','prompt_toolkit',
     'prompt_toolkit.token', 'prompt_toolkit.styles','prompt_toolkit.validation']
 for mod_name in MOCK_MODULES:


### PR DESCRIPTION
Closes #1019 (hopefully for good, if not we'll go back to using a conda env). Marking this as a bug as technically it is (our master branch docs are failing to build) and it'll hopefully stop @meatballs and I getting emails from rtd...

Here's a passed build: https://readthedocs.org/projects/axelrod/builds/5454913/