### PR TITLE
Refactor tests for player.

### DIFF
--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -163,7 +163,7 @@ class Player(object):
 
                 for _ in range(200):
                     try:
-                        if not next(generator) == next(other_generator):
+                        if next(generator) != next(other_generator):
                             return False
                     except StopIteration:
                         break

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -161,9 +161,12 @@ class Player(object):
                     setattr(other, attribute,
                             itertools.cycle(original_other_value))
 
-                if not (all(next(generator) == next(other_generator)
-                        for _ in range(200))):
-                    return False
+                for _ in range(200):
+                    try:
+                        if not next(generator) == next(other_generator):
+                            return False
+                    except StopIteration:
+                        break
 
             # Code for a strange edge case where each strategy points at each
             # other

--- a/axelrod/tests/strategies/test_player.py
+++ b/axelrod/tests/strategies/test_player.py
@@ -24,10 +24,6 @@ def cooperate(*args):
 def defect(*args):
     return D
 
-
-def randomize(*args):
-    return random.choice([C, D])
-
 # Test classifier used to create tests players
 _test_classifier = {
         'memory_depth': 0,
@@ -98,13 +94,10 @@ class TestPlayerClass(unittest.TestCase):
         self.assertEqual(player2.state_distribution, {(D, C): 2})
 
     def test_state_distribution(self):
-        player1, player2 = self.player(), self.player()
-        player1.strategy = randomize
-        player2.strategy = randomize
-        history_1 = [C, C, D, D, C]
-        history_2 = [C, D, C, D, D]
-        for h1, h2 in zip(history_1, history_2):
-            simulate_play(player1, player2, h1, h2)
+        player1 = axelrod.MockPlayer([C, C, D, D, C])
+        player2 = axelrod.MockPlayer([C, D, C, D, D])
+        match = axelrod.Match((player1, player2), turns=5)
+        _ = match.play()
         self.assertEqual(player1.state_distribution,
                          {(C, C): 1, (C, D): 2, (D, C): 1, (D, D): 1})
         self.assertEqual(player2.state_distribution,


### PR DESCRIPTION
This is a minor refactor of some warnings that were occurring:

- A `simulate_play` that was using a fake history;
- A warning from the generator equality

The change to the way the generator equality was being run is based on
this error:

```
.........../home/vince/src/Axelrod/axelrod/player.py:165:
PendingDeprecationWarning: generator 'Player.__eq__.<locals>.<genexpr>'
raised StopIteration
  for _ in range(200))):
```

Addresses #884