### PR TITLE
Fake name se dynamic tit for tat

### DIFF
--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -263,4 +263,5 @@ all_strategies = [
     ZDGen2,
     ZDSet2,
     e,
+    DynamicTitForTat,
 ]

--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -76,7 +76,8 @@ from .titfortat import (
     TitForTat, TitFor2Tats, TwoTitsForTat, Bully, SneakyTitForTat,
     SuspiciousTitForTat, AntiTitForTat, HardTitForTat, HardTitFor2Tats,
     OmegaTFT, Gradual, ContriteTitForTat, SlowTitForTwoTats, AdaptiveTitForTat,
-    SpitefulTitForTat, SlowTitForTwoTats2, Alexei, EugineNier)
+    SpitefulTitForTat, SlowTitForTwoTats2, Alexei, EugineNier,
+    DynamicTitForTat)
 from .verybad import VeryBad
 from .worse_and_worse import (WorseAndWorse, KnowledgeableWorseAndWorse,
                               WorseAndWorse2, WorseAndWorse3)

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -91,7 +91,36 @@ class TwoTitsForTat(Player):
     @staticmethod
     def strategy(opponent: Player) -> Action:
         return D if D in opponent.history[-2:] else C
+    
+class DynamicTitForTat(Player):
+    """A player starts by cooperating and then mimics previous move by
+     opponent with a dynamic bias based off of the opponents ratio of
+      defections to cooperations towards cooporating regardless of 
+      the move."""
 
+    name = 'Dynamic Tit for Tat'
+    classifier = {
+        'memory_depth': 2,  # Long memory, memory-2
+        'stochastic': False,
+        'makes_use_of': set(),
+        'long_run_time': False,
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+
+    @staticmethod
+    def strategy(self, opponent):
+        try:
+            if 'D' in opponent.history[-2:]:
+                if random.random() < (sum([s == 'C' for s in opponent.history]) / len(opponent.history)):
+                    return 'C'
+                else:
+                    return 'D'
+            else:
+                return 'C'
+        except IndexError:
+            return 'C'    
 
 class Bully(Player):
     """A player that behaves opposite to Tit For Tat, including first move.

--- a/axelrod/tests/strategies/test_titfortat.py
+++ b/axelrod/tests/strategies/test_titfortat.py
@@ -89,7 +89,28 @@ class TestTitFor2Tats(TestPlayer):
         opponent = axelrod.MockPlayer(actions=[D, D, D, C, C])
         actions = [(C, D), (C, D), (D, D), (D, C), (C, C)]
         self.versus_test(opponent, expected_actions=actions)
+        
+class TestDynamicTitForTat(TestPlayer):
 
+    name = 'Dynamic Tit For Tat'
+    player = axelrod.DynamicTitForTat
+    expected_classifier = {
+        'memory_depth': 2,
+        'stochastic': False,
+        'makes_use_of': set(),
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+
+    def test_strategy(self):
+        self.first_play_test(C)
+        self.second_play_test(rCC=C, rCD=C, rDC=C, rDD=C)
+
+        # Will punish sequence of 2 defections but will forgive
+        opponent = axelrod.MockPlayer(actions=[D, D, D, C, C])
+        actions = [(C, D), (C, D), (D, D), (D, C), (C, C)]
+        self.versus_test(opponent, expected_actions=actions)
 
 class TestTwoTitsForTat(TestPlayer):
 


### PR DESCRIPTION
Hi, here is a modified version of the Tit for Tat strategy which adjusts its probability to forgive based off of the ration of defects to cooporations of the opponent. It considers defecting for two moves after the opponent last defected (like 2tits for tat) because I found that it performed better this way. I may have incorrectly added a test, so if so please let me know so that I can learn and fix it.
Have a nice day!