### PR TITLE
Add a new DynamicTwoTitsForTat strategy

### DIFF
--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -76,7 +76,7 @@ from .titfortat import (
     TitForTat, TitFor2Tats, TwoTitsForTat, Bully, SneakyTitForTat,
     SuspiciousTitForTat, AntiTitForTat, HardTitForTat, HardTitFor2Tats,
     OmegaTFT, Gradual, ContriteTitForTat, SlowTitForTwoTats, AdaptiveTitForTat,
-    SpitefulTitForTat, SlowTitForTwoTats2, Alexei, EugineNier)
+    SpitefulTitForTat, SlowTitForTwoTats2, Alexei, EugineNier, DynamicTwoTitsForTat)
 from .verybad import VeryBad
 from .worse_and_worse import (WorseAndWorse, KnowledgeableWorseAndWorse,
                               WorseAndWorse2, WorseAndWorse3)
@@ -263,4 +263,5 @@ all_strategies = [
     ZDGen2,
     ZDSet2,
     e,
+    DynamicTwoTitsForTat,
 ]

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -96,10 +96,10 @@ class TwoTitsForTat(Player):
 class DynamicTwoTitsForTat(Player):
     """
     A player starts by cooperating and then punishes its opponent's 
-    defectiions by opponent with a dynamic bias based off of the 
-    opponents ratio of cooperations to total moves (so their current 
-    probability of cooperating towards cooporating regardless of the 
-    move (aka: forgiveness)).
+    defections with defections, but with a dynamic bias towards cooperating 
+    based off of the opponent's ratio of cooperations to total moves 
+    (so their current probability of cooperating regardless of the 
+    opponent's move (aka: forgiveness)).
     
     Names:
 
@@ -120,7 +120,7 @@ class DynamicTwoTitsForTat(Player):
     @staticmethod
     def strategy(opponent):
         # First move
-        if len(opponent.history) == 0:
+        if not opponent.history:
             # Make sure we cooporate first turn
             return C
         if D in opponent.history[-2:]:

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -97,7 +97,7 @@ class DynamicTwoTitsForTat(Player):
     """
     A player starts by cooperating and then punishes its opponent's 
     defections with defections, but with a dynamic bias towards cooperating 
