### PR TITLE
Re classify run time for dbs.

### DIFF
--- a/axelrod/strategies/dbs.py
+++ b/axelrod/strategies/dbs.py
@@ -26,7 +26,7 @@ class DBS(Player):
         'memory_depth': float('inf'),
         'stochastic': False,
         'makes_use_of': set(),
-        'long_run_time': False,
+        'long_run_time': True,
         'inspects_source': False,
         'manipulates_source': False,
         'manipulates_state': False

--- a/axelrod/tests/strategies/test_dbs.py
+++ b/axelrod/tests/strategies/test_dbs.py
@@ -199,7 +199,7 @@ class TestDBS(TestPlayer):
         'memory_depth': float('inf'),
         'stochastic': False,
         'makes_use_of': set(),
-        'long_run_time': False,
+        'long_run_time': True,
         'inspects_source': False,
         'manipulates_source': False,
         'manipulates_state': False

--- a/axelrod/tests/unit/test_classification.py
+++ b/axelrod/tests/unit/test_classification.py
@@ -188,21 +188,22 @@ class TestStrategies(unittest.TestCase):
 
     def test_long_run_strategies(self):
         long_run_time_strategies = [
+            axl.DBS,
             axl.MetaMajority,
-            axl.MetaMinority,
-            axl.MetaWinner,
-            axl.MetaWinnerEnsemble,
             axl.MetaMajorityFiniteMemory,
-            axl.MetaWinnerFiniteMemory,
             axl.MetaMajorityLongMemory,
-            axl.MetaWinnerLongMemory,
+            axl.MetaMinority,
             axl.MetaMixer,
-            axl.NMWEFiniteMemory,
+            axl.MetaWinner,
             axl.MetaWinnerDeterministic,
+            axl.MetaWinnerEnsemble,
+            axl.MetaWinnerFiniteMemory,
+            axl.MetaWinnerLongMemory,
+            axl.MetaWinnerStochastic,
+            axl.NMWEDeterministic,
+            axl.NMWEFiniteMemory,
             axl.NMWELongMemory,
             axl.NMWEStochastic,
-            axl.NMWEDeterministic,
-            axl.MetaWinnerStochastic,
             axl.NiceMetaWinner,
             axl.NiceMetaWinnerEnsemble
         ]

--- a/docs/tutorials/advanced/classification_of_strategies.rst
+++ b/docs/tutorials/advanced/classification_of_strategies.rst
@@ -100,7 +100,7 @@ Some strategies have been classified as having a particularly long run time::
     ... }
     >>> strategies = axl.filtered_strategies(filterset)
     >>> len(strategies)
-    17
+    18
 
 Strategies that :code:`manipulate_source`, :code:`manipulate_state`
 and/or :code:`inspect_source` return :code:`False` for the :code:`obey_axelrod`


### PR DESCRIPTION
This is in fact a strategy with significant run time:
https://github.com/Axelrod-Python/Axelrod-notebooks/pull/13