### PR TITLE
Reconcile Moran processes

### DIFF
--- a/axelrod/__init__.py
+++ b/axelrod/__init__.py
@@ -16,7 +16,7 @@ from .player import (
     update_history, update_state_distribution, Player)
 from .mock_player import MockPlayer
 from .match import Match
-from .moran import MoranProcess, MoranProcessGraph, ApproximateMoranProcess
+from .moran import MoranProcess, ApproximateMoranProcess
 from .strategies import *
 from .deterministic_cache import DeterministicCache
 from .match_generator import *

--- a/axelrod/graph.py
+++ b/axelrod/graph.py
@@ -47,6 +47,12 @@ class Graph(object):
         for edge in edges:
             self.add_edge(*edge)
 
+    def add_loops(self):
+        """
+        Add all loops to edges
+        """
+        self.add_edges((i, i) for i, _ in enumerate(self.vertices()))
+
     def edges(self):
         return self._edges
 
@@ -116,13 +122,14 @@ def complete_graph(length, loops=True):
     -------
     a Graph object
     """
-    offset = 1
-    if loops:
-        offset = 0
     graph = Graph(directed=False)
     edges = []
     for i in range(length):
-        for j in range(i + offset, length):
+        for j in range(i + 1, length):
             edges.append((i, j))
     graph.add_edges(edges)
+
+    if loops:
+        graph.add_loops()
+
     return graph

--- a/axelrod/moran.py
+++ b/axelrod/moran.py
@@ -136,8 +136,8 @@ class MoranProcess(object):
         self.interaction_graph = interaction_graph
         self.reproduction_graph = reproduction_graph
         # Map players to graph vertices
-        self.locations = list(interaction_graph.vertices())
-        self.index = dict(zip(interaction_graph.vertices(),
+        self.locations = sorted(interaction_graph.vertices())
+        self.index = dict(zip(sorted(interaction_graph.vertices()),
                               range(len(players))))
 
     def set_players(self) -> None:
@@ -190,7 +190,7 @@ class MoranProcess(object):
             # Select locally
             # index is not None in this case
             vertex = random.choice(
-                self.reproduction_graph.out_vertices(self.locations[index]))
+                sorted(self.reproduction_graph.out_vertices(self.locations[index])))
             i = self.index[vertex]
         return i
 
@@ -290,12 +290,12 @@ class MoranProcess(object):
         if self.mode == "db":
             source = self.index[self.dead]
             self.dead = None
-            sources = self.interaction_graph.out_vertices(source)
+            sources = sorted(self.interaction_graph.out_vertices(source))
         else:
             # birth-death is global
-            sources = self.locations
+            sources = sorted(self.locations)
         for i, source in enumerate(sources):
-            for target in self.interaction_graph.out_vertices(source):
+            for target in sorted(self.interaction_graph.out_vertices(source)):
                 j = self.index[target]
                 if (self.players[i] is None) or (self.players[j] is None):
                     continue

--- a/axelrod/moran.py
+++ b/axelrod/moran.py
@@ -4,6 +4,7 @@ import random
 import numpy as np
 
 from axelrod import DEFAULT_TURNS
+from .graph import complete_graph
 from .deterministic_cache import DeterministicCache
 from .match import Match
 from .random_ import randrange
@@ -31,9 +32,10 @@ def fitness_proportionate_selection(scores):
 
 
 class MoranProcess(object):
-    def __init__(self, players, turns=DEFAULT_TURNS, noise=0,
+    def __init__(self, players, turns=DEFAULT_TURNS, prob_end=None, noise=0,
                  deterministic_cache=None, mutation_rate=0., mode='bd',
-                 match_class=Match):
+                 match_class=Match, interaction_graph=None,
+                 reproduction_graph=None):
         """
         An agent based Moran process class. In each round, each player plays a
         Match with each other player. Players are assigned a fitness score by
@@ -51,11 +53,21 @@ class MoranProcess(object):
         population. This is not the only method yet emulates the common method
         in the literature.
 
+		It is possible to pass interaction graphs and reproduction graphs to the
+        Moran process. In this case, in each round, each player plays a
+        Match with each neighboring player according to the interaction graph.
+        Players are assigned a fitness score by their total score from all
+        matches in the round. A player is chosen to reproduce proportionally to
+        fitness, possibly mutated, and is cloned. The clone replaces a randomly
+        chosen neighboring player according to the reproduction graph.
+
         Parameters
         ----------
         players, iterable of axelrod.Player subclasses
         turns: int, 100
             The number of turns in each pairwise interaction
+        prob_end : float
+            The probability of a given turn ending a match
         noise: float, 0
             The background noise, if any. Randomly flips plays with probability
             `noise`.
@@ -68,9 +80,15 @@ class MoranProcess(object):
             Birth-Death (bd) or Death-Birth (db)
         match_class: subclass of Match
             The match type to use for scoring
+        interaction_graph: Axelrod.graph.Graph
+            The graph in which the replicators are arranged
+        reproduction_graph: Axelrod.graph.Graph
+            The reproduction graph, set equal to the interaction graph if not
+            given
         """
         self.match_class = match_class
         self.turns = turns
+        self.prob_end = prob_end
         self.noise = noise
         self.initial_players = players  # save initial population
         self.players = []
@@ -101,6 +119,23 @@ class MoranProcess(object):
             mutation_targets[key] = [v for (k, v) in sorted(d.items()) if k != key]
         self.mutation_targets = mutation_targets
 
+        if interaction_graph is None:
+            interaction_graph = complete_graph(len(players), loops=False)
+            if reproduction_graph is None:
+                reproduction_graph = complete_graph(len(players))
+        if reproduction_graph is None:
+            reproduction_graph = interaction_graph
+        # Check equal vertices
+        v1 = interaction_graph.vertices()
+        v2 = reproduction_graph.vertices()
+        assert list(v1) == list(v2)
+        self.interaction_graph = interaction_graph
+        self.reproduction_graph = reproduction_graph
+        # Map players to graph vertices
+        self.locations = list(interaction_graph.vertices())
+        self.index = dict(zip(interaction_graph.vertices(),
+                              range(len(players))))
+
     def set_players(self):
         """Copy the initial players into the first population."""
         self.players = []
@@ -124,14 +159,20 @@ class MoranProcess(object):
         return new_player
 
     def death(self, index=None):
-        """Selects the player to be removed. Note that the in the birth-death
-        case, the player that is reproducing may also be replaced. However in
-        the death-birth case, this player will be excluded from the choices.
-
-        `index` is unused here but is needed in the graph case.
-        """
-        i = randrange(0, len(self.players))
+        """Selects the player to be removed."""
+        if self.mode == "db":
+            # Select a player to be replaced globally
+            i = randrange(0, len(self.players))
+            # Record internally for use in _matchup_indices
+            self.dead = i
+        else:
+            # Select locally
+            # index is not None in this case
+            vertex = random.choice(
+                self.reproduction_graph.out_vertices(self.locations[index]))
+            i = self.index[vertex]
         return i
+
 
     def birth(self, index=None):
         """The birth event."""
@@ -193,16 +234,26 @@ class MoranProcess(object):
         return self
 
     def _matchup_indices(self):
-        """Generate the matchup pairs."""
-        indices = []
-        N = len(self.players)
-        for i in range(N):
-            for j in range(i + 1, N):
-                # For the death-birth mode the dead player is marked None
-                # so skip those
+        """Generate the matchup pairs"""
+        indices = set()
+        # For death-birth we only want the neighbors of the dead node
+        # The other calculations are unnecessary
+        if self.mode == "db":
+            source = self.index[self.dead]
+            self.dead = None
+            sources = self.interaction_graph.out_vertices(source)
+        else:
+            # birth-death is global
+            sources = self.locations
+        for i, source in enumerate(sources):
+            for target in self.interaction_graph.out_vertices(source):
+                j = self.index[target]
                 if (self.players[i] is None) or (self.players[j] is None):
                     continue
-                indices.append((i, j))
+                # Don't duplicate matches
+                if ((i, j) in indices) or ((j, i) in indices):
+                    continue
+                indices.add((i, j))
         return indices
 
     def score_all(self):
@@ -214,7 +265,8 @@ class MoranProcess(object):
             player1 = self.players[i]
             player2 = self.players[j]
             match = self.match_class(
-                (player1, player2), turns=self.turns, noise=self.noise,
+                (player1, player2), turns=self.turns, prob_end=self.prob_end,
+                noise=self.noise,
                 deterministic_cache=self.deterministic_cache)
             match.play()
             match_scores = match.final_score_per_turn()
@@ -252,133 +304,6 @@ class MoranProcess(object):
 
     def __len__(self):
         return len(self.populations)
-
-
-class MoranProcessGraph(MoranProcess):
-    def __init__(self, players, interaction_graph, reproduction_graph=None,
-                 turns=100, noise=0, deterministic_cache=None,
-                 mutation_rate=0., mode='bd', match_class=Match):
-        """
-        An agent based Moran process class. In each round, each player plays a
-        Match with each neighboring player according to the interaction graph.
-        Players are assigned a fitness score by their total score from all
-        matches in the round. A player is chosen to reproduce proportionally to
-        fitness, possibly mutated, and is cloned. The clone replaces a randomly
-        chosen neighboring player according to the reproduction graph.
-
-        If the mutation_rate is 0, the population will eventually fixate on
-        exactly one player type. In this case a StopIteration exception is
-        raised and the play stops. If mutation_rate is not zero, then the
-        process will iterate indefinitely, so mp.play() will never exit, and
-        you should use the class as an iterator instead.
-
-        When a player mutates it chooses a random player type from the initial
-        population. This is not the only method yet emulates the common method
-        in the literature.
-
-        Note: the weighted graph case is not yet implemented, nor is birth-bias,
-        death-bias, or Link Dynamics updating; however the most common use cases
-        are implemented.
-
-        See [Shakarian2013]_ for more detail on the process and different
-        updating modes.
-
-        Parameters
-        ----------
-        players, iterable of axelrod.Player subclasses
-        interaction_graph: Axelrod.graph.Graph
-            The graph in which the replicators are arranged
-        reproduction_graph: Axelrod.graph.Graph
-            The reproduction graph, set equal to the interaction graph if not
-            given
-        turns: int, 100
-            The number of turns in each pairwise interaction
-        noise: float, 0
-            The background noise, if any. Randomly flips plays with probability
-            `noise`.
-        deterministic_cache: axelrod.DeterministicCache, None
-            A optional prebuilt deterministic cache
-        mutation_rate: float, 0
-            The rate of mutation. Replicating players are mutated with
-            probability `mutation_rate`
-        mode: string, bd
-            Birth-Death (bd) or Death-Birth (db)
-        match_class: subclass of Match
-            The match type to use for scoring
-        """
-        super().__init__(players, turns=turns, noise=noise,
-                              deterministic_cache=deterministic_cache,
-                              mutation_rate=mutation_rate, mode=mode)
-        if not reproduction_graph:
-            reproduction_graph = interaction_graph
-        # Check equal vertices
-        v1 = interaction_graph.vertices()
-        v2 = reproduction_graph.vertices()
-        assert list(v1) == list(v2)
-        self.interaction_graph = interaction_graph
-        self.reproduction_graph = reproduction_graph
-        # Map players to graph vertices
-        self.locations = list(interaction_graph.vertices())
-        self.index = dict(zip(interaction_graph.vertices(),
-                              range(len(players))))
-
-    def birth(self, index=None):
-        """Compute the birth index."""
-        scores = self.score_all()
-        if index:
-            # Death-birth case
-            scores.pop(index)
-            # Make sure to get the correct index post-pop
-            j = fitness_proportionate_selection(scores)
-            if j >= index:
-                j += 1
-        else:
-            j = fitness_proportionate_selection(scores)
-        return j
-
-    def death(self, index=None):
-        """Selects the player to be removed."""
-        if self.mode == "db":
-            # Select a player to be replaced globally
-            i = randrange(0, len(self.players))
-            # Record internally for use in _matchup_indices
-            self.dead = i
-        else:
-            # Select locally
-            # index is not None in this case
-            vertex = random.choice(
-                self.reproduction_graph.out_vertices(self.locations[index]))
-            i = self.index[vertex]
-        return i
-
-    def _matchup_indices(self):
-        """Generate the matchup pairs"""
-        indices = set()
-        # For death-birth we only want the neighbors of the dead node
-        # The other calculations are unnecessary
-        if self.mode == "db":
-            source = self.index[self.dead]
-            self.dead = None
-            sources = self.interaction_graph.out_vertices(source)
-        else:
-            # birth-death is global
-            sources = self.locations
-        for i, source in enumerate(sources):
-            for target in self.interaction_graph.out_vertices(source):
-                j = self.index[target]
-                if (self.players[i] is None) or (self.players[j] is None):
-                    continue
-                # Don't duplicate matches
-                if ((i, j) in indices) or ((j, i) in indices):
-                    continue
-                indices.add((i, j))
-        return indices
-
-    def population_distribution(self):
-        """Returns the population distribution of the last iteration."""
-        player_names = [str(player) for player in self.players]
-        counter = Counter(player_names)
-        return counter
 
 
 class ApproximateMoranProcess(MoranProcess):

--- a/axelrod/moran.py
+++ b/axelrod/moran.py
@@ -1,18 +1,18 @@
+"""Implementation of the Moran process on Graphs."""
+
 from collections import Counter
 import random
 
 import numpy as np
 
-from axelrod import DEFAULT_TURNS
-from axelrod import Match
-from axelrod import Player
-from .graph import complete_graph, Graph
+from axelrod import DEFAULT_TURNS, Player
 from .deterministic_cache import DeterministicCache
+from .graph import complete_graph, Graph
 from .match import Match
 from .random_ import randrange
-import copy
 
 from typing import List, Tuple, Set
+
 
 def fitness_proportionate_selection(scores: List) -> int:
     """Randomly selects an individual proportionally to score.
@@ -60,7 +60,7 @@ class MoranProcess(object):
         population. This is not the only method yet emulates the common method
         in the literature.
 
-		It is possible to pass interaction graphs and reproduction graphs to the
+        It is possible to pass interaction graphs and reproduction graphs to the
         Moran process. In this case, in each round, each player plays a
         Match with each neighboring player according to the interaction graph.
         Players are assigned a fitness score by their total score from all
@@ -85,8 +85,6 @@ class MoranProcess(object):
             probability `mutation_rate`
         mode:
             Birth-Death (bd) or Death-Birth (db)
-        match_class: subclass of Match
-            The match type to use for scoring
         interaction_graph: Axelrod.graph.Graph
             The graph in which the replicators are arranged
         reproduction_graph: Axelrod.graph.Graph
@@ -174,9 +172,9 @@ class MoranProcess(object):
         """
         Selects the player to be removed.
 
-		Note that the in the birth-death
-        case, the player that is reproducing may also be replaced. However in
-        the death-birth case, this player will be excluded from the choices.
+        Note that the in the birth-death case, the player that is reproducing
+        may also be replaced. However in the death-birth case, this player will
+        be excluded from the choices.
 
         Parameters
         ----------
@@ -278,7 +276,7 @@ class MoranProcess(object):
 
     def _matchup_indices(self) -> Set[Tuple[int, int]]:
         """
-        Generate the matchup pairs
+        Generate the matchup pairs.
 
         Returns
         -------
@@ -370,7 +368,9 @@ class MoranProcess(object):
             Returns a list of all the populations
         """
         if self.mutation_rate != 0:
-            raise ValueError("MoranProcess.play() will never exit if mutation_rate is nonzero")
+            raise ValueError(
+                "MoranProcess.play() will never exit if mutation_rate is"
+                "nonzero. Use iteration instead.")
         while True:
             try:
                 self.__next__()

--- a/axelrod/tests/unit/test_graph.py
+++ b/axelrod/tests/unit/test_graph.py
@@ -86,6 +86,15 @@ class TestGraph(unittest.TestCase):
             self.assertEqual(g.in_mapping[node], expected_in_mapping[node])
         self.assertEqual(g._edges, expected_edges)
 
+    def test_add_loops(self):
+        edges = [(0, 1), (0, 2), (1, 2)]
+        g = graph.Graph(edges)
+        g.add_loops()
+        self.assertEqual(g._edges,
+                         [(0, 1), (1, 0), (0, 2), (2, 0), (1, 2),
+                          (2, 1), (0, 0), (1, 1), (2, 2)])
+
+
     def test_out_dict(self):
         # Undirected graph with vertices and unweighted edges
         g = graph.Graph(edges=[[1, 2], [2, 3]])
@@ -217,11 +226,13 @@ class TestGraph(unittest.TestCase):
         self.assertEqual(g.vertices(), [0, 1])
         self.assertEqual(g.edges(), [(0, 1), (1, 0)])
         self.assertEqual(g.directed, False)
+
         g = graph.complete_graph(3, loops=False)
         self.assertEqual(g.vertices(), [0, 1, 2])
         edges = [(0, 1), (1, 0), (0, 2), (2, 0), (1, 2), (2, 1)]
         self.assertEqual(g.edges(), edges)
         self.assertEqual(g.directed, False)
+
         g = graph.complete_graph(4, loops=False )
         self.assertEqual(g.vertices(), [0, 1, 2, 3])
         edges = [(0, 1), (1, 0), (0, 2), (2, 0), (0, 3), (3, 0),
@@ -238,19 +249,18 @@ class TestGraph(unittest.TestCase):
     def test_complete_with_loops(self):
         g = graph.complete_graph(2, loops=True)
         self.assertEqual(g.vertices(), [0, 1])
-        self.assertEqual(g.edges(), [(0, 0), (0, 1), (1, 0), (1, 1)])
+        self.assertEqual(g.edges(), [(0, 1), (1, 0), (0, 0), (1, 1)])
         self.assertEqual(g.directed, False)
         g = graph.complete_graph(3, loops=True)
         self.assertEqual(g.vertices(), [0, 1, 2])
-        edges = [(0, 0), (0, 1), (1, 0), (0, 2), (2, 0), (1, 1),
-                 (1, 2), (2, 1), (2, 2)]
+        edges = [(0, 1), (1, 0), (0, 2), (2, 0),
+                 (1, 2), (2, 1), (0, 0), (1, 1), (2, 2)]
         self.assertEqual(g.edges(), edges)
         self.assertEqual(g.directed, False)
         g = graph.complete_graph(4, loops=True)
         self.assertEqual(g.vertices(), [0, 1, 2, 3])
-        edges = [(0, 0), (0, 1), (1, 0), (0, 2), (2, 0), (0, 3), (3, 0),
-                  (1, 1), (1, 2), (2, 1), (1, 3), (3, 1),
-                  (2, 2), (2, 3), (3, 2), (3, 3)]
+        edges = [(0, 1), (1, 0), (0, 2), (2, 0), (0, 3), (3, 0), (1, 2), (2, 1),
+                 (1, 3), (3, 1), (2, 3), (3, 2), (0, 0), (1, 1), (2, 2), (3, 3)]
         self.assertEqual(g.edges(), edges)
         self.assertEqual(g.directed, False)
         neighbors = range(4)

--- a/axelrod/tests/unit/test_moran.py
+++ b/axelrod/tests/unit/test_moran.py
@@ -6,10 +6,11 @@ import unittest
 from hypothesis import given, example, settings
 
 import axelrod
-from axelrod import (Match, MoranProcess,
-                     ApproximateMoranProcess, Pdf)
+from axelrod import Match, MoranProcess, ApproximateMoranProcess, Pdf
 from axelrod.moran import fitness_proportionate_selection
 from axelrod.tests.property import strategy_lists
+
+C, D = axelrod.Actions.C, axelrod.Actions.D
 
 
 class TestMoranProcess(unittest.TestCase):
@@ -297,6 +298,21 @@ class TestMoranProcess(unittest.TestCase):
         # Check that players reset
         for player, initial_player in zip(mp.players, mp.initial_players):
             self.assertEqual(str(player), str(initial_player))
+
+    def test_constant_fitness_case(self):
+        # Scores between an Alternator and Defector will be: (1,  6)
+        axelrod.seed(0)
+        players = (axelrod.Alternator(), axelrod.Alternator(),
+                   axelrod.Defector(), axelrod.Defector())
+        mp = MoranProcess(players, turns=2)
+        winners = []
+        for _ in range(100):
+            mp.play()
+            winners.append(mp.winning_strategy_name)
+            mp.reset()
+        winners = Counter(winners)
+        self.assertEqual(winners["Defector"], 88)
+
 
     def test_cache(self):
         p1, p2 = axelrod.Cooperator(), axelrod.Defector()

--- a/axelrod/tests/unit/test_moran.py
+++ b/axelrod/tests/unit/test_moran.py
@@ -121,9 +121,9 @@ class TestMoranProcess(unittest.TestCase):
         self.assertIsInstance(next(mp), MoranProcess)
 
     def test_matchup_indices(self):
-        players = axelrod.Cooperator(), axelrod.Defector()
-        mp = MoranProcess(players)
-        self.assertEqual(mp._matchup_indices(), {(0, 1)})
+        # players = axelrod.Cooperator(), axelrod.Defector()
+        # mp = MoranProcess(players)
+        # self.assertEqual(mp._matchup_indices(), {(0, 1)})
 
         players = axelrod.Cooperator(), axelrod.Defector(), axelrod.TitForTat()
         edges = [(0, 1), (2, 0), (1, 2)]

--- a/axelrod/tests/unit/test_moran.py
+++ b/axelrod/tests/unit/test_moran.py
@@ -122,9 +122,9 @@ class TestMoranProcess(unittest.TestCase):
         self.assertIsInstance(next(mp), MoranProcess)
 
     def test_matchup_indices(self):
-        # players = axelrod.Cooperator(), axelrod.Defector()
-        # mp = MoranProcess(players)
-        # self.assertEqual(mp._matchup_indices(), {(0, 1)})
+        players = axelrod.Cooperator(), axelrod.Defector()
+        mp = MoranProcess(players)
+        self.assertEqual(mp._matchup_indices(), {(0, 1)})
 
         players = axelrod.Cooperator(), axelrod.Defector(), axelrod.TitForTat()
         edges = [(0, 1), (2, 0), (1, 2)]

--- a/axelrod/tests/unit/test_moran.py
+++ b/axelrod/tests/unit/test_moran.py
@@ -12,28 +12,128 @@ from axelrod.moran import fitness_proportionate_selection
 from axelrod.tests.property import strategy_lists
 
 
-class MockMatch(object):
-    """Mock Match class to always return the same score for testing purposes."""
-
-    def __init__(self, players, *args, **kwargs):
-        self.players = players
-        score_dict = {"Cooperator": 2, "Defector": 1}
-        self.score_dict = score_dict
-
-    def play(self):
-        pass
-
-    def final_score_per_turn(self):
-        s = (self.score_dict[str(self.players[0])],
-             self.score_dict[str(self.players[1])])
-        return s
-
-
 class TestMoranProcess(unittest.TestCase):
+
+    def test_init(self):
+        players = axelrod.Cooperator(), axelrod.Defector()
+        mp = MoranProcess(players)
+        self.assertEqual(mp.turns, axelrod.DEFAULT_TURNS)
+        self.assertIsNone(mp.prob_end)
+        self.assertEqual(mp.noise, 0)
+        self.assertEqual(mp.initial_players, players)
+        self.assertEqual(mp.players, list(players))
+        self.assertEqual(mp.populations,
+                         [Counter({'Cooperator': 1, 'Defector': 1})])
+        self.assertIsNone(mp.winning_strategy_name)
+        self.assertEqual(mp.mutation_rate, 0)
+        self.assertEqual(mp.mode, 'bd')
+        self.assertEqual(mp.deterministic_cache, axelrod.DeterministicCache())
+        self.assertEqual(mp.mutation_targets,
+                         {'Cooperator': [players[1]], 'Defector': [players[0]]})
+        self.assertEqual(mp.interaction_graph._edges, [(0, 1), (1, 0)])
+        self.assertEqual(mp.reproduction_graph._edges,
+                         [(0, 1), (1, 0), (0, 0), (1, 1)])
+        self.assertEqual(mp.locations, [0, 1])
+        self.assertEqual(mp.index, {0: 0, 1: 1})
+
+        # Test non default graph cases
+        players = axelrod.Cooperator(), axelrod.Defector(), axelrod.TitForTat()
+        edges = [(0, 1), (2, 0), (1, 2)]
+        graph = axelrod.graph.Graph(edges, directed=True)
+        mp = MoranProcess(players, interaction_graph=graph)
+        self.assertEqual(mp.interaction_graph._edges, [(0, 1), (2, 0), (1, 2)])
+        self.assertEqual(mp.reproduction_graph._edges,
+                         [(0, 1), (2, 0), (1, 2), (0, 0), (1, 1), (2, 2)])
+
+        mp = MoranProcess(players, interaction_graph=graph,
+                          reproduction_graph=graph)
+        self.assertEqual(mp.interaction_graph._edges, [(0, 1), (2, 0), (1, 2)])
+        self.assertEqual(mp.reproduction_graph._edges, [(0, 1), (2, 0), (1, 2)])
+
+    def test_set_players(self):
+        """Test that set players resets all players"""
+        players = axelrod.Cooperator(), axelrod.Defector()
+        mp = MoranProcess(players)
+        players[0].cooperations += 1
+        mp.set_players()
+        self.assertEqual(players[0].cooperations, 0)
+
+    def test_mutate(self):
+        """Test that a mutated player is returned"""
+        players = axelrod.Cooperator(), axelrod.Defector(), axelrod.TitForTat()
+        mp = MoranProcess(players, mutation_rate=0.5)
+        axelrod.seed(0)
+        self.assertEqual(mp.mutate(0), players[0])
+        axelrod.seed(1)
+        self.assertEqual(mp.mutate(0), players[2])
+        axelrod.seed(4)
+        self.assertEqual(mp.mutate(0), players[1])
+
+    def test_death_in_db(self):
+        players = axelrod.Cooperator(), axelrod.Defector(), axelrod.TitForTat()
+        mp = MoranProcess(players, mutation_rate=0.5, mode="db")
+        axelrod.seed(1)
+        self.assertEqual(mp.death(0), 0)
+        self.assertEqual(mp.dead, 0)
+        axelrod.seed(5)
+        self.assertEqual(mp.death(0), 1)
+        self.assertEqual(mp.dead, 1)
+        axelrod.seed(2)
+        self.assertEqual(mp.death(0), 2)
+        self.assertEqual(mp.dead, 2)
+
+    def test_death_in_bd(self):
+        players = axelrod.Cooperator(), axelrod.Defector(), axelrod.TitForTat()
+        edges = [(0, 1), (2, 0), (1, 2)]
+        graph = axelrod.graph.Graph(edges, directed=True)
+        mp = MoranProcess(players, mode="bd", interaction_graph=graph)
+        axelrod.seed(1)
+        self.assertEqual(mp.death(0), 0)
+        axelrod.seed(5)
+        self.assertEqual(mp.death(0), 1)
+        axelrod.seed(2)
+        self.assertEqual(mp.death(0), 0)
+
+    def test_birth_in_db(self):
+        players = axelrod.Cooperator(), axelrod.Defector(), axelrod.TitForTat()
+        mp = MoranProcess(players, mode="db")
+        axelrod.seed(1)
+        self.assertEqual(mp.death(0), 0)
+        self.assertEqual(mp.birth(0), 2)
+
+    def test_birth_in_bd(self):
+        players = axelrod.Cooperator(), axelrod.Defector(), axelrod.TitForTat()
+        mp = MoranProcess(players, mode="bd")
+        axelrod.seed(1)
+        self.assertEqual(mp.birth(0), 0)
+
+    def test_fixation_check(self):
+        players = axelrod.Cooperator(), axelrod.Cooperator()
+        mp = MoranProcess(players)
+        self.assertTrue(mp.fixation_check())
+        players = axelrod.Cooperator(), axelrod.Defector()
+        mp = MoranProcess(players)
+        self.assertFalse(mp.fixation_check())
+
+    def test_next(self):
+        players = axelrod.Cooperator(), axelrod.Defector()
+        mp = MoranProcess(players)
+        self.assertIsInstance(next(mp), MoranProcess)
+
+    def test_matchup_indices(self):
+        players = axelrod.Cooperator(), axelrod.Defector()
+        mp = MoranProcess(players)
+        self.assertEqual(mp._matchup_indices(), {(0, 1)})
+
+        players = axelrod.Cooperator(), axelrod.Defector(), axelrod.TitForTat()
+        edges = [(0, 1), (2, 0), (1, 2)]
+        graph = axelrod.graph.Graph(edges, directed=True)
+        mp = MoranProcess(players, mode="bd", interaction_graph=graph)
+        self.assertEqual(mp._matchup_indices(), {(0, 1), (1, 2), (2, 0)})
 
     def test_fps(self):
         self.assertEqual(fitness_proportionate_selection([0, 0, 1]), 2)
-        random.seed(1)
+        axelrod.seed(1)
         self.assertEqual(fitness_proportionate_selection([1, 1, 1]), 0)
         self.assertEqual(fitness_proportionate_selection([1, 1, 1]), 2)
 
@@ -45,7 +145,7 @@ class TestMoranProcess(unittest.TestCase):
 
     def test_two_players(self):
         p1, p2 = axelrod.Cooperator(), axelrod.Defector()
-        random.seed(17)
+        axelrod.seed(17)
         mp = MoranProcess((p1, p2))
         populations = mp.play()
         self.assertEqual(len(mp), 5)
@@ -55,7 +155,7 @@ class TestMoranProcess(unittest.TestCase):
 
     def test_two_prob_end(self):
         p1, p2 = axelrod.Random(), axelrod.TitForTat()
-        random.seed(0)
+        axelrod.seed(0)
         mp = MoranProcess((p1, p2), prob_end=.5)
         populations = mp.play()
         self.assertEqual(len(mp), 4)
@@ -68,7 +168,7 @@ class TestMoranProcess(unittest.TestCase):
         p1, p2 = axelrod.Cooperator(), axelrod.Defector()
         seeds = range(0, 20)
         for seed in seeds:
-            random.seed(seed)
+            axelrod.seed(seed)
             mp = MoranProcess((p1, p2), mode='db')
             next(mp)
             self.assertIsNotNone(mp.winning_strategy_name)
@@ -95,7 +195,7 @@ class TestMoranProcess(unittest.TestCase):
 
     def test_two_random_players(self):
         p1, p2 = axelrod.Random(p=0.5), axelrod.Random(p=0.25)
-        random.seed(0)
+        axelrod.seed(0)
         mp = MoranProcess((p1, p2))
         populations = mp.play()
         self.assertEqual(len(mp), 2)
@@ -105,7 +205,7 @@ class TestMoranProcess(unittest.TestCase):
 
     def test_two_players_with_mutation(self):
         p1, p2 = axelrod.Cooperator(), axelrod.Defector()
-        random.seed(5)
+        axelrod.seed(5)
         mp = MoranProcess((p1, p2), mutation_rate=0.2)
         self.assertDictEqual(mp.mutation_targets,
                              {str(p1): [p2], str(p2): [p1]})
@@ -131,7 +231,7 @@ class TestMoranProcess(unittest.TestCase):
     def test_three_players(self):
         players = [axelrod.Cooperator(), axelrod.Cooperator(),
                    axelrod.Defector()]
-        random.seed(11)
+        axelrod.seed(11)
         mp = MoranProcess(players)
         populations = mp.play()
         self.assertEqual(len(mp), 7)
@@ -161,7 +261,7 @@ class TestMoranProcess(unittest.TestCase):
     def test_four_players(self):
         players = [axelrod.Cooperator() for _ in range(3)]
         players.append(axelrod.Defector())
-        random.seed(29)
+        axelrod.seed(29)
         mp = MoranProcess(players)
         populations = mp.play()
         self.assertEqual(len(mp), 9)
@@ -169,38 +269,23 @@ class TestMoranProcess(unittest.TestCase):
         self.assertEqual(populations, mp.populations)
         self.assertEqual(mp.winning_strategy_name, str(axelrod.Defector()))
 
-    def test_standard_fixation(self):
-        """Test a traditional Moran process with a MockMatch."""
-        axelrod.seed(0)
-        players = (axelrod.Cooperator(), axelrod.Cooperator(),
-                   axelrod.Defector(), axelrod.Defector())
-        mp = MoranProcess(players, match_class=MockMatch)
-        winners = []
-        for i in range(100):
-            mp.play()
-            winner = mp.winning_strategy_name
-            winners.append(winner)
-            mp.reset()
-        winners = Counter(winners)
-        self.assertEqual(winners["Cooperator"], 73)
+    @given(strategies=strategy_lists(min_size=2, max_size=4))
+    @settings(max_examples=5, timeout=0)  # Very low number of examples
 
-    # @given(strategies=strategy_lists(min_size=2, max_size=5))
-    # @settings(max_examples=5, timeout=0)  # Very low number of examples
-
-    # # Two specific examples relating to cloning of strategies
-    # @example(strategies=[axelrod.BackStabber, axelrod.MindReader])
-    # @example(strategies=[axelrod.ThueMorse, axelrod.MindReader])
-    # def test_property_players(self, strategies):
-        # """Hypothesis test that randomly checks players"""
-        # players = [s() for s in strategies]
-        # mp = MoranProcess(players)
-        # populations = mp.play()
-        # self.assertEqual(populations, mp.populations)
-        # self.assertIn(mp.winning_strategy_name, [str(p) for p in players])
+    # Two specific examples relating to cloning of strategies
+    @example(strategies=[axelrod.BackStabber, axelrod.MindReader])
+    @example(strategies=[axelrod.ThueMorse, axelrod.MindReader])
+    def test_property_players(self, strategies):
+        """Hypothesis test that randomly checks players"""
+        players = [s() for s in strategies]
+        mp = MoranProcess(players)
+        populations = mp.play()
+        self.assertEqual(populations, mp.populations)
+        self.assertIn(mp.winning_strategy_name, [str(p) for p in players])
 
     def test_reset(self):
         p1, p2 = axelrod.Cooperator(), axelrod.Defector()
-        random.seed(45)
+        axelrod.seed(45)
         mp = MoranProcess((p1, p2))
         mp.play()
         self.assertEqual(len(mp), 4)
@@ -352,8 +437,8 @@ class TestApproximateMoranProcess(unittest.TestCase):
         self.assertEqual(self.amp.turns, 0)
         self.assertEqual(self.amp.noise, 0)
 
-    def test_next(self):
-        """Test the next function of the Moran process"""
+    def test_score_all(self):
+        """Test the score_all function of the Moran process"""
         scores = self.amp.score_all()
         self.assertEqual(scores, [0, 5])
         scores = self.amp.score_all()

--- a/docs/tutorials/further_topics/moran_processes_on_graphs.rst
+++ b/docs/tutorials/further_topics/moran_processes_on_graphs.rst
@@ -4,7 +4,7 @@ Moran Process on Graphs
 =======================
 
 The library also provides a graph-based Moran process [Shakarian2013]_ with
-:code:`MoranProcessGraph`.  To use this class you must supply at least one
+:code:`MoranProcess`.  To use this class you must supply at least one
 :code:`Axelrod.graph.Graph` object, which can be initialized with just a list of
 edges::
 
@@ -34,10 +34,12 @@ To create a graph-based Moran process, use a graph as follows::
     >>> edges = [(0, 1), (1, 2), (2, 3), (3, 1)]
     >>> graph = Graph(edges)
     >>> players = [axl.Cooperator(), axl.Cooperator(), axl.Cooperator(), axl.Defector()]
-    >>> mp = axl.MoranProcessGraph(players, interaction_graph=graph)
+    >>> mp = axl.MoranProcess(players, interaction_graph=graph)
     >>> results = mp.play()
     >>> mp.population_distribution()
     Counter({'Cooperator': 4})
 
-You can supply the `reproduction_graph` as a keyword argument. The standard Moran
-process is equivalent to using a complete graph for both graphs.
+You can supply the :code:`reproduction_graph` as a keyword argument. The
+standard Moran process is equivalent to using a complete graph with no loops
+for the :code:`interaction_graph` and with loops for the
+:code:`reproduction_graph`.

--- a/docs/tutorials/further_topics/moran_processes_on_graphs.rst
+++ b/docs/tutorials/further_topics/moran_processes_on_graphs.rst
@@ -4,7 +4,7 @@ Moran Process on Graphs
 =======================
 
 The library also provides a graph-based Moran process [Shakarian2013]_ with
-:code:`MoranProcess`.  To use this class you must supply at least one
+:code:`MoranProcess`.  To use this feature you must supply at least one
 :code:`Axelrod.graph.Graph` object, which can be initialized with just a list of
 edges::
 
@@ -17,8 +17,9 @@ The nodes can be any hashable object (integers, strings, etc.). For example::
     >>> edges = [(0, 1), (1, 2), (2, 3), (3, 1)]
     >>> graph = Graph(edges)
 
-Graphs are undirected by default. Various intermediates such as the list of
-neighbors are cached for efficiency by the graph object.
+Graphs are undirected by default but you can pass :code:`directed=True` to
+create a directed graph.. Various intermediates such as the list of neighbors
+are cached for efficiency by the graph object.
 
 A Moran process can be invoked with one or two graphs. The first graph, the
 *interaction graph*, dictates how players are matched up in the scoring phase.

--- a/docs/tutorials/further_topics/moran_processes_on_graphs.rst
+++ b/docs/tutorials/further_topics/moran_processes_on_graphs.rst
@@ -18,7 +18,7 @@ The nodes can be any hashable object (integers, strings, etc.). For example::
     >>> graph = Graph(edges)
 
 Graphs are undirected by default but you can pass :code:`directed=True` to
-create a directed graph.. Various intermediates such as the list of neighbors
+create a directed graph. Various intermediates such as the list of neighbors
 are cached for efficiency by the graph object.
 
 A Moran process can be invoked with one or two graphs. The first graph, the

--- a/docs/tutorials/getting_started/moran.rst
+++ b/docs/tutorials/getting_started/moran.rst
@@ -28,31 +28,34 @@ the library, proceed as follows::
     >>> mp = axl.MoranProcess(players)
     >>> populations = mp.play()
     >>> mp.winning_strategy_name
-    'Grudger'
+    'Defector'
 
 You can access some attributes of the process, such as the number of rounds::
 
     >>> len(mp)
-    14
+    16
 
 The sequence of populations::
 
     >>> import pprint
     >>> pprint.pprint(populations)  # doctest: +SKIP
-    [Counter({'Cooperator': 1, 'Tit For Tat': 1, 'Grudger': 1, 'Defector': 1}),
-     Counter({'Cooperator': 1, 'Tit For Tat': 1, 'Grudger': 1, 'Defector': 1}),
-     Counter({'Cooperator': 1, 'Tit For Tat': 1, 'Grudger': 1, 'Defector': 1}),
-     Counter({'Tit For Tat': 2, 'Cooperator': 1, 'Grudger': 1}),
-     Counter({'Grudger': 2, 'Cooperator': 1, 'Tit For Tat': 1}),
-     Counter({'Grudger': 3, 'Cooperator': 1}),
-     Counter({'Grudger': 3, 'Cooperator': 1}),
-     Counter({'Grudger': 3, 'Cooperator': 1}),
-     Counter({'Grudger': 3, 'Cooperator': 1}),
-     Counter({'Grudger': 3, 'Cooperator': 1}),
-     Counter({'Grudger': 3, 'Cooperator': 1}),
-     Counter({'Grudger': 3, 'Cooperator': 1}),
-     Counter({'Grudger': 3, 'Cooperator': 1}),
-     Counter({'Grudger': 4})]
+    [Counter({'Defector': 1, 'Tit For Tat': 1, 'Grudger': 1, 'Cooperator': 1}),
+     Counter({'Defector': 1, 'Tit For Tat': 1, 'Grudger': 1, 'Cooperator': 1}),
+     Counter({'Cooperator': 2, 'Defector': 1, 'Tit For Tat': 1}),
+     Counter({'Defector': 2, 'Cooperator': 2}),
+     Counter({'Cooperator': 3, 'Defector': 1}),
+     Counter({'Cooperator': 3, 'Defector': 1}),
+     Counter({'Defector': 2, 'Cooperator': 2}),
+     Counter({'Defector': 3, 'Cooperator': 1}),
+     Counter({'Defector': 3, 'Cooperator': 1}),
+     Counter({'Defector': 3, 'Cooperator': 1}),
+     Counter({'Defector': 3, 'Cooperator': 1}),
+     Counter({'Defector': 3, 'Cooperator': 1}),
+     Counter({'Defector': 3, 'Cooperator': 1}),
+     Counter({'Defector': 3, 'Cooperator': 1}),
+     Counter({'Defector': 3, 'Cooperator': 1}),
+     Counter({'Defector': 4})]
+
 
 
 The scores in each round::
@@ -61,17 +64,19 @@ The scores in each round::
     ...     print([round(element, 1) for element in row])
     [6.0, 7.0, 7.0, 7.0]
     [6.0, 7.0, 7.0, 7.0]
-    [6.0, 7.0, 7.0, 7.0]
-    [9.0, 9.0, 9.0, 9.0]
-    [9.0, 9.0, 9.0, 9.0]
-    [9.0, 9.0, 9.0, 9.0]
-    [9.0, 9.0, 9.0, 9.0]
-    [9.0, 9.0, 9.0, 9.0]
-    [9.0, 9.0, 9.0, 9.0]
-    [9.0, 9.0, 9.0, 9.0]
-    [9.0, 9.0, 9.0, 9.0]
-    [9.0, 9.0, 9.0, 9.0]
-    [9.0, 9.0, 9.0, 9.0]
+    [6.0, 11.0, 7.0, 6.0]
+    [3.0, 11.0, 11.0, 3.0]
+    [6.0, 15.0, 6.0, 6.0]
+    [6.0, 15.0, 6.0, 6.0]
+    [3.0, 11.0, 11.0, 3.0]
+    [7.0, 7.0, 7.0, 0.0]
+    [7.0, 7.0, 7.0, 0.0]
+    [7.0, 7.0, 7.0, 0.0]
+    [7.0, 7.0, 7.0, 0.0]
+    [7.0, 7.0, 7.0, 0.0]
+    [7.0, 7.0, 7.0, 0.0]
+    [7.0, 7.0, 7.0, 0.0]
+    [7.0, 7.0, 7.0, 0.0]
 
 
 The :code:`MoranProcess` class also accepts an argument for a mutation rate.
@@ -88,7 +93,7 @@ function like :code:`takewhile` from :code:`itertools`)::
     ...     if len(mp.population_distribution()) == 1:
     ...         break
     >>> mp.population_distribution()
-    Counter({'Cooperator': 4})
+    Counter({'Grudger': 4})
 
 Other types of implemented Moran processes:
 


### PR DESCRIPTION
Use spatial Moran Processes throughout. 

Also add ability to pass a prob_end to the Matches.

In terms of performance this actually seems faster:

```
%%timeit
# Branch implementation of Moran Process
for players in [[axl.Cooperator()] * 3 + [axl.Defector()] * 3,
                [axl.Random(), axl.Grudger(), axl.TitFor2Tats()],
                [s() for s in axl.demo_strategies]]:

    for seed in range(100):
        axl.seed(seed)
        mp = axl.MoranProcess(players)
        mp.play()
        winner = mp.winning_strategy_name
```

output: `1 loop, best of 3: 8.7 s per loop`

whereas current `master`:

```
%%timeit
# Master branch implementation of Moran Process
for players in [[axl.Cooperator()] * 3 + [axl.Defector()] * 3,
                [axl.Random(), axl.Grudger(), axl.TitFor2Tats()],
                [s() for s in axl.demo_strategies]]:

    for seed in range(100):
        axl.seed(seed)
        mp = axl.MoranProcess(players)
        mp.play()
        winner = mp.winning_strategy_name
```
Output: `1 loop, best of 3: 9.92 s per loop`

This complements #1042.