-    based off of the opponent's ratio of cooperations to total moves 
+    based on the opponent's ratio of cooperations to total moves 
     (so their current probability of cooperating regardless of the 
     opponent's move (aka: forgiveness)).
     

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -2,7 +2,6 @@ from axelrod.actions import Actions, Action
 from axelrod.player import Player
 from axelrod.strategy_transformers import TrackHistoryTransformer, FinalTransformer
 from axelrod.random_ import random_choice
-import random
 
 C, D = Actions.C, Actions.D
 
@@ -95,16 +94,21 @@ class TwoTitsForTat(Player):
         return D if D in opponent.history[-2:] else C
 
 class DynamicTwoTitsForTat(Player):
-    """A player starts by cooperating and then mimics previous move by 
-    opponent with a dynamic bias based off of the opponents ratio of 
-    cooperations to total moves (so their current probability of 
-    cooperating towards cooporating regardless of the move 
-    (aka: forgiveness)."""
+    """
+    A player starts by cooperating and then punishes its opponent's 
+    defectiions by opponent with a dynamic bias based off of the 
+    opponents ratio of cooperations to total moves (so their current 
+    probability of cooperating towards cooporating regardless of the 
+    move (aka: forgiveness)).
+    Names:
+
+     - Dynamic Two Tits For Tat: Original name by Grant Garrett-Grossman.
+    """
 
     name = 'Dynamic Two Tits For Tat'
     classifier = {
         'memory_depth': 2,  # Long memory, memory-2
-        'stochastic': False,
+        'stochastic': True,
         'makes_use_of': set(),
         'long_run_time': False,
         'inspects_source': False,
@@ -119,9 +123,8 @@ class DynamicTwoTitsForTat(Player):
             # Make sure we cooporate first turn
             return C
         if D in opponent.history[-2:]:
-            # Probability of turning the other cheek based off of 
-            # opponent's probability of defection
-            if random.random() < (opponent.cooperations / len(opponent.history)):
+            # Probability of cooperating regardless
+            if random_choice(opponent.cooperations / len(opponent.history)):
                 return C
             else:
                 return D

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -119,16 +119,13 @@ class DynamicTwoTitsForTat(Player):
     
     @staticmethod
     def strategy(opponent):
-		# First move
+        # First move
         if len(opponent.history) == 0:
             # Make sure we cooporate first turn
             return C
         if D in opponent.history[-2:]:
             # Probability of cooperating regardless
-            if random_choice(opponent.cooperations / len(opponent.history)):
-                return C
-            else:
-                return D
+            return random_choice(opponent.cooperations / len(opponent.history))                                                                 
         else:
             return C
 

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -1,6 +1,8 @@
 from axelrod.actions import Actions, Action
 from axelrod.player import Player
 from axelrod.strategy_transformers import TrackHistoryTransformer, FinalTransformer
+from axelrod.random_ import random_choice
+import random
 
 C, D = Actions.C, Actions.D
 
@@ -92,6 +94,39 @@ class TwoTitsForTat(Player):
     def strategy(opponent: Player) -> Action:
         return D if D in opponent.history[-2:] else C
 
+class DynamicTwoTitsForTat(Player):
+    """A player starts by cooperating and then mimics previous move by 
+    opponent with a dynamic bias based off of the opponents ratio of 
+    cooperations to total moves (so their current probability of 
+    cooperating towards cooporating regardless of the move 
+    (aka: forgiveness)."""
+
+    name = 'Dynamic Two Tits For Tat'
+    classifier = {
+        'memory_depth': 2,  # Long memory, memory-2
+        'stochastic': False,
+        'makes_use_of': set(),
+        'long_run_time': False,
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+    
+    @staticmethod
+    def strategy(opponent):
+		# First move
+        if len(opponent.history) == 0:
+            # Make sure we cooporate first turn
+            return C
+        if D in opponent.history[-2:]:
+            # Probability of turning the other cheek based off of 
+            # opponent's probability of defection
+            if random.random() < (opponent.cooperations / len(opponent.history)):
+                return C
+            else:
+                return D
+        else:
+            return C
 
 class Bully(Player):
     """A player that behaves opposite to Tit For Tat, including first move.

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -100,6 +100,7 @@ class DynamicTwoTitsForTat(Player):
     opponents ratio of cooperations to total moves (so their current 
     probability of cooperating towards cooporating regardless of the 
     move (aka: forgiveness)).
+    
     Names:
 
      - Dynamic Two Tits For Tat: Original name by Grant Garrett-Grossman.

--- a/axelrod/tests/strategies/test_titfortat.py
+++ b/axelrod/tests/strategies/test_titfortat.py
@@ -131,25 +131,19 @@ class TestDynamicTwoTitsForTat(TestPlayer):
         # First move is to cooperate
         self.first_play_test(C)
         # Test that it is stochastic        
- 
-        opponent = axelrod.MockPlayer(actions=[D, C, D, D, C])
-        actions = [(C, D), (C,C), (C,D), (C,D), (C,C)]
-        self.versus_test(opponent, expected_actions=actions, seed=2)
+        opponent = axelrod.MockPlayer(actions=[D, C, D, D, C])                                                                                  
+        actions = [(C, D), (D, C), (C, D), (D, D), (D, C)]                                                                                      
+        self.versus_test(opponent, expected_actions=actions, seed=1)                                                                            
+        # Should respond differently with a different seed                                                                                                                                         
+        actions = [(C, D), (D, C), (D, D), (D, D), (C, C)]                                                                                      
+        self.versus_test(opponent, expected_actions=actions, seed=2) 
         
-        opponent = axelrod.MockPlayer(actions=[D, C, D, D, C])
-        actions = [(C, D), (C,C), (C,D), (C,D), (D,C)]
-        self.versus_test(opponent, expected_actions=actions, seed=13)
-        
-        ## Will cooperate if opponent cooperates.
-        #actions = [(C, C), (C, C), (C, C), (C, C), (C, C)]
-        #self.versus_test(axelrod.Cooperator(), expected_actions=actions)
-        ## Will defect twice when last turn of opponent was defection.
-        #opponent = axelrod.MockPlayer(actions=[D, C, C, D, C])
-        #actions = [(C, D), (D, C), (D, C), (C, D), (D, C)]
-        #self.versus_test(opponent, expected_actions=actions)
-        ## Test against defector
-        #actions = [(C, D), (D, D), (D, D), (D, D), (D, D)]
-        #self.versus_test(axelrod.Defector(), expected_actions=actions)
+        # Will cooperate if opponent cooperates.
+        actions = [(C, C), (C, C), (C, C), (C, C), (C, C)]
+        self.versus_test(axelrod.Cooperator(), expected_actions=actions)
+        # Test against defector
+        actions = [(C, D), (D, D), (D, D), (D, D), (D, D)]
+        self.versus_test(axelrod.Defector(), expected_actions=actions)
 
 class TestBully(TestPlayer):
 

--- a/axelrod/tests/strategies/test_titfortat.py
+++ b/axelrod/tests/strategies/test_titfortat.py
@@ -120,7 +120,7 @@ class TestDynamicTwoTitsForTat(TestPlayer):
     player = axelrod.DynamicTwoTitsForTat
     expected_classifier = {
         'memory_depth': 2,
-        'stochastic': False,
+        'stochastic': True,
         'makes_use_of': set(),
         'inspects_source': False,
         'manipulates_source': False,
@@ -128,19 +128,28 @@ class TestDynamicTwoTitsForTat(TestPlayer):
     }
 
     def test_strategy(self):
+        # First move is to cooperate
         self.first_play_test(C)
-        self.second_play_test(rCC=C, rCD=D, rDC=C, rDD=D)
-
-        # Will cooperate if opponent cooperates/.
-        actions = [(C, C), (C, C), (C, C), (C, C), (C, C)]
-        self.versus_test(axelrod.Cooperator(), expected_actions=actions)
-        # Will defect twice when last turn of opponent was defection.
-        opponent = axelrod.MockPlayer(actions=[D, C, C, D, C])
-        actions = [(C, D), (D, C), (D, C), (C, D), (D, C)]
-        self.versus_test(opponent, expected_actions=actions)
-        # Test against defector
-        actions = [(C, D), (D, D), (D, D), (D, D), (D, D)]
-        self.versus_test(axelrod.Defector(), expected_actions=actions)
+        # Test that it is stochastic        
+ 
+        opponent = axelrod.MockPlayer(actions=[D, C, D, D, C])
+        actions = [(C, D), (C,C), (C,D), (C,D), (C,C)]
+        self.versus_test(opponent, expected_actions=actions, seed=2)
+        
+        opponent = axelrod.MockPlayer(actions=[D, C, D, D, C])
+        actions = [(C, D), (C,C), (C,D), (C,D), (D,C)]
+        self.versus_test(opponent, expected_actions=actions, seed=13)
+        
+        ## Will cooperate if opponent cooperates.
+        #actions = [(C, C), (C, C), (C, C), (C, C), (C, C)]
+        #self.versus_test(axelrod.Cooperator(), expected_actions=actions)
+        ## Will defect twice when last turn of opponent was defection.
+        #opponent = axelrod.MockPlayer(actions=[D, C, C, D, C])
+        #actions = [(C, D), (D, C), (D, C), (C, D), (D, C)]
+        #self.versus_test(opponent, expected_actions=actions)
+        ## Test against defector
+        #actions = [(C, D), (D, D), (D, D), (D, D), (D, D)]
+        #self.versus_test(axelrod.Defector(), expected_actions=actions)
 
 class TestBully(TestPlayer):
 

--- a/axelrod/tests/strategies/test_titfortat.py
+++ b/axelrod/tests/strategies/test_titfortat.py
@@ -114,6 +114,34 @@ class TestTwoTitsForTat(TestPlayer):
         self.versus_test(opponent, expected_actions=actions)
 
 
+class TestDynamicTwoTitsForTat(TestPlayer):
+
+    name = 'Dynamic Two Tits For Tat'
+    player = axelrod.DynamicTwoTitsForTat
+    expected_classifier = {
+        'memory_depth': 2,
+        'stochastic': False,
+        'makes_use_of': set(),
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+
+    def test_strategy(self):
+        self.first_play_test(C)
+        self.second_play_test(rCC=C, rCD=D, rDC=C, rDD=D)
+
+        # Will cooperate if opponent cooperates/.
+        actions = [(C, C), (C, C), (C, C), (C, C), (C, C)]
+        self.versus_test(axelrod.Cooperator(), expected_actions=actions)
+        # Will defect twice when last turn of opponent was defection.
+        opponent = axelrod.MockPlayer(actions=[D, C, C, D, C])
+        actions = [(C, D), (D, C), (D, C), (C, D), (D, C)]
+        self.versus_test(opponent, expected_actions=actions)
+        # Test against defector
+        actions = [(C, D), (D, D), (D, D), (D, D), (D, D)]
+        self.versus_test(axelrod.Defector(), expected_actions=actions)
+
 class TestBully(TestPlayer):
 
     name = "Bully"

--- a/docs/tutorials/advanced/classification_of_strategies.rst
+++ b/docs/tutorials/advanced/classification_of_strategies.rst
@@ -69,7 +69,7 @@ range of memory_depth values, we can use the 'min_memory_depth' and
     ... }
     >>> strategies = axl.filtered_strategies(filterset)
     >>> len(strategies)
-    49
+    50
 
 We can also identify strategies that make use of particular properties of the
 tournament. For example, here is the number of strategies that  make use of the

--- a/docs/tutorials/advanced/classification_of_strategies.rst
+++ b/docs/tutorials/advanced/classification_of_strategies.rst
@@ -47,7 +47,7 @@ strategies::
     ... }
     >>> strategies = axl.filtered_strategies(filterset)
     >>> len(strategies)
-    66
+    67
 
 Or, to find out how many strategies only use 1 turn worth of memory to
 make a decision::


### PR DESCRIPTION
Adds the new strategy DynamicTwoTitsForTat, based off of the TwoTitsForTat stategy by adding a probability of forgiveness based off of the ratio of the opponent's cooperations to total moves (so their rough probability of cooperation).

Link to original request: https://github.com/Axelrod-Python/Axelrod/pull/1027