### PR TITLE
Enum actions #816

### DIFF
--- a/axelrod/actions.py
+++ b/axelrod/actions.py
@@ -13,9 +13,9 @@ from enum import Enum
 from typing import Iterable
 
 
-class UnknownAction(ValueError):
+class UnknownActionError(ValueError):
     def __init__(self, *args):
-        super(UnknownAction, self).__init__(*args)
+        super(UnknownActionError, self).__init__(*args)
 
 
 class Actions(Enum):
@@ -49,7 +49,7 @@ class Actions(Enum):
         elif character == 'D':
             return cls.D
         else:
-            raise UnknownAction('Character must be "C" or "D".')
+            raise UnknownActionError('Character must be "C" or "D".')
 
 # Type alias for actions.
 Action = Actions
@@ -57,7 +57,7 @@ Action = Actions
 
 def flip_action(action: Action) -> Action:
     if not isinstance(action, Action):
-        raise UnknownAction('Not an Action')
+        raise UnknownActionError('Not an Action')
     return action.flip()
 
 

--- a/axelrod/actions.py
+++ b/axelrod/actions.py
@@ -11,6 +11,7 @@ C, D = Actions.C, Actions.D
 
 from enum import Enum
 import random
+from typing import Union
 
 
 class UnknownAction(ValueError):
@@ -36,6 +37,15 @@ class Actions(Enum):
             return Action.C
         else:
             raise UnknownAction('Cannot flip action: {!r}'.format(self))
+
+    @classmethod
+    def from_char(cls, character):
+        if character == 'C':
+            return cls.C
+        elif character == 'D':
+            return cls.D
+        else:
+            raise UnknownAction('Character must be "C" or "D".')
 
     @classmethod
     def random_choice(cls, p: float = 0.5) -> 'Action':
@@ -71,4 +81,8 @@ def str_to_actions(actions: str) -> tuple:
     except KeyError:
         raise UnknownAction(
             'The characters of "actions" str may only be "C" or "D"')
+
+
+def action_sequence_to_str(actions: Union[tuple, list]) -> str:
+    return "".join(map(repr, actions))
 

--- a/axelrod/actions.py
+++ b/axelrod/actions.py
@@ -11,7 +11,7 @@ C, D = Actions.C, Actions.D
 
 from enum import Enum
 import random
-from typing import Union
+from typing import Iterable
 
 
 class UnknownAction(ValueError):
@@ -30,16 +30,24 @@ class Actions(Enum):
     def __repr__(self):
         return '{}'.format(self.name)
 
+    def __str__(self):
+        return '{}'.format(self.name)
+
     def flip(self):
-        if self == Action.C:
-            return Action.D
-        if self == Action.D:
-            return Action.C
+        """Returns the opposite Action. """
+        if self == Actions.C:
+            return Actions.D
+        if self == Actions.D:
+            return Actions.C
         else:
             raise UnknownAction('Cannot flip action: {!r}'.format(self))
 
     @classmethod
     def from_char(cls, character):
+        """Converts a single character into an Action.
+        :code:`Action.from_char('C')` returns Action.C.
+        :code:`Action.from_char('CC')` raises an error.  Use
+        :code:`str_to_actions` instead."""
         if character == 'C':
             return cls.C
         elif character == 'D':
@@ -74,15 +82,10 @@ def flip_action(action: Action) -> Action:
 def str_to_actions(actions: str) -> tuple:
     """Takes a string like 'CCDD' and returns a tuple of the appropriate
     actions."""
-    action_dict = {'C': Actions.C,
-                   'D': Actions.D}
-    try:
-        return tuple(action_dict[action] for action in actions)
-    except KeyError:
-        raise UnknownAction(
-            'The characters of "actions" str may only be "C" or "D"')
+    return tuple(Actions.from_char(element) for element in actions)
 
 
-def action_sequence_to_str(actions: Union[tuple, list]) -> str:
+def action_sequence_to_str(actions: Iterable[Action]) -> str:
+    """Takes any iterable of Action and returns a string of 'C's
+    and 'D's.  ex: (D, D, C) -> 'DDC' """
     return "".join(map(repr, actions))
-

--- a/axelrod/actions.py
+++ b/axelrod/actions.py
@@ -9,22 +9,56 @@ from Axelrod import Actions
 C, D = Actions.C, Actions.D
 """
 
+from enum import Enum
+import random
+
+
+class UnknownAction(ValueError):
+    def __init__(self, *args):
+        super(UnknownAction, self).__init__(*args)
+
+
+class Actions(Enum):
+
+    C = 1
+    D = 0
+
+    def __bool__(self):
+        return bool(self.value)
+
+    def __repr__(self):
+        return '{}'.format(self.name)
+
+    def flip(self):
+        if self == Action.C:
+            return Action.D
+        if self == Action.D:
+            return Action.C
+        else:
+            raise UnknownAction('Cannot flip action: {!r}'.format(self))
+
+    @classmethod
+    def random_choice(cls, p: float = 0.5) -> 'Action':
+
+        if p == 0:
+            return cls.D
+
+        if p == 1:
+            return cls.C
+
+        r = random.random()
+        if r < p:
+            return cls.C
+        return cls.D
+
 # Type alias for actions.
-Action = str
-
-
-class Actions(object):
-    C = 'C'  # type: Action
-    D = 'D'  # type: Action
+Action = Actions
 
 
 def flip_action(action: Action) -> Action:
-    if action == Actions.C:
-        return Actions.D
-    elif action == Actions.D:
-        return Actions.C
-    else:
-        raise ValueError("Encountered a invalid action.")
+    if not isinstance(action, Action):
+        raise UnknownAction('Not an Action')
+    return action.flip()
 
 
 def str_to_actions(actions: str) -> tuple:
@@ -35,5 +69,6 @@ def str_to_actions(actions: str) -> tuple:
     try:
         return tuple(action_dict[action] for action in actions)
     except KeyError:
-        raise ValueError(
+        raise UnknownAction(
             'The characters of "actions" str may only be "C" or "D"')
+

--- a/axelrod/actions.py
+++ b/axelrod/actions.py
@@ -67,7 +67,7 @@ def str_to_actions(actions: str) -> tuple:
     return tuple(Actions.from_char(element) for element in actions)
 
 
-def action_sequence_to_str(actions: Iterable[Action]) -> str:
+def actions_to_str(actions: Iterable[Action]) -> str:
     """Takes any iterable of Action and returns a string of 'C's
     and 'D's.  ex: (D, D, C) -> 'DDC' """
     return "".join(map(repr, actions))

--- a/axelrod/actions.py
+++ b/axelrod/actions.py
@@ -38,8 +38,6 @@ class Actions(Enum):
             return Actions.D
         if self == Actions.D:
             return Actions.C
-        else:
-            raise UnknownAction('Cannot flip action: {!r}'.format(self))
 
     @classmethod
     def from_char(cls, character):

--- a/axelrod/actions.py
+++ b/axelrod/actions.py
@@ -10,7 +10,6 @@ C, D = Actions.C, Actions.D
 """
 
 from enum import Enum
-import random
 from typing import Iterable
 
 
@@ -44,30 +43,15 @@ class Actions(Enum):
 
     @classmethod
     def from_char(cls, character):
-        """Converts a single character into an Action.
-        :code:`Action.from_char('C')` returns Action.C.
-        :code:`Action.from_char('CC')` raises an error.  Use
-        :code:`str_to_actions` instead."""
+        """Converts a single character into an Action. `Action.from_char('C')`
+        returns `Action.C`. `Action.from_char('CC')` raises an error. Use
+        `str_to_actions` instead."""
         if character == 'C':
             return cls.C
         elif character == 'D':
             return cls.D
         else:
             raise UnknownAction('Character must be "C" or "D".')
-
-    @classmethod
-    def random_choice(cls, p: float = 0.5) -> 'Action':
-
-        if p == 0:
-            return cls.D
-
-        if p == 1:
-            return cls.C
-
-        r = random.random()
-        if r < p:
-            return cls.C
-        return cls.D
 
 # Type alias for actions.
 Action = Actions

--- a/axelrod/deterministic_cache.py
+++ b/axelrod/deterministic_cache.py
@@ -25,7 +25,7 @@ class DeterministicCache(UserDict):
     resulting interactions. e.g. for a 3 turn Match between Cooperator and
     Alternator, the dictionary entry would be:
 
-    (axelrod.Cooperator, axelrod.Alternator): [('C', 'C'), ('C', 'D'), ('C', 'C')]
+    (axelrod.Cooperator, axelrod.Alternator): [(C, C), (C, D), (C, C)]
 
     Most of the functionality is provided by the UserDict class (which uses an
     instance of dict as the 'data' attribute to hold the dictionary entries).

--- a/axelrod/interaction_utils.py
+++ b/axelrod/interaction_utils.py
@@ -11,7 +11,7 @@ from collections import Counter
 import csv
 import tqdm
 
-from axelrod.actions import Actions
+from axelrod.actions import Actions, str_to_actions
 from .game import Game
 
 
@@ -255,7 +255,9 @@ def read_interactions_from_file(filename, progress_bar=True,
     with open(filename, 'r') as f:
         for row in csv.reader(f):
             index_pair = (int(row[0]), int(row[1]))
-            interaction = list(zip(row[4], row[5]))
+            p1_actions = str_to_actions(row[4])
+            p2_actions = str_to_actions(row[5])
+            interaction = list(zip(p1_actions, p2_actions))
 
             try:
                 pairs_to_interactions[index_pair].append(interaction)
@@ -280,7 +282,7 @@ def string_to_interactions(string):
     interactions = []
     interactions_list = list(string)
     while interactions_list:
-        p1action = interactions_list.pop(0)
-        p2action = interactions_list.pop(0)
+        p1action = Actions.from_char(interactions_list.pop(0))
+        p2action = Actions.from_char(interactions_list.pop(0))
         interactions.append((p1action, p2action))
     return interactions

--- a/axelrod/interaction_utils.py
+++ b/axelrod/interaction_utils.py
@@ -277,7 +277,7 @@ def string_to_interactions(string):
     Converts a compact string representation of an interaction to an
     interaction:
 
-    'CDCDDD' -> [('C', 'D'), ('C', 'D'), ('D', 'D')]
+    'CDCDDD' -> [(C, D), (C, D), (D, D)]
     """
     interactions = []
     interactions_list = list(string)

--- a/axelrod/random_.py
+++ b/axelrod/random_.py
@@ -5,14 +5,14 @@ from axelrod.actions import Action, Actions
 
 def random_choice(p: float = 0.5) -> Action:
     """
-    Return 'C' with probability `p`, else return 'D'
+    Return C with probability `p`, else return D
 
     No random sample is carried out if p is 0 or 1.
 
     Parameters
     ----------
     p : float
-        The probability of picking 'C'
+        The probability of picking C
 
     Returns
     -------

--- a/axelrod/result_set.py
+++ b/axelrod/result_set.py
@@ -4,7 +4,7 @@ import csv
 from numpy import mean, nanmedian, std
 import tqdm
 
-from axelrod.actions import Actions
+from axelrod.actions import Actions, str_to_actions
 import axelrod.interaction_utils as iu
 from . import eigen
 from .game import Game
@@ -1075,7 +1075,9 @@ class ResultSetFromFile(ResultSet):
             count = 0
             for row in csv_reader:
                 index_and_names = row[:4]
-                interactions = list(zip(row[4], row[5]))
+                p1_actions = str_to_actions(row[4])
+                p2_actions = str_to_actions(row[5])
+                interactions = list(zip(p1_actions, p2_actions))
                 repetitions.append(index_and_names + interactions)
                 count += 1
                 if progress_bar:

--- a/axelrod/result_set.py
+++ b/axelrod/result_set.py
@@ -848,8 +848,8 @@ class ResultSet(object):
         for player in self.normalised_state_to_action_distribution:
             rates = []
             for state in states:
-                counts = [counter[(state, 'C')] for counter in player
-                          if counter[(state, 'C')] > 0]
+                counts = [counter[(state, C)] for counter in player
+                          if counter[(state, C)] > 0]
 
                 if len(counts) > 0:
                     rate = mean(counts)

--- a/axelrod/strategies/appeaser.py
+++ b/axelrod/strategies/appeaser.py
@@ -7,8 +7,8 @@ C, D = Actions.C, Actions.D
 class Appeaser(Player):
     """A player who tries to guess what the opponent wants.
 
-    Switch the classifier every time the opponent plays 'D'.
-    Start with 'C', switch between 'C' and 'D' when opponent plays 'D'.
+    Switch the classifier every time the opponent plays D.
+    Start with C, switch between C and D when opponent plays D.
 
     Names:
 

--- a/axelrod/strategies/human.py
+++ b/axelrod/strategies/human.py
@@ -136,7 +136,7 @@ class Human(Player):
             get_bottom_toolbar_tokens=self.status_messages['toolbar'],
             style=toolbar_style)
 
-        return action.upper()
+        return Actions.from_char(action.upper())
 
     def strategy(self, opponent: Player, input_function=None):
         """

--- a/axelrod/strategies/lookerup.py
+++ b/axelrod/strategies/lookerup.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 from itertools import product
 
-from axelrod.actions import Action, Actions, str_to_actions, action_sequence_to_str
+from axelrod.actions import Action, Actions, str_to_actions, actions_to_str
 from axelrod.player import Player
 
 from typing import Any, TypeVar
@@ -139,7 +139,7 @@ class LookupTable(object):
         :param sort_by: only_elements='self_plays', 'op_plays', 'op_openings'
         """
         def sorter(plays):
-            return tuple(action_sequence_to_str(
+            return tuple(actions_to_str(
                 getattr(plays, field) for field in sort_by))
 
         col_width = 11

--- a/axelrod/strategies/lookerup.py
+++ b/axelrod/strategies/lookerup.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 from itertools import product
 
-from axelrod.actions import Action, Actions, str_to_actions
+from axelrod.actions import Action, Actions, str_to_actions, action_sequence_to_str
 from axelrod.player import Player
 
 from typing import Any, TypeVar
@@ -139,7 +139,8 @@ class LookupTable(object):
         :param sort_by: only_elements='self_plays', 'op_plays', 'op_openings'
         """
         def sorter(plays):
-            return tuple(getattr(plays, field) for field in sort_by)
+            return tuple(action_sequence_to_str(
+                getattr(plays, field) for field in sort_by))
 
         col_width = 11
         sorted_keys = sorted(self._dict, key=sorter)
@@ -148,9 +149,12 @@ class LookupTable(object):
                        '{str_list[2]:^{width}}')
         display_line = header_line.replace('|', ',') + ': {str_list[3]},'
 
-        line_elements = [(', '.join(getattr(key, sort_by[0])),
-                          ', '.join(getattr(key, sort_by[1])),
-                          ', '.join(getattr(key, sort_by[2])),
+        def make_commaed_str(action_tuple):
+            return ', '.join(str(action) for action in action_tuple)
+
+        line_elements = [(make_commaed_str(getattr(key, sort_by[0])),
+                          make_commaed_str(getattr(key, sort_by[1])),
+                          make_commaed_str(getattr(key, sort_by[2])),
                           self._dict[key])
                          for key in sorted_keys]
         header = header_line.format(str_list=sort_by, width=col_width) + '\n'

--- a/axelrod/strategies/meta.py
+++ b/axelrod/strategies/meta.py
@@ -82,7 +82,7 @@ class MetaPlayer(Player):
     def meta_strategy(self, results, opponent):
         """Determine the meta result based on results of all players.
         Override this function in child classes."""
-        return 'C'
+        return C
 
     def reset(self):
         super().reset()

--- a/axelrod/strategies/qlearner.py
+++ b/axelrod/strategies/qlearner.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 import random
 
-from axelrod.actions import Actions, Action
+from axelrod.actions import Actions, Action, action_sequence_to_str
 from axelrod.player import Player
 from axelrod.random_ import random_choice
 
@@ -92,7 +92,9 @@ class RiskyQLearner(Player):
         its previous proportion of playing C) as a hashable state
         """
         prob = '{:.1f}'.format(opponent.cooperations)
-        return ''.join(opponent.history[-self.memory_length:]) + prob
+        action_str = action_sequence_to_str(
+            opponent.history[-self.memory_length:])
+        return action_str + prob
 
     def perform_q_learning(self, prev_state: str, state: str, action: Action, reward):
         """

--- a/axelrod/strategies/qlearner.py
+++ b/axelrod/strategies/qlearner.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 import random
 
-from axelrod.actions import Actions, Action, action_sequence_to_str
+from axelrod.actions import Actions, Action, actions_to_str
 from axelrod.player import Player
 from axelrod.random_ import random_choice
 
@@ -92,7 +92,7 @@ class RiskyQLearner(Player):
         its previous proportion of playing C) as a hashable state
         """
         prob = '{:.1f}'.format(opponent.cooperations)
-        action_str = action_sequence_to_str(
+        action_str = actions_to_str(
             opponent.history[-self.memory_length:])
         return action_str + prob
 

--- a/axelrod/strategies/shortmem.py
+++ b/axelrod/strategies/shortmem.py
@@ -37,8 +37,8 @@ class ShortMem(Player):
             return C
 
         array = opponent.history[-10:]
-        C_counts = array.count('C')
-        D_counts = array.count('D')
+        C_counts = array.count(C)
+        D_counts = array.count(D)
 
         if C_counts - D_counts >= 3:
             return C

--- a/axelrod/strategies/stalker.py
+++ b/axelrod/strategies/stalker.py
@@ -6,7 +6,7 @@ from axelrod.strategy_transformers import FinalTransformer
 C, D = Actions.C, Actions.D
 
 
-@FinalTransformer((D), name_prefix=None)  # End with defection
+@FinalTransformer((D,), name_prefix=None)  # End with defection
 class Stalker(Player):
     """
 

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -182,11 +182,11 @@ class SneakyTitForTat(Player):
 
     def strategy(self, opponent: Player) -> Action:
         if len(self.history) < 2:
-            return "C"
+            return C
         if D not in opponent.history:
             return D
         if opponent.history[-1] == D and self.history[-2] == D:
-            return "C"
+            return C
         return opponent.history[-1]
 
 
@@ -297,8 +297,9 @@ class HardTitFor2Tats(Player):
         if not opponent.history:
             return C
         # Defects if two consecutive D in the opponent's last three moves
-        history_string = "".join(opponent.history[-3:])
-        if 'DD' in history_string:
+        last_three = opponent.history[-3:]
+        if any(last_three[n: n + 2] == [D, D] for n in (0, 1)):
+        # if last_three[-3: -1] == [D, D] or last_three[-2:] == [D, D]:
             return D
         # Otherwise cooperates
         return C

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -1,4 +1,4 @@
-from axelrod.actions import Actions, Action, action_sequence_to_str
+from axelrod.actions import Actions, Action, actions_to_str
 from axelrod.player import Player
 from axelrod.random_ import random_choice
 from axelrod.strategy_transformers import (
@@ -297,7 +297,7 @@ class HardTitFor2Tats(Player):
         if not opponent.history:
             return C
         # Defects if two consecutive D in the opponent's last three moves
-        history_string = action_sequence_to_str(opponent.history[-3:])
+        history_string = actions_to_str(opponent.history[-3:])
         if 'DD' in history_string:
             return D
         # Otherwise cooperates

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -1,4 +1,4 @@
-from axelrod.actions import Actions, Action
+from axelrod.actions import Actions, Action, action_sequence_to_str
 from axelrod.player import Player
 from axelrod.random_ import random_choice
 from axelrod.strategy_transformers import (
@@ -297,9 +297,8 @@ class HardTitFor2Tats(Player):
         if not opponent.history:
             return C
         # Defects if two consecutive D in the opponent's last three moves
-        last_three = opponent.history[-3:]
-        if any(last_three[n: n + 2] == [D, D] for n in (0, 1)):
-        # if last_three[-3: -1] == [D, D] or last_three[-2:] == [D, D]:
+        history_string = action_sequence_to_str(opponent.history[-3:])
+        if 'DD' in history_string:
             return D
         # Otherwise cooperates
         return C

--- a/axelrod/strategy_transformers.py
+++ b/axelrod/strategy_transformers.py
@@ -130,10 +130,12 @@ def StrategyTransformerFactory(strategy_wrapper, name_prefix=None,
                 prefix = ': '
                 for arg in args:
                     try:
-                        arg = [player.name for player in arg]
-                    except TypeError:
-                        pass
+                        # Action has .name but should not be made into a list
+                        if not any(isinstance(el, Actions) for el in arg):
+                            arg = [player.name for player in arg]
                     except AttributeError:
+                        pass
+                    except TypeError:
                         pass
                     name = ''.join([name, prefix, str(arg)])
                     prefix = ', '

--- a/axelrod/tests/integration/test_matches.py
+++ b/axelrod/tests/integration/test_matches.py
@@ -52,10 +52,10 @@ class TestMatchOutcomes(unittest.TestCase):
         p3 = axelrod.MemoryOnePlayer(four_vector=(1, 1, 1, 0))
 
         m = axelrod.Match((p1, p2), turns=3)
-        self.assertEqual(m.play(), [('C', 'C'), ('D', 'C'), ('D', 'D')])
+        self.assertEqual(m.play(), [(C, C), (D, C), (D, D)])
 
         m = axelrod.Match((p2, p3), turns=3)
-        self.assertEqual(m.play(), [('C', 'C'), ('C', 'C'), ('C', 'C')])
+        self.assertEqual(m.play(), [(C, C), (C, C), (C, C)])
 
         m = axelrod.Match((p1, p3), turns=3)
-        self.assertEqual(m.play(), [('C', 'C'), ('D', 'C'), ('D', 'C')])
+        self.assertEqual(m.play(), [(C, C), (D, C), (D, C)])

--- a/axelrod/tests/strategies/test_axelrod_first.py
+++ b/axelrod/tests/strategies/test_axelrod_first.py
@@ -367,7 +367,7 @@ class TestUnnamedStrategy(TestPlayer):
 
 class TestSteinAndRapoport(TestPlayer):
 
-    name = "Stein and Rapoport: 0.05: ('D', 'D')"
+    name = "Stein and Rapoport: 0.05: (D, D)"
     player = axelrod.SteinAndRapoport
     expected_classifier = {
         'memory_depth': 15,

--- a/axelrod/tests/strategies/test_backstabber.py
+++ b/axelrod/tests/strategies/test_backstabber.py
@@ -11,7 +11,7 @@ C, D = axelrod.Actions.C, axelrod.Actions.D
 
 class TestBackStabber(TestPlayer):
 
-    name = "BackStabber: ('D', 'D')"
+    name = "BackStabber: (D, D)"
     player = axelrod.BackStabber
     expected_classifier = {
         'memory_depth': float('inf'),
@@ -56,7 +56,7 @@ class TestDoubleCrosser(TestBackStabber):
     The alternate strategy is triggered when opponent did not defect in the
     first 7 rounds, and 8 <= the current round <= 180.
     """
-    name = "DoubleCrosser: ('D', 'D')"
+    name = "DoubleCrosser: (D, D)"
     player = axelrod.DoubleCrosser
     expected_classifier = {
         'memory_depth': float('inf'),

--- a/axelrod/tests/strategies/test_cycler.py
+++ b/axelrod/tests/strategies/test_cycler.py
@@ -68,7 +68,8 @@ class TestBasicCycler(TestPlayer):
 
     def test_cycler_works_as_expected(self):
         expected = [(C, D), (D, D), (D, D), (C, D)] * 2
-        self.versus_test(axelrod.Defector(), expected_actions=expected, init_kwargs={'cycle': 'CDDC'})
+        self.versus_test(axelrod.Defector(), expected_actions=expected,
+                         init_kwargs={'cycle': 'CDDC'})
 
     def test_cycle_raises_value_error_on_bad_cycle_str(self):
         self.assertRaises(ValueError, Cycler, cycle='CdDC')

--- a/axelrod/tests/strategies/test_finite_state_machines.py
+++ b/axelrod/tests/strategies/test_finite_state_machines.py
@@ -81,7 +81,7 @@ class TestSampleFSMPlayer(TestPlayer):
     """Test a few sample tables to make sure that the finite state machines are
     working as intended."""
 
-    name = "FSM Player: ((1, 'C', 1, 'C'), (1, 'D', 1, 'D')), 1, C"
+    name = "FSM Player: ((1, C, 1, C), (1, D, 1, D)), 1, C"
     player = axelrod.FSMPlayer
 
     expected_classifier = {
@@ -137,7 +137,7 @@ class TestSampleFSMPlayer(TestPlayer):
 
 
 class TestFSMPlayer(TestPlayer):
-    name = "FSM Player: ((1, 'C', 1, 'C'), (1, 'D', 1, 'D')), 1, C"
+    name = "FSM Player: ((1, C, 1, C), (1, D, 1, D)), 1, C"
     player = axelrod.FSMPlayer
 
     expected_classifier = {

--- a/axelrod/tests/strategies/test_gradualkiller.py
+++ b/axelrod/tests/strategies/test_gradualkiller.py
@@ -8,7 +8,7 @@ C, D = axl.Actions.C, axl.Actions.D
 
 class TestGradualKiller(TestPlayer):
 
-    name = "Gradual Killer: ('D', 'D', 'D', 'D', 'D', 'C', 'C')"
+    name = "Gradual Killer: (D, D, D, D, D, C, C)"
     player = axl.GradualKiller
     expected_classifier = {
         'memory_depth': float('Inf'),

--- a/axelrod/tests/strategies/test_human.py
+++ b/axelrod/tests/strategies/test_human.py
@@ -1,7 +1,8 @@
 from os import linesep
 from unittest import TestCase
+from unittest.mock import patch
 from prompt_toolkit.validation import ValidationError
-from axelrod import Actions, Player
+from axelrod import Actions, Player, Cooperator
 from axelrod.strategies.human import Human, ActionValidator
 from .test_player import TestPlayer
 
@@ -21,7 +22,7 @@ class TestDocument(object):
 class TestActionValidator(TestCase):
 
     def test_validator(self):
-        test_documents = [TestDocument(x) for x in [C, C, D, D]]
+        test_documents = [TestDocument(x) for x in ['C', 'c', 'D', 'd']]
         for test_document in test_documents:
             ActionValidator().validate(test_document)
 
@@ -79,12 +80,33 @@ class TestHumanClass(TestPlayer):
         self.assertEqual(actual_messages['print'], expected_print_message)
         self.assertIsNotNone(actual_messages['toolbar'])
 
-    def test_get_human_input(self):
-        # There are no tests for this method.
-        # The method purely calls prompt_toolkit.prompt which is difficult to
-        # test and we therefore rely upon the test suite of the prompt_toolkit
-        # library itself.
-        pass
+    def test_get_human_input_c(self):
+        with patch('axelrod.human.prompt', return_value='c') as prompt_:
+            actions = [(C, C)] * 5
+            self.versus_test(Cooperator(), expected_actions=actions)
+            self.assertEqual(prompt_.call_args[0],
+                             ('Turn 5 action [C or D] for human: ',))
+
+    def test_get_human_input_C(self):
+        with patch('axelrod.human.prompt', return_value='C') as prompt_:
+            actions = [(C, C)] * 5
+            self.versus_test(Cooperator(), expected_actions=actions)
+            self.assertEqual(prompt_.call_args[0],
+                             ('Turn 5 action [C or D] for human: ',))
+
+    def test_get_human_input_d(self):
+        with patch('axelrod.human.prompt', return_value='d') as prompt_:
+            actions = [(D, C)] * 5
+            self.versus_test(Cooperator(), expected_actions=actions)
+            self.assertEqual(prompt_.call_args[0],
+                             ('Turn 5 action [C or D] for human: ',))
+
+    def test_get_human_input_D(self):
+        with patch('axelrod.human.prompt', return_value='D') as prompt_:
+            actions = [(D, C)] * 5
+            self.versus_test(Cooperator(), expected_actions=actions)
+            self.assertEqual(prompt_.call_args[0],
+                             ('Turn 5 action [C or D] for human: ',))
 
     def test_strategy(self):
         human = Human()

--- a/axelrod/tests/strategies/test_mindcontrol.py
+++ b/axelrod/tests/strategies/test_mindcontrol.py
@@ -75,15 +75,15 @@ class TestMindWarper(TestMindController):
 
     def test_setattr(self):
         player = self.player()
-        player.strategy = lambda opponent: 'C'
+        player.strategy = lambda opponent: C
 
     def test_strategy(self):
         player = self.player()
         opponent = axelrod.Defector()
         play1 = player.strategy(opponent)
         play2 = opponent.strategy(player)
-        self.assertEqual(play1, 'D')
-        self.assertEqual(play2, 'C')
+        self.assertEqual(play1, D)
+        self.assertEqual(play2, C)
 
 
 class TestMindBender(TestMindController):
@@ -105,5 +105,5 @@ class TestMindBender(TestMindController):
         opponent = axelrod.Defector()
         play1 = player.strategy(opponent)
         play2 = opponent.strategy(player)
-        self.assertEqual(play1, 'D')
-        self.assertEqual(play2, 'C')
+        self.assertEqual(play1, D)
+        self.assertEqual(play2, C)

--- a/axelrod/tests/strategies/test_player.py
+++ b/axelrod/tests/strategies/test_player.py
@@ -559,6 +559,6 @@ def test_four_vector(test_class, expected_dictionary):
     a memory-one strategy and the given expected dictionary.
     """
     player1 = test_class.player()
-    for key in sorted(expected_dictionary.keys()):
+    for key in sorted(expected_dictionary.keys(), key=str):
         test_class.assertAlmostEqual(
             player1._four_vector[key], expected_dictionary[key])

--- a/axelrod/tests/strategies/test_stalker.py
+++ b/axelrod/tests/strategies/test_stalker.py
@@ -8,7 +8,7 @@ C, D = axl.Actions.C, axl.Actions.D
 
 class TestStalker(TestPlayer):
 
-    name = "Stalker: D"
+    name = "Stalker: (D,)"
     player = axl.Stalker
     expected_classifier = {
         'memory_depth': float('inf'),

--- a/axelrod/tests/strategies/test_titfortat.py
+++ b/axelrod/tests/strategies/test_titfortat.py
@@ -571,7 +571,7 @@ class TestAlexei(TestPlayer):
     Tests for the Alexei strategy
     """
 
-    name = "Alexei: ('D',)"
+    name = "Alexei: (D,)"
     player = axelrod.Alexei
     expected_classifier = {
         'memory_depth': float('inf'),
@@ -605,7 +605,7 @@ class TestEugineNier(TestPlayer):
     Tests for the Eugine Nier strategy
     """
 
-    name = "EugineNier: ('D',)"
+    name = "EugineNier: (D,)"
     player = axelrod.EugineNier
     expected_classifier = {
         'memory_depth': float('inf'),

--- a/axelrod/tests/unit/test_actions.py
+++ b/axelrod/tests/unit/test_actions.py
@@ -1,6 +1,7 @@
 import unittest
 from axelrod import Actions, flip_action
-from axelrod.actions import str_to_actions, UnknownAction
+from axelrod.actions import (str_to_actions, UnknownAction,
+                             action_sequence_to_str)
 
 C, D = Actions.C, Actions.D
 
@@ -35,3 +36,8 @@ class TestAction(unittest.TestCase):
 
     def test_str_to_actions_fails_fast_and_raises_value_error(self):
         self.assertRaises(UnknownAction, str_to_actions, 'Cc')
+
+    def test_action_sequence_to_str(self):
+        self.assertEqual(action_sequence_to_str([]), "")
+        self.assertEqual(action_sequence_to_str([C, D, C]), "CDC")
+        self.assertEqual(action_sequence_to_str((C, C, D)), "CCD")

--- a/axelrod/tests/unit/test_actions.py
+++ b/axelrod/tests/unit/test_actions.py
@@ -16,17 +16,30 @@ class TestAction(unittest.TestCase):
         self.assertTrue(C)
         self.assertFalse(D)
 
-    def test_flip_action(self):
-        self.assertEqual(flip_action(D), C)
-        self.assertEqual(flip_action(C), D)
-
     def test__eq__(self):
         self.assertTrue(C == C)
         self.assertTrue(D == D)
         self.assertFalse(C == D)
         self.assertFalse(D == C)
 
-    def test_error(self):
+    def test_flip(self):
+        self.assertEqual(C.flip(), D)
+        self.assertEqual(D.flip(), C)
+
+    def test_from_char(self):
+        self.assertEqual(Actions.from_char('C'), C)
+        self.assertEqual(Actions.from_char('D'), D)
+
+    def test_from_char_error(self):
+        self.assertRaises(UnknownAction, Actions.from_char, '')
+        self.assertRaises(UnknownAction, Actions.from_char, 'c')
+        self.assertRaises(UnknownAction, Actions.from_char, 'A')
+
+    def test_flip_action(self):
+        self.assertEqual(flip_action(D), C)
+        self.assertEqual(flip_action(C), D)
+
+    def test_flip_action_error(self):
         self.assertRaises(UnknownAction, flip_action, 'R')
 
     def test_str_to_actions(self):
@@ -41,3 +54,8 @@ class TestAction(unittest.TestCase):
         self.assertEqual(action_sequence_to_str([]), "")
         self.assertEqual(action_sequence_to_str([C, D, C]), "CDC")
         self.assertEqual(action_sequence_to_str((C, C, D)), "CCD")
+
+    def test_action_sequence_to_str_with_iterable(self):
+        self.assertEqual(action_sequence_to_str(iter([C, D, C])), "CDC")
+        generator = (action for action in [C, D, C])
+        self.assertEqual(action_sequence_to_str(generator), "CDC")

--- a/axelrod/tests/unit/test_actions.py
+++ b/axelrod/tests/unit/test_actions.py
@@ -1,7 +1,6 @@
 import unittest
 from axelrod import Actions, flip_action
-from axelrod.actions import (str_to_actions, UnknownAction,
-                             action_sequence_to_str)
+from axelrod.actions import str_to_actions, UnknownAction,  actions_to_str
 
 C, D = Actions.C, Actions.D
 
@@ -11,6 +10,10 @@ class TestAction(unittest.TestCase):
     def test_repr(self):
         self.assertEqual(repr(C), 'C')
         self.assertEqual(repr(D), 'D')
+
+    def test_str(self):
+        self.assertEqual(str(C), 'C')
+        self.assertEqual(str(D), 'D')
 
     def test_bool(self):
         self.assertTrue(C)
@@ -33,6 +36,7 @@ class TestAction(unittest.TestCase):
     def test_from_char_error(self):
         self.assertRaises(UnknownAction, Actions.from_char, '')
         self.assertRaises(UnknownAction, Actions.from_char, 'c')
+        self.assertRaises(UnknownAction, Actions.from_char, 'd')
         self.assertRaises(UnknownAction, Actions.from_char, 'A')
 
     def test_flip_action(self):
@@ -50,12 +54,12 @@ class TestAction(unittest.TestCase):
     def test_str_to_actions_fails_fast_and_raises_value_error(self):
         self.assertRaises(UnknownAction, str_to_actions, 'Cc')
 
-    def test_action_sequence_to_str(self):
-        self.assertEqual(action_sequence_to_str([]), "")
-        self.assertEqual(action_sequence_to_str([C, D, C]), "CDC")
-        self.assertEqual(action_sequence_to_str((C, C, D)), "CCD")
+    def test_actions_to_str(self):
+        self.assertEqual(actions_to_str([]), "")
+        self.assertEqual(actions_to_str([C, D, C]), "CDC")
+        self.assertEqual(actions_to_str((C, C, D)), "CCD")
 
-    def test_action_sequence_to_str_with_iterable(self):
-        self.assertEqual(action_sequence_to_str(iter([C, D, C])), "CDC")
+    def test_actions_to_str_with_iterable(self):
+        self.assertEqual(actions_to_str(iter([C, D, C])), "CDC")
         generator = (action for action in [C, D, C])
-        self.assertEqual(action_sequence_to_str(generator), "CDC")
+        self.assertEqual(actions_to_str(generator), "CDC")

--- a/axelrod/tests/unit/test_actions.py
+++ b/axelrod/tests/unit/test_actions.py
@@ -1,6 +1,6 @@
 import unittest
 from axelrod import Actions, flip_action
-from axelrod.actions import str_to_actions, UnknownAction,  actions_to_str
+from axelrod.actions import str_to_actions, UnknownActionError,  actions_to_str
 
 C, D = Actions.C, Actions.D
 
@@ -34,17 +34,17 @@ class TestAction(unittest.TestCase):
         self.assertEqual(Actions.from_char('D'), D)
 
     def test_from_char_error(self):
-        self.assertRaises(UnknownAction, Actions.from_char, '')
-        self.assertRaises(UnknownAction, Actions.from_char, 'c')
-        self.assertRaises(UnknownAction, Actions.from_char, 'd')
-        self.assertRaises(UnknownAction, Actions.from_char, 'A')
+        self.assertRaises(UnknownActionError, Actions.from_char, '')
+        self.assertRaises(UnknownActionError, Actions.from_char, 'c')
+        self.assertRaises(UnknownActionError, Actions.from_char, 'd')
+        self.assertRaises(UnknownActionError, Actions.from_char, 'A')
 
     def test_flip_action(self):
         self.assertEqual(flip_action(D), C)
         self.assertEqual(flip_action(C), D)
 
     def test_flip_action_error(self):
-        self.assertRaises(UnknownAction, flip_action, 'R')
+        self.assertRaises(UnknownActionError, flip_action, 'R')
 
     def test_str_to_actions(self):
         self.assertEqual(str_to_actions(''), ())
@@ -52,7 +52,7 @@ class TestAction(unittest.TestCase):
         self.assertEqual(str_to_actions('CDDC'), (C, D, D, C))
 
     def test_str_to_actions_fails_fast_and_raises_value_error(self):
-        self.assertRaises(UnknownAction, str_to_actions, 'Cc')
+        self.assertRaises(UnknownActionError, str_to_actions, 'Cc')
 
     def test_actions_to_str(self):
         self.assertEqual(actions_to_str([]), "")

--- a/axelrod/tests/unit/test_actions.py
+++ b/axelrod/tests/unit/test_actions.py
@@ -1,27 +1,32 @@
 import unittest
 from axelrod import Actions, flip_action
-from axelrod.actions import str_to_actions
+from axelrod.actions import str_to_actions, UnknownAction
 
 C, D = Actions.C, Actions.D
 
 
 class TestAction(unittest.TestCase):
 
-    def test_action_values(self):
-        self.assertEqual(C, 'C')
-        self.assertEqual(D, 'D')
-        self.assertNotEqual(D, 'd')
-        self.assertNotEqual(C, 'c')
-        self.assertNotEqual(D, 0)
-        self.assertNotEqual(C, 1)
-        self.assertNotEqual(C, D)
+    def test_repr(self):
+        self.assertEqual(repr(C), 'C')
+        self.assertEqual(repr(D), 'D')
+
+    def test_bool(self):
+        self.assertTrue(C)
+        self.assertFalse(D)
 
     def test_flip_action(self):
         self.assertEqual(flip_action(D), C)
         self.assertEqual(flip_action(C), D)
 
+    def test__eq__(self):
+        self.assertTrue(C == C)
+        self.assertTrue(D == D)
+        self.assertFalse(C == D)
+        self.assertFalse(D == C)
+
     def test_error(self):
-        self.assertRaises(ValueError, flip_action, 'R')
+        self.assertRaises(UnknownAction, flip_action, 'R')
 
     def test_str_to_actions(self):
         self.assertEqual(str_to_actions(''), ())
@@ -29,4 +34,4 @@ class TestAction(unittest.TestCase):
         self.assertEqual(str_to_actions('CDDC'), (C, D, D, C))
 
     def test_str_to_actions_fails_fast_and_raises_value_error(self):
-        self.assertRaises(ValueError, str_to_actions, 'Cc')
+        self.assertRaises(UnknownAction, str_to_actions, 'Cc')

--- a/axelrod/tests/unit/test_deterministic_cache.py
+++ b/axelrod/tests/unit/test_deterministic_cache.py
@@ -14,7 +14,11 @@ class TestDeterministicCache(unittest.TestCase):
         cls.test_value = [(C, D), (D, D), (D, D)]
         cls.test_save_file = 'test_cache_save.txt'
         cls.test_load_file = 'test_cache_load.txt'
-        cls.test_pickle = b'\x80\x03}q\x00X\x0b\x00\x00\x00Tit For Tatq\x01X\x08\x00\x00\x00Defectorq\x02K\x03\x87q\x03]q\x04(X\x01\x00\x00\x00Cq\x05X\x01\x00\x00\x00Dq\x06\x86q\x07h\x06h\x06\x86q\x08h\x06h\x06\x86q\tes.'
+        test_data_to_pickle = {
+            ('Tit For Tat', 'Defector', 3): [(C, D), (D, D), (D, D)]
+        }
+        cls.test_pickle = pickle.dumps(test_data_to_pickle)
+
         with open(cls.test_load_file, 'wb') as f:
             f.write(cls.test_pickle)
 

--- a/axelrod/tests/unit/test_interaction_utils.py
+++ b/axelrod/tests/unit/test_interaction_utils.py
@@ -18,29 +18,29 @@ class TestMatch(unittest.TestCase):
     winners = [False, 0, 1, None]
     cooperations = [(1, 1), (0, 2), (2, 1), None]
     normalised_cooperations = [(.5, .5), (0, 1), (1, .5), None]
-    state_distribution = [Counter({('C', 'D'): 1, ('D', 'C'): 1}),
-                          Counter({('D', 'C'): 2}),
-                          Counter({('C', 'C'): 1, ('C', 'D'): 1}),
+    state_distribution = [Counter({(C, D): 1, (D, C): 1}),
+                          Counter({(D, C): 2}),
+                          Counter({(C, C): 1, (C, D): 1}),
                           None]
-    state_to_action_distribution = [[Counter({(('C', 'D'), 'D'): 1}),
-                                     Counter({(('C', 'D'), 'C'): 1})],
-                                    [Counter({(('D', 'C'), 'D'): 1}),
-                                     Counter({(('D', 'C'), 'C'): 1})],
-                                    [Counter({(('C', 'C'), 'C'): 1}),
-                                     Counter({(('C', 'C'), 'D'): 1})],
+    state_to_action_distribution = [[Counter({((C, D), D): 1}),
+                                     Counter({((C, D), C): 1})],
+                                    [Counter({((D, C), D): 1}),
+                                     Counter({((D, C), C): 1})],
+                                    [Counter({((C, C), C): 1}),
+                                     Counter({((C, C), D): 1})],
                                     None]
 
     normalised_state_distribution = [
-        Counter({('C', 'D'): 0.5, ('D', 'C'): 0.5}),
-        Counter({('D', 'C'): 1.0}),
-        Counter({('C', 'C'): 0.5, ('C', 'D'): 0.5}),
+        Counter({(C, D): 0.5, (D, C): 0.5}),
+        Counter({(D, C): 1.0}),
+        Counter({(C, C): 0.5, (C, D): 0.5}),
         None]
-    normalised_state_to_action_distribution = [[Counter({(('C', 'D'), 'D'): 1}),
-                                                Counter({(('C', 'D'), 'C'): 1})],
-                                               [Counter({(('D', 'C'), 'D'): 1}),
-                                                Counter({(('D', 'C'), 'C'): 1})],
-                                               [Counter({(('C', 'C'), 'C'): 1}),
-                                                Counter({(('C', 'C'), 'D'): 1})],
+    normalised_state_to_action_distribution = [[Counter({((C, D), D): 1}),
+                                                Counter({((C, D), C): 1})],
+                                               [Counter({((D, C), D): 1}),
+                                                Counter({((D, C), C): 1})],
+                                               [Counter({((C, C), C): 1}),
+                                                Counter({((C, C), D): 1})],
                                                None]
 
     sparklines = [ '█ \n █', '  \n██', '██\n█ ', None ]
@@ -85,12 +85,12 @@ class TestMatch(unittest.TestCase):
             self.assertEqual(dist,
                              iu.compute_state_to_action_distribution(inter))
         inter = [(C, D), (D, C), (C, D), (D, C), (D, D), (C, C), (C, D)]
-        expected_dist =[Counter({(('C', 'C'), 'C'): 1, (('D', 'C'), 'C'): 1,
-                                 (('C', 'D'), 'D'): 2, (('D', 'C'), 'D'): 1,
-                                 (('D', 'D'), 'C'): 1}),
-                        Counter({(('C', 'C'), 'D'): 1,
-                                 (('C', 'D'), 'C'): 2, (('D', 'C'), 'D'): 2,
-                                 (('D', 'D'), 'C'): 1})]
+        expected_dist =[Counter({((C, C), C): 1, ((D, C), C): 1,
+                                 ((C, D), D): 2, ((D, C), D): 1,
+                                 ((D, D), C): 1}),
+                        Counter({((C, C), D): 1,
+                                 ((C, D), C): 2, ((D, C), D): 2,
+                                 ((D, D), C): 1})]
 
         self.assertEqual(expected_dist,
                          iu.compute_state_to_action_distribution(inter))
@@ -101,12 +101,12 @@ class TestMatch(unittest.TestCase):
             self.assertEqual(dist,
                              iu.compute_normalised_state_to_action_distribution(inter))
         inter = [(C, D), (D, C), (C, D), (D, C), (D, D), (C, C), (C, D)]
-        expected_dist =[Counter({(('C', 'C'), 'C'): 1, (('D', 'C'), 'C'): 1 / 2,
-                                 (('C', 'D'), 'D'): 1, (('D', 'C'), 'D'): 1 / 2,
-                                 (('D', 'D'), 'C'): 1}),
-                        Counter({(('C', 'C'), 'D'): 1,
-                                 (('C', 'D'), 'C'): 1, (('D', 'C'), 'D'): 1,
-                                 (('D', 'D'), 'C'): 1})]
+        expected_dist =[Counter({((C, C), C): 1, ((D, C), C): 1 / 2,
+                                 ((C, D), D): 1, ((D, C), D): 1 / 2,
+                                 ((D, D), C): 1}),
+                        Counter({((C, C), D): 1,
+                                 ((C, D), C): 1, ((D, C), D): 1,
+                                 ((D, D), C): 1})]
         self.assertEqual(expected_dist,
                          iu.compute_normalised_state_to_action_distribution(inter))
 
@@ -121,11 +121,11 @@ class TestMatch(unittest.TestCase):
         tournament = axelrod.Tournament(players=players, turns=2, repetitions=3)
         tournament.play(filename=tmp_file.name)
         tmp_file.close()
-        expected_interactions = {(0, 0): [[('C', 'C'), ('C', 'C')] for _ in
+        expected_interactions = {(0, 0): [[(C, C), (C, C)] for _ in
                                           range(3)],
-                                 (0, 1): [[('C', 'D'), ('C', 'D')] for _ in
+                                 (0, 1): [[(C, D), (C, D)] for _ in
                                           range(3)],
-                                 (1, 1): [[('D', 'D'), ('D', 'D')] for _ in
+                                 (1, 1): [[(D, D), (D, D)] for _ in
                                           range(3)]}
         interactions = iu.read_interactions_from_file(tmp_file.name,
                                                       progress_bar=False)
@@ -133,5 +133,5 @@ class TestMatch(unittest.TestCase):
 
     def test_string_to_interactions(self):
         string = 'CDCDDD'
-        interactions = [('C', 'D'), ('C', 'D'), ('D', 'D')]
+        interactions = [(C, D), (C, D), (D, D)]
         self.assertEqual(iu.string_to_interactions(string), interactions)

--- a/axelrod/tests/unit/test_resultset.py
+++ b/axelrod/tests/unit/test_resultset.py
@@ -534,6 +534,35 @@ class TestResultSet(unittest.TestCase):
                 self.assertLessEqual(rate, 1)
                 self.assertGreaterEqual(rate, 0)
 
+    # When converting Actions to Enum, test coverage gap exposed from example in
+    # docs/tutorial/getting_started/summarising_tournamens.rst
+    def test_summarise_regression_test(self):
+        players = [axelrod.Cooperator(), axelrod.Defector(),
+                   axelrod.TitForTat(), axelrod.Grudger()]
+        tournament = axelrod.Tournament(players, turns=10, repetitions=3)
+        results = tournament.play()
+
+        summary = [
+            (0,  'Defector',  2.6000000000000001, 0.0,  3.0,  0.0, 0.0,  0.0,
+             0.4000000000000001,0.6, 0, 0, 0,0),
+            (1,  'Tit For Tat', 2.3000000000000003, 0.7,  0.0,  1.0,
+             0.6666666666666666,  0.03333333333333333, 0.0,  0.3,
+             1.0, 0, 0, 0),
+            (2,  'Grudger',  2.3000000000000003, 0.7,  0.0,  1.0,
+             0.6666666666666666,  0.03333333333333333, 0.0,  0.3,
+             1.0, 0, 0, 0),
+            (3,  'Cooperator',  2.0, 1.0,  0.0,  1.0, 0.6666666666666666,
+             0.3333333333333333, 0.0, 0.0, 1.0, 1.0, 0, 0)
+        ]
+        for outer_index, player in enumerate(results.summarise()):
+            for inner_index, value in enumerate(player):
+                if isinstance(value, str):
+                    self.assertEqual(value, summary[outer_index][inner_index])
+                else:
+                    self.assertAlmostEqual(value,
+                                           summary[outer_index][inner_index],
+                                           places=3)
+
     def test_write_summary(self):
         rs = axelrod.ResultSet(self.players, self.interactions,
                                progress_bar=False)

--- a/axelrod/tests/unit/test_resultset.py
+++ b/axelrod/tests/unit/test_resultset.py
@@ -535,7 +535,7 @@ class TestResultSet(unittest.TestCase):
                 self.assertGreaterEqual(rate, 0)
 
     # When converting Actions to Enum, test coverage gap exposed from example in
-    # docs/tutorial/getting_started/summarising_tournamens.rst
+    # docs/tutorial/getting_started/summarising_tournaments.rst
     def test_summarise_regression_test(self):
         players = [axelrod.Cooperator(), axelrod.Defector(),
                    axelrod.TitForTat(), axelrod.Grudger()]

--- a/axelrod/tests/unit/test_resultset.py
+++ b/axelrod/tests/unit/test_resultset.py
@@ -10,6 +10,8 @@ import axelrod.interaction_utils as iu
 from axelrod.tests.property import tournaments, prob_end_tournaments
 
 
+C, D = axelrod.Actions.C, axelrod.Actions.D
+
 class TestResultSet(unittest.TestCase):
 
     @classmethod
@@ -130,53 +132,53 @@ class TestResultSet(unittest.TestCase):
 
         cls.expected_state_distribution = [
                 [Counter(),
-                 Counter({('D', 'C'): 6, ('C', 'D'): 6, ('C', 'C'): 3}),
-                 Counter({('C', 'D'): 9, ('D', 'D'): 6})],
-                [Counter({('D', 'C'): 6, ('C', 'D'): 6, ('C', 'C'): 3}),
+                 Counter({(D, C): 6, (C, D): 6, (C, C): 3}),
+                 Counter({(C, D): 9, (D, D): 6})],
+                [Counter({(D, C): 6, (C, D): 6, (C, C): 3}),
                  Counter(),
-                 Counter({('D', 'D'): 12, ('C', 'D'): 3})],
-                [Counter({('D', 'C'): 9, ('D', 'D'): 6}),
-                 Counter({('D', 'D'): 12, ('D', 'C'): 3}),
+                 Counter({(D, D): 12, (C, D): 3})],
+                [Counter({(D, C): 9, (D, D): 6}),
+                 Counter({(D, D): 12, (D, C): 3}),
                  Counter()]
             ]
 
         cls.expected_normalised_state_distribution = [
                 [Counter(),
-                 Counter({('D', 'C'): 0.4, ('C', 'D'): 0.4, ('C', 'C'): 0.2}),
-                 Counter({('C', 'D'): 0.6, ('D', 'D'): 0.4})],
-                [Counter({('D', 'C'): 0.4, ('C', 'D'): 0.4, ('C', 'C'): 0.2}),
+                 Counter({(D, C): 0.4, (C, D): 0.4, (C, C): 0.2}),
+                 Counter({(C, D): 0.6, (D, D): 0.4})],
+                [Counter({(D, C): 0.4, (C, D): 0.4, (C, C): 0.2}),
                  Counter(),
-                 Counter({('D', 'D'): 0.8, ('C', 'D'): 0.2})],
-                [Counter({('D', 'C'): 0.6, ('D', 'D'): 0.4}),
-                 Counter({('D', 'D'): 0.8, ('D', 'C'): 0.2}),
+                 Counter({(D, D): 0.8, (C, D): 0.2})],
+                [Counter({(D, C): 0.6, (D, D): 0.4}),
+                 Counter({(D, D): 0.8, (D, C): 0.2}),
                  Counter()]
             ]
 
         cls.expected_state_to_action_distribution = [
              [Counter(),
-              Counter({(('C', 'C'), 'D'): 3, (('C', 'D'), 'D'): 3,
-			   		(('D', 'C'), 'C'): 6}),
-              Counter({(('C', 'D'), 'D'): 6, (('D', 'D'), 'C'): 6})],
-             [Counter({(('C', 'C'), 'C'): 3, (('D', 'C'), 'C'): 3,
-			   		(('C', 'D'), 'D'): 6}),
+              Counter({((C, C), D): 3, ((C, D), D): 3,
+			   		((D, C), C): 6}),
+              Counter({((C, D), D): 6, ((D, D), C): 6})],
+             [Counter({((C, C), C): 3, ((D, C), C): 3,
+			   		((C, D), D): 6}),
               Counter(),
-              Counter({(('C', 'D'), 'D'): 3, (('D', 'D'), 'D'): 9})],
-             [Counter({(('D', 'C'), 'D'): 6, (('D', 'D'), 'D'): 6}),
-              Counter({(('D', 'C'), 'D'): 3, (('D', 'D'), 'D'): 9}),
+              Counter({((C, D), D): 3, ((D, D), D): 9})],
+             [Counter({((D, C), D): 6, ((D, D), D): 6}),
+              Counter({((D, C), D): 3, ((D, D), D): 9}),
               Counter()]
              ]
 
         cls.expected_normalised_state_to_action_distribution = [
              [Counter(),
-              Counter({(('C', 'C'), 'D'): 1, (('C', 'D'), 'D'): 1,
-			   		(('D', 'C'), 'C'): 1}),
-              Counter({(('C', 'D'), 'D'): 1, (('D', 'D'), 'C'): 1})],
-             [Counter({(('C', 'C'), 'C'): 1, (('D', 'C'), 'C'): 1,
-			   		   (('C', 'D'), 'D'): 1}),
+              Counter({((C, C), D): 1, ((C, D), D): 1,
+			   		((D, C), C): 1}),
+              Counter({((C, D), D): 1, ((D, D), C): 1})],
+             [Counter({((C, C), C): 1, ((D, C), C): 1,
+			   		   ((C, D), D): 1}),
               Counter(),
-              Counter({(('C', 'D'), 'D'): 1, (('D', 'D'), 'D'): 1})],
-             [Counter({(('D', 'C'), 'D'): 1, (('D', 'D'), 'D'): 1}),
-              Counter({(('D', 'C'), 'D'): 1, (('D', 'D'), 'D'): 1}),
+              Counter({((C, D), D): 1, ((D, D), D): 1})],
+             [Counter({((D, C), D): 1, ((D, D), D): 1}),
+              Counter({((D, C), D): 1, ((D, D), D): 1}),
               Counter()]
              ]
 
@@ -700,11 +702,11 @@ class TestResultSetFromFile(unittest.TestCase):
         matches = brs.read_match_chunks()
         chunk = next(matches)
         self.assertEqual(chunk[0],
-                         ['0'] * 2 + ['Cooperator'] * 2 + [('C', 'C')] * 2)
+                         ['0'] * 2 + ['Cooperator'] * 2 + [(C, C)] * 2)
         self.assertEqual(chunk[1],
-                         ['0'] * 2 + ['Cooperator'] * 2 + [('C', 'C')] * 2)
+                         ['0'] * 2 + ['Cooperator'] * 2 + [(C, C)] * 2)
         self.assertEqual(chunk[2],
-                         ['0'] * 2 + ['Cooperator'] * 2 + [('C', 'C')] * 2)
+                         ['0'] * 2 + ['Cooperator'] * 2 + [(C, C)] * 2)
         self.assertEqual(len(list(matches)), 5)
 
     def test_build_all(self):
@@ -917,45 +919,45 @@ class TestResultSetSpatialStructure(TestResultSet):
 
         cls.expected_state_distribution = [
               [Counter(),
-               Counter({('C', 'C'): 3, ('C', 'D'): 6, ('D', 'C'): 6}),
-               Counter({('C', 'D'): 9, ('D', 'D'): 6})],
-              [Counter({('C', 'C'): 3, ('C', 'D'): 6, ('D', 'C'): 6}),
+               Counter({(C, C): 3, (C, D): 6, (D, C): 6}),
+               Counter({(C, D): 9, (D, D): 6})],
+              [Counter({(C, C): 3, (C, D): 6, (D, C): 6}),
                Counter(),
                Counter()],
-              [Counter({('D', 'C'): 9, ('D', 'D'): 6}), Counter(), Counter()]
+              [Counter({(D, C): 9, (D, D): 6}), Counter(), Counter()]
             ]
 
         cls.expected_normalised_state_distribution = [
               [Counter(),
-               Counter({('C', 'C'): 0.2, ('C', 'D'): 0.4, ('D', 'C'): 0.4}),
-               Counter({('C', 'D'): 0.6, ('D', 'D'): 0.4})],
-              [Counter({('C', 'C'): 0.2, ('C', 'D'): 0.4, ('D', 'C'): 0.4}),
+               Counter({(C, C): 0.2, (C, D): 0.4, (D, C): 0.4}),
+               Counter({(C, D): 0.6, (D, D): 0.4})],
+              [Counter({(C, C): 0.2, (C, D): 0.4, (D, C): 0.4}),
                Counter(),
                Counter()],
-              [Counter({('D', 'C'): 0.6, ('D', 'D'): 0.4}), Counter(), Counter()]
+              [Counter({(D, C): 0.6, (D, D): 0.4}), Counter(), Counter()]
             ]
 
         cls.expected_state_to_action_distribution = [
             [Counter(),
-             Counter({(('C', 'C'), 'D'): 3,
-                      (('C', 'D'), 'D'): 3,
-                      (('D', 'C'), 'C'): 6}),
-             Counter({(('C', 'D'), 'D'): 6,
-                      (('D', 'D'), 'C'): 6})],
-            [Counter({(('C', 'C'), 'C'): 3, (('D', 'C'), 'C'): 3,
-                      (('C', 'D'), 'D'): 6}), Counter(), Counter()],
-            [Counter({(('D', 'C'), 'D'): 6, (('D', 'D'), 'D'): 6}),
+             Counter({((C, C), D): 3,
+                      ((C, D), D): 3,
+                      ((D, C), C): 6}),
+             Counter({((C, D), D): 6,
+                      ((D, D), C): 6})],
+            [Counter({((C, C), C): 3, ((D, C), C): 3,
+                      ((C, D), D): 6}), Counter(), Counter()],
+            [Counter({((D, C), D): 6, ((D, D), D): 6}),
              Counter(), Counter()]]
 
         cls.expected_normalised_state_to_action_distribution = [
             [Counter(),
-             Counter({(('C', 'C'), 'D'): 1.0, (('C', 'D'), 'D'): 1.0,
-                      (('D', 'C'), 'C'): 1.0}),
-             Counter({(('C', 'D'), 'D'): 1.0, (('D', 'D'), 'C'): 1.0})],
-            [Counter({(('C', 'C'), 'C'): 1.0, (('D', 'C'), 'C'): 1.0,
-                      (('C', 'D'), 'D'): 1.0}),
+             Counter({((C, C), D): 1.0, ((C, D), D): 1.0,
+                      ((D, C), C): 1.0}),
+             Counter({((C, D), D): 1.0, ((D, D), C): 1.0})],
+            [Counter({((C, C), C): 1.0, ((D, C), C): 1.0,
+                      ((C, D), D): 1.0}),
              Counter(), Counter()],
-            [Counter({(('D', 'C'), 'D'): 1.0, (('D', 'D'), 'D'): 1.0}),
+            [Counter({((D, C), D): 1.0, ((D, D), D): 1.0}),
              Counter(), Counter()]]
 
     def test_match_lengths(self):
@@ -1165,51 +1167,51 @@ class TestResultSetSpatialStructureTwo(TestResultSetSpatialStructure):
 
         cls.expected_state_distribution = [
                [Counter(),
-                Counter({('C', 'C'): 3, ('C', 'D'): 6, ('D', 'C'): 6}),
+                Counter({(C, C): 3, (C, D): 6, (D, C): 6}),
                 Counter(),
                 Counter()],
-               [Counter({('C', 'C'): 3, ('C', 'D'): 6, ('D', 'C'): 6}),
+               [Counter({(C, C): 3, (C, D): 6, (D, C): 6}),
                 Counter(),
                 Counter(),
                 Counter()],
-               [Counter(), Counter(), Counter(), Counter({('D', 'C'): 15})],
-               [Counter(), Counter(), Counter({('C', 'D'): 15}), Counter()]
+               [Counter(), Counter(), Counter(), Counter({(D, C): 15})],
+               [Counter(), Counter(), Counter({(C, D): 15}), Counter()]
             ]
 
         cls.expected_normalised_state_distribution = [
                [Counter(),
-                Counter({('C', 'C'): 0.2, ('C', 'D'): 0.4, ('D', 'C'): 0.4}),
+                Counter({(C, C): 0.2, (C, D): 0.4, (D, C): 0.4}),
                 Counter(),
                 Counter()],
-               [Counter({('C', 'C'): 0.2, ('C', 'D'): 0.4, ('D', 'C'): 0.4}),
+               [Counter({(C, C): 0.2, (C, D): 0.4, (D, C): 0.4}),
                 Counter(),
                 Counter(),
                 Counter()],
-               [Counter(), Counter(), Counter(), Counter({('D', 'C'): 1.0})],
-               [Counter(), Counter(), Counter({('C', 'D'): 1.0}), Counter()]
+               [Counter(), Counter(), Counter(), Counter({(D, C): 1.0})],
+               [Counter(), Counter(), Counter({(C, D): 1.0}), Counter()]
             ]
 
         cls.expected_state_to_action_distribution = [
             [Counter(),
-             Counter({(('C', 'C'), 'D'): 3, (('C', 'D'), 'D'): 3,
-                      (('D', 'C'), 'C'): 6}),
+             Counter({((C, C), D): 3, ((C, D), D): 3,
+                      ((D, C), C): 6}),
              Counter(), Counter()],
-            [Counter({(('C', 'C'), 'C'): 3, (('D', 'C'), 'C'): 3,
-                      (('C', 'D'), 'D'): 6}),
+            [Counter({((C, C), C): 3, ((D, C), C): 3,
+                      ((C, D), D): 6}),
              Counter(), Counter(), Counter()],
-            [Counter(), Counter(), Counter(), Counter({(('D', 'C'), 'D'): 12})],
-            [Counter(), Counter(), Counter({(('C', 'D'), 'C'): 12}), Counter()]]
+            [Counter(), Counter(), Counter(), Counter({((D, C), D): 12})],
+            [Counter(), Counter(), Counter({((C, D), C): 12}), Counter()]]
 
         cls.expected_normalised_state_to_action_distribution = [
             [Counter(),
-             Counter({(('C', 'C'), 'D'): 1.0, (('C', 'D'), 'D'): 1.0,
-                      (('D', 'C'), 'C'): 1.0}),
+             Counter({((C, C), D): 1.0, ((C, D), D): 1.0,
+                      ((D, C), C): 1.0}),
              Counter(), Counter()],
-            [Counter({(('C', 'C'), 'C'): 1.0, (('D', 'C'), 'C'): 1.0,
-                      (('C', 'D'), 'D'): 1.0}),
+            [Counter({((C, C), C): 1.0, ((D, C), C): 1.0,
+                      ((C, D), D): 1.0}),
              Counter(), Counter(), Counter()],
-            [Counter(), Counter(), Counter(), Counter({(('D', 'C'), 'D'): 1.0})],
-            [Counter(), Counter(), Counter({(('C', 'D'), 'C'): 1.0}), Counter()]]
+            [Counter(), Counter(), Counter(), Counter({((D, C), D): 1.0})],
+            [Counter(), Counter(), Counter({((C, D), C): 1.0}), Counter()]]
 
 
 

--- a/axelrod/tests/unit/test_strategy_transformers.py
+++ b/axelrod/tests/unit/test_strategy_transformers.py
@@ -45,9 +45,10 @@ class TestTransformers(unittest.TestCase):
         """Tests that the player __repr__ is properly modified to add
         Transformer's parameters.
         """
+        self.maxDiff = None
         self.assertEqual(str(ForgiverTransformer(0.5)(axelrod.Alternator)()), "Forgiving Alternator: 0.5")
         self.assertEqual(str(InitialTransformer([D, D, C])(axelrod.Alternator)()),
-                         "Initial Alternator: ['D', 'D', 'C']")
+                         "Initial Alternator: [D, D, C]")
         self.assertEqual(str(FlipTransformer()(axelrod.Random)(0.1)), "Flipped Random: 0.1")
         self.assertEqual(str(MixedTransformer(0.3, (axelrod.Alternator, axelrod.Bully))(axelrod.Random)(0.1)),
                          "Mutated Random: 0.1: 0.3, ['Alternator', 'Bully']")

--- a/axelrod/tests/unit/test_strategy_transformers.py
+++ b/axelrod/tests/unit/test_strategy_transformers.py
@@ -45,7 +45,6 @@ class TestTransformers(unittest.TestCase):
         """Tests that the player __repr__ is properly modified to add
         Transformer's parameters.
         """
-        self.maxDiff = None
         self.assertEqual(str(ForgiverTransformer(0.5)(axelrod.Alternator)()), "Forgiving Alternator: 0.5")
         self.assertEqual(str(InitialTransformer([D, D, C])(axelrod.Alternator)()),
                          "Initial Alternator: [D, D, C]")

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -17,6 +17,8 @@ from axelrod.tests.property import (tournaments,
 import axelrod
 
 
+C, D = axelrod.Actions.C, axelrod.Actions.D
+
 test_strategies = [axelrod.Cooperator,
                    axelrod.TitForTat,
                    axelrod.Defector,
@@ -70,7 +72,7 @@ class TestTournament(unittest.TestCase):
         self.assertIsInstance(
             tournament.players[0].match_attributes['game'], axelrod.Game
         )
-        self.assertEqual(tournament.game.score(('C', 'C')), (3, 3))
+        self.assertEqual(tournament.game.score((C, C)), (3, 3))
         self.assertEqual(tournament.turns, self.test_turns)
         self.assertEqual(tournament.repetitions, 10)
         self.assertEqual(tournament.name, 'test')
@@ -559,7 +561,7 @@ class TestProbEndTournament(unittest.TestCase):
                                         noise=0.2)
         self.assertEqual(tournament.match_generator.prob_end, tournament.prob_end)
         self.assertEqual(len(tournament.players), len(test_strategies))
-        self.assertEqual(tournament.game.score(('C', 'C')), (3, 3))
+        self.assertEqual(tournament.game.score((C, C)), (3, 3))
         self.assertIsNone(tournament.turns)
         self.assertEqual(tournament.repetitions, 10)
         self.assertEqual(tournament.name, 'test')
@@ -618,7 +620,7 @@ class TestSpatialTournament(unittest.TestCase):
                                         noise=0.2)
         self.assertEqual(tournament.match_generator.edges, tournament.edges)
         self.assertEqual(len(tournament.players), len(test_strategies))
-        self.assertEqual(tournament.game.score(('C', 'C')), (3, 3))
+        self.assertEqual(tournament.game.score((C, C)), (3, 3))
         self.assertEqual(tournament.turns, 100)
         self.assertEqual(tournament.repetitions, 10)
         self.assertEqual(tournament.name, 'test')
@@ -722,7 +724,7 @@ class TestProbEndingSpatialTournament(unittest.TestCase):
                                         noise=0.2)
         self.assertEqual(tournament.match_generator.edges, tournament.edges)
         self.assertEqual(len(tournament.players), len(test_strategies))
-        self.assertEqual(tournament.game.score(('C', 'C')), (3, 3))
+        self.assertEqual(tournament.game.score((C, C)), (3, 3))
         self.assertIsNone(tournament.turns)
         self.assertEqual(tournament.repetitions, 10)
         self.assertEqual(tournament.name, 'test')

--- a/axelrod/tournament.py
+++ b/axelrod/tournament.py
@@ -9,6 +9,7 @@ import tqdm
 
 from axelrod import on_windows, DEFAULT_TURNS
 from axelrod.player import Player
+from axelrod.actions import action_sequence_to_str
 from .game import Game
 from .match import Match
 from .match_generator import MatchGenerator
@@ -210,8 +211,8 @@ class Tournament(object):
                 row = list(index_pair)
                 row.append(str(self.players[index_pair[0]]))
                 row.append(str(self.players[index_pair[1]]))
-                history1 = "".join([i[0] for i in interaction])
-                history2 = "".join([i[1] for i in interaction])
+                history1 = action_sequence_to_str([i[0] for i in interaction])
+                history2 = action_sequence_to_str([i[1] for i in interaction])
                 row.append(history1)
                 row.append(history2)
                 self.writer.writerow(row)

--- a/axelrod/tournament.py
+++ b/axelrod/tournament.py
@@ -9,7 +9,7 @@ import tqdm
 
 from axelrod import on_windows, DEFAULT_TURNS
 from axelrod.player import Player
-from axelrod.actions import action_sequence_to_str
+from axelrod.actions import actions_to_str
 from .game import Game
 from .match import Match
 from .match_generator import MatchGenerator
@@ -211,8 +211,8 @@ class Tournament(object):
                 row = list(index_pair)
                 row.append(str(self.players[index_pair[0]]))
                 row.append(str(self.players[index_pair[1]]))
-                history1 = action_sequence_to_str([i[0] for i in interaction])
-                history2 = action_sequence_to_str([i[1] for i in interaction])
+                history1 = actions_to_str([i[0] for i in interaction])
+                history2 = actions_to_str([i[1] for i in interaction])
                 row.append(history1)
                 row.append(history2)
                 self.writer.writerow(row)
@@ -348,7 +348,7 @@ class Tournament(object):
         interactions : dictionary
             Mapping player index pairs to results of matches:
 
-                (0, 1) -> [('C', 'D'), ('D', 'C'),...]
+                (0, 1) -> [(C, D), (D, C),...]
         """
         interactions = defaultdict(list)
         index_pair, match_params, repetitions = chunk

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,7 +56,7 @@ Create matches between two players::
     >>> match = axl.Match(players, 5)
     >>> interactions = match.play()
     >>> interactions
-    [('C', 'C'), ('D', 'C'), ('C', 'D'), ('D', 'C'), ('C', 'D')]
+    [(C, C), (D, C), (C, D), (D, C), (C, D)]
 
 Build full tournaments between groups of players::
 

--- a/docs/reference/glossary.rst
+++ b/docs/reference/glossary.rst
@@ -12,9 +12,9 @@ You can access these actions as follows but should not really have a reason to::
 
     >>> import axelrod as axl
     >>> axl.Actions.C
-    'C'
+    C
     >>> axl.Actions.D
-    'D'
+    D
 
 A play
 ------
@@ -48,7 +48,7 @@ used in the tournament is 200. Here is a single match between two players over
     >>> for turn in range(10):
     ...     p1.play(p2)
     >>> p1.history, p2.history
-    (['C', 'C', 'C', 'C', 'C', 'C', 'C', 'C', 'C', 'C'], ['D', 'D', 'D', 'D', 'D', 'D', 'D', 'D', 'D', 'D'])
+    ([C, C, C, C, C, C, C, C, C, C], [D, D, D, D, D, D, D, D, D, D])
 
 A win
 -----

--- a/docs/tutorials/advanced/player_equality.rst
+++ b/docs/tutorials/advanced/player_equality.rst
@@ -20,7 +20,7 @@ This however does not check if the players will behave in the same way. For
 example here are two equivalent players::
 
     >>> p1 = axl.Alternator()
-    >>> p2 = axl.Cycler((axl.Actions.C, axl.Actions.D))
+    >>> p2 = axl.Cycler("CD")
     >>> p1 == p2
     False
 

--- a/docs/tutorials/advanced/reading_and_writing_interactions.rst
+++ b/docs/tutorials/advanced/reading_and_writing_interactions.rst
@@ -108,8 +108,9 @@ could also be in a different order.
 
 This can be transformed in to the usual interactions by zipping:
 
-    >>> list(zip("CCDC", "CDCD"))
-    [('C', 'C'), ('C', 'D'), ('D', 'C'), ('C', 'D')]
+    >>> from axelrod.actions import str_to_actions
+    >>> list(zip(str_to_actions("CCDC"), str_to_actions("CDCD")))
+    [(C, C), (C, D), (D, C), (C, D)]
 
 This should allow for easy manipulation of data outside of the capabilities
 within the library. Note that you can supply `build_results=False` as a keyword

--- a/docs/tutorials/advanced/strategy_transformers.rst
+++ b/docs/tutorials/advanced/strategy_transformers.rst
@@ -16,9 +16,9 @@ C to D and D to C::
     >>> player = FlippedCooperator()
     >>> opponent = axl.Cooperator()
     >>> player.strategy(opponent)
-    'D'
+    D
     >>> opponent.strategy(player)
-    'C'
+    C
 
 Our player was switched from a :code:`Cooperator` to a :code:`Defector` when
 we applied the transformer. The transformer also changed the name of the

--- a/docs/tutorials/advanced/tournament_results.rst
+++ b/docs/tutorials/advanced/tournament_results.rst
@@ -224,26 +224,26 @@ State distribution counts
 -------------------------
 
 This gives a total state count against each opponent. A state corresponds to 1
-turn of a match and can be one of :code:`('C', 'C'), ('C', 'D'), ('D', 'C'),
-('D', 'D')` where the first element is the action of the player in question and
+turn of a match and can be one of :code:`(C, C), (C, D), (D, C),
+(D, D)` where the first element is the action of the player in question and
 the second the action of the opponent::
 
     >>> pprint.pprint(results.state_distribution)
     [[Counter(),
-      Counter({('C', 'D'): 30}),
-      Counter({('C', 'C'): 30}),
-      Counter({('C', 'C'): 30})],
-     [Counter({('D', 'C'): 30}),
+      Counter({(C, D): 30}),
+      Counter({(C, C): 30}),
+      Counter({(C, C): 30})],
+     [Counter({(D, C): 30}),
       Counter(),
-      Counter({('D', 'D'): 27, ('D', 'C'): 3}),
-      Counter({('D', 'D'): 27, ('D', 'C'): 3})],
-     [Counter({('C', 'C'): 30}),
-      Counter({('D', 'D'): 27, ('C', 'D'): 3}),
+      Counter({(D, D): 27, (D, C): 3}),
+      Counter({(D, D): 27, (D, C): 3})],
+     [Counter({(C, C): 30}),
+      Counter({(D, D): 27, (C, D): 3}),
       Counter(),
-      Counter({('C', 'C'): 30})],
-     [Counter({('C', 'C'): 30}),
-      Counter({('D', 'D'): 27, ('C', 'D'): 3}),
-      Counter({('C', 'C'): 30}),
+      Counter({(C, C): 30})],
+     [Counter({(C, C): 30}),
+      Counter({(D, D): 27, (C, D): 3}),
+      Counter({(C, C): 30}),
       Counter()]]
 
 Normalised state distribution
@@ -251,52 +251,52 @@ Normalised state distribution
 
 This gives the average rate state distribution against each opponent.
 A state corresponds to 1
-turn of a match and can be one of :code:`('C', 'C'), ('C', 'D'), ('D', 'C'),
-('D', 'D')` where the first element is the action of the player in question and
+turn of a match and can be one of :code:`(C, C), (C, D), (D, C),
+(D, D)` where the first element is the action of the player in question and
 the second the action of the opponent::
 
     >>> pprint.pprint(results.normalised_state_distribution)
     [[Counter(),
-      Counter({('C', 'D'): 1.0}),
-      Counter({('C', 'C'): 1.0}),
-      Counter({('C', 'C'): 1.0})],
-     [Counter({('D', 'C'): 1.0}),
+      Counter({(C, D): 1.0}),
+      Counter({(C, C): 1.0}),
+      Counter({(C, C): 1.0})],
+     [Counter({(D, C): 1.0}),
       Counter(),
-      Counter({('D', 'D'): 0.9, ('D', 'C'): 0.1}),
-      Counter({('D', 'D'): 0.9, ('D', 'C'): 0.1})],
-     [Counter({('C', 'C'): 1.0}),
-      Counter({('D', 'D'): 0.9, ('C', 'D'): 0.1}),
+      Counter({(D, D): 0.9, (D, C): 0.1}),
+      Counter({(D, D): 0.9, (D, C): 0.1})],
+     [Counter({(C, C): 1.0}),
+      Counter({(D, D): 0.9, (C, D): 0.1}),
       Counter(),
-      Counter({('C', 'C'): 1.0})],
-     [Counter({('C', 'C'): 1.0}),
-      Counter({('D', 'D'): 0.9, ('C', 'D'): 0.1}),
-      Counter({('C', 'C'): 1.0}),
+      Counter({(C, C): 1.0})],
+     [Counter({(C, C): 1.0}),
+      Counter({(D, D): 0.9, (C, D): 0.1}),
+      Counter({(C, C): 1.0}),
       Counter()]]
 
 State to action distribution counts
 -----------------------------------
 
 This gives a total state action pair count against each opponent. A state
-corresponds to 1 turn of a match and can be one of :code:`('C', 'C'), ('C',
-'D'), ('D', 'C'), ('D', 'D')` where the first element is the action of the
+corresponds to 1 turn of a match and can be one of :code:`(C, C), (C,
+D), (D, C), (D, D)` where the first element is the action of the
 player in question and the second the action of the opponent::
 
     >>> pprint.pprint(results.state_to_action_distribution)  # doctest: +SKIP
     [[Counter(),
-      Counter({(('C', 'D'), 'C'): 27}),
-      Counter({(('C', 'C'), 'C'): 27}),
-      Counter({(('C', 'C'), 'C'): 27})],
-     [Counter({(('D', 'C'), 'D'): 27}),
+      Counter({((C, D), C): 27}),
+      Counter({((C, C), C): 27}),
+      Counter({((C, C), C): 27})],
+     [Counter({((D, C), D): 27}),
       Counter(),
-      Counter({(('D', 'D'), 'D'): 24, (('D', 'C'), 'D'): 3}),
-      Counter({(('D', 'D'), 'D'): 24, (('D', 'C'), 'D'): 3})],
-     [Counter({(('C', 'C'), 'C'): 27}),
-      Counter({(('D', 'D'), 'D'): 24, (('C', 'D'), 'D'): 3}),
+      Counter({((D, D), D): 24, ((D, C), D): 3}),
+      Counter({((D, D), D): 24, ((D, C), D): 3})],
+     [Counter({((C, C), C): 27}),
+      Counter({((D, D), D): 24, ((C, D), D): 3}),
       Counter(),
-      Counter({(('C', 'C'), 'C'): 27})],
-     [Counter({(('C', 'C'), 'C'): 27}),
-      Counter({(('D', 'D'), 'D'): 24, (('C', 'D'), 'D'): 3}),
-      Counter({(('C', 'C'), 'C'): 27}),
+      Counter({((C, C), C): 27})],
+     [Counter({((C, C), C): 27}),
+      Counter({((D, D), D): 24, ((C, D), D): 3}),
+      Counter({((C, C), C): 27}),
       Counter()]]
 
 Normalised state to action distribution
@@ -304,26 +304,26 @@ Normalised state to action distribution
 
 This gives the average rate state to action pair distribution against each
 opponent.  A state corresponds to 1 turn of a match and can be one of
-:code:`('C', 'C'), ('C', 'D'), ('D', 'C'), ('D', 'D')` where the first element
+:code:`(C, C), (C, D), (D, C), (D, D)` where the first element
 is the action of the player in question and the second the action of the
 opponent::
 
     >>> pprint.pprint(results.normalised_state_to_action_distribution) # doctest: +SKIP
     [[Counter(),
-      Counter({(('C', 'D'), 'C'): 1.0}),
-      Counter({(('C', 'C'), 'C'): 1.0}),
-      Counter({(('C', 'C'), 'C'): 1.0})],
-     [Counter({(('D', 'C'), 'D'): 1.0}),
+      Counter({((C, D), C): 1.0}),
+      Counter({((C, C), C): 1.0}),
+      Counter({((C, C), C): 1.0})],
+     [Counter({((D, C), D): 1.0}),
       Counter(),
-      Counter({(('D', 'C'), 'D'): 1.0, (('D', 'D'), 'D'): 1.0}),
-      Counter({(('D', 'C'), 'D'): 1.0, (('D', 'D'), 'D'): 1.0})],
-     [Counter({(('C', 'C'), 'C'): 1.0}),
-      Counter({(('C', 'D'), 'D'): 1.0, (('D', 'D'), 'D'): 1.0}),
+      Counter({((D, C), D): 1.0, ((D, D), D): 1.0}),
+      Counter({((D, C), D): 1.0, ((D, D), D): 1.0})],
+     [Counter({((C, C), C): 1.0}),
+      Counter({((C, D), D): 1.0, ((D, D), D): 1.0}),
       Counter(),
-      Counter({(('C', 'C'), 'C'): 1.0})],
-     [Counter({(('C', 'C'), 'C'): 1.0}),
-      Counter({(('C', 'D'), 'D'): 1.0, (('D', 'D'), 'D'): 1.0}),
-      Counter({(('C', 'C'), 'C'): 1.0}),
+      Counter({((C, C), C): 1.0})],
+     [Counter({((C, C), C): 1.0}),
+      Counter({((C, D), D): 1.0, ((D, D), D): 1.0}),
+      Counter({((C, C), C): 1.0}),
       Counter()]]
 
 Initial cooperation counts

--- a/docs/tutorials/advanced/using_the_cache.rst
+++ b/docs/tutorials/advanced/using_the_cache.rst
@@ -35,12 +35,12 @@ Let us rerun the above match but using the cache::
     >>> p1, p2 = axl.GoByMajority(), axl.Alternator()
     >>> match = axl.Match((p1, p2), turns=200, deterministic_cache=cache)
     >>> match.play()  # doctest: +ELLIPSIS
-    [('C', 'C'), ..., ('C', 'D')]
+    [(C, C), ..., (C, D)]
 
 We can take a look at the cache::
 
     >>> cache  # doctest: +ELLIPSIS
-    {('Soft Go By Majority', 'Alternator', 200): [('C', 'C'), ..., ('C', 'D')]}
+    {('Soft Go By Majority', 'Alternator', 200): [(C, C), ..., (C, D)]}
     >>> len(cache)
     1
 

--- a/docs/tutorials/further_topics/spatial_tournaments.rst
+++ b/docs/tutorials/further_topics/spatial_tournaments.rst
@@ -56,10 +56,10 @@ and obtain the interactions::
     ...     player1 = spatial_tournament.players[index_pair[0]]
     ...     player2 = spatial_tournament.players[index_pair[1]]
     ...     print('%s vs %s: %s' % (player1, player2, interaction))
-    Cooperator vs Tit For Tat: [[('C', 'C'), ('C', 'C')], [('C', 'C'), ('C', 'C')]]
-    Cooperator vs Grudger: [[('C', 'C'), ('C', 'C')], [('C', 'C'), ('C', 'C')]]
-    Defector vs Tit For Tat: [[('D', 'C'), ('D', 'D')], [('D', 'C'), ('D', 'D')]]
-    Defector vs Grudger: [[('D', 'C'), ('D', 'D')], [('D', 'C'), ('D', 'D')]]
+    Cooperator vs Tit For Tat: [[(C, C), (C, C)], [(C, C), (C, C)]]
+    Cooperator vs Grudger: [[(C, C), (C, C)], [(C, C), (C, C)]]
+    Defector vs Tit For Tat: [[(D, C), (D, D)], [(D, C), (D, D)]]
+    Defector vs Grudger: [[(D, C), (D, D)], [(D, C), (D, D)]]
 
 As anticipated  :code:`Cooperator` does not interact with :code:`Defector` neither
 :code:`TitForTat` with :code:`Grudger`.

--- a/docs/tutorials/getting_started/human_interaction.rst
+++ b/docs/tutorials/getting_started/human_interaction.rst
@@ -23,7 +23,7 @@ You will be prompted for the action to play at each turn:
 
     Turn 2: me played D, opponent played C
     Turn 3 action [C or D] for me: C
-    [('C', 'C'), ('C', 'D'), ('D', 'C')]
+    [(C, C), (C, D), (D, C)]
 
 after this, the :code:`match` object can be manipulated as described in
 :ref:`creating_matches`

--- a/docs/tutorials/getting_started/interactions.rst
+++ b/docs/tutorials/getting_started/interactions.rst
@@ -24,16 +24,16 @@ view the history of the interactions::
     ...     player1 = tournament.players[index_pair[0]]
     ...     player2 = tournament.players[index_pair[1]]
     ...     print('%s vs %s: %s' % (player1, player2, interaction)) # doctest: +SKIP
-    Cooperator vs Defector: [('C', 'D'), ('C', 'D'), ('C', 'D')]
-    Defector vs Tit For Tat: [('D', 'C'), ('D', 'D'), ('D', 'D')]
-    Cooperator vs Cooperator: [('C', 'C'), ('C', 'C'), ('C', 'C')]
-    Tit For Tat vs Grudger: [('C', 'C'), ('C', 'C'), ('C', 'C')]
-    Grudger vs Grudger: [('C', 'C'), ('C', 'C'), ('C', 'C')]
-    Tit For Tat vs Tit For Tat: [('C', 'C'), ('C', 'C'), ('C', 'C')]
-    Defector vs Grudger: [('D', 'C'), ('D', 'D'), ('D', 'D')]
-    Cooperator vs Grudger: [('C', 'C'), ('C', 'C'), ('C', 'C')]
-    Cooperator vs Tit For Tat: [('C', 'C'), ('C', 'C'), ('C', 'C')]
-    Defector vs Defector: [('D', 'D'), ('D', 'D'), ('D', 'D')]
+    Cooperator vs Defector: [(C, D), (C, D), (C, D)]
+    Defector vs Tit For Tat: [(D, C), (D, D), (D, D)]
+    Cooperator vs Cooperator: [(C, C), (C, C), (C, C)]
+    Tit For Tat vs Grudger: [(C, C), (C, C), (C, C)]
+    Grudger vs Grudger: [(C, C), (C, C), (C, C)]
+    Tit For Tat vs Tit For Tat: [(C, C), (C, C), (C, C)]
+    Defector vs Grudger: [(D, C), (D, D), (D, D)]
+    Cooperator vs Grudger: [(C, C), (C, C), (C, C)]
+    Cooperator vs Tit For Tat: [(C, C), (C, C), (C, C)]
+    Defector vs Defector: [(D, D), (D, D), (D, D)]
 
 We can use these interactions to reconstruct :code:`axelrod.Match` objects which
 have a variety of available methods for analysis (more information can be found

--- a/docs/tutorials/getting_started/match.rst
+++ b/docs/tutorials/getting_started/match.rst
@@ -14,7 +14,7 @@ For example, to create a 5 turn match between :code:`Cooperator` and
     >>> players = (axl.Cooperator(), axl.Alternator())
     >>> match = axl.Match(players, 5)
     >>> match.play()
-    [('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C')]
+    [(C, C), (C, D), (C, C), (C, D), (C, C)]
 
 By default, a match will not be noisy, but you can introduce noise if you wish.
 Noise is the probability with which any action dictated by a strategy will be
@@ -22,18 +22,18 @@ swapped::
 
     >>> match = axl.Match(players=players, turns=5, noise=0.2)
     >>> match.play()  # doctest: +SKIP
-    [('D', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('D', 'D')]
+    [(D, C), (C, D), (C, C), (C, D), (D, D)]
 
 The result of the match is held as an attribute within the :code:`Match` class.
 Each time :code:`play()` is called, it will overwrite the content of that
 attribute::
 
     >>> match.result  # doctest: +SKIP
-    [('D', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('D', 'D')]
+    [(D, C), (C, D), (C, C), (C, D), (D, D)]
     >>> match.play()  # doctest: +SKIP
-    [('C', 'C'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'C')]
+    [(C, C), (C, C), (C, D), (C, C), (C, C)]
     >>> match.result  # doctest: +SKIP
-    [('C', 'C'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'C')]
+    [(C, C), (C, C), (C, D), (C, C), (C, C)]
 
 
 The result of the match can also be viewed as sparklines where cooperation is
@@ -45,7 +45,7 @@ way to view the result and can be useful for spotting patterns::
     >>> players = (axl.Cooperator(), axl.Alternator())
     >>> match = axl.Match(players, 25)
     >>> match.play()
-    [('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C')]
+    [(C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C)]
     >>> print(match.sparklines())  # doctest: +SKIP
     █████████████████████████
     █ █ █ █ █ █ █ █ █ █ █ █ █
@@ -57,7 +57,7 @@ but you can use any characters you like::
     >>> players = (axl.Cooperator(), axl.Alternator())
     >>> match = axl.Match(players, 25)
     >>> match.play()
-    [('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C')]
+    [(C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C)]
     >>> print(match.sparklines(c_symbol='|', d_symbol='-'))
     |||||||||||||||||||||||||
     |-|-|-|-|-|-|-|-|-|-|-|-|
@@ -69,7 +69,7 @@ A `Match` class can also score the individual turns of a match. Just call
     >>> players = (axl.Cooperator(), axl.Alternator())
     >>> match = axl.Match(players, 25)
     >>> match.play()
-    [('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C'), ('C', 'D'), ('C', 'C')]
+    [(C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C), (C, D), (C, C)]
     >>> match.scores()
     [(3, 3), (0, 5), (3, 3), (0, 5), (3, 3), (0, 5), (3, 3), (0, 5), (3, 3), (0, 5), (3, 3), (0, 5), (3, 3), (0, 5), (3, 3), (0, 5), (3, 3), (0, 5), (3, 3), (0, 5), (3, 3), (0, 5), (3, 3), (0, 5), (3, 3)]
 


### PR DESCRIPTION
There is still some work to do, but this should pass all tests.  (i hope. i'll have to wait for TravisCI. i'm on windows).  I tried to keep changes to an absolute minimum.  I needed to add a test in `test_resultset.py` (it has a comment why it's there) and I wanted to check inputs on Human, so I added 4 tests in `test_human.py` .

work not done yet - 

- flip_action can be replaced by the action's `.flip()` method, but basic tests first.
- it was mentioned moving `random_choice` to an Action method. I have not touched that yet.
- the alias `Action = Actions` can now be removed. I didn't want to do it yet, because it affects the import statement of almost every module and there's more than enough code to look through already.
- if this looks good, should the enum be "Action" or "Actions"?