### PR TITLE
Change Grudger mem depth to 1.

### DIFF
--- a/axelrod/strategies/grudger.py
+++ b/axelrod/strategies/grudger.py
@@ -20,7 +20,7 @@ class Grudger(Player):
 
     name = 'Grudger'
     classifier = {
-        'memory_depth': float('inf'),  # Long memory
+        'memory_depth': 1,
         'stochastic': False,
         'makes_use_of': set(),
         'long_run_time': False,

--- a/axelrod/tests/strategies/test_grudger.py
+++ b/axelrod/tests/strategies/test_grudger.py
@@ -11,7 +11,7 @@ class TestGrudger(TestPlayer):
     name = "Grudger"
     player = axl.Grudger
     expected_classifier = {
-        'memory_depth': float('inf'),  # Long memory
+        'memory_depth': 1,
         'stochastic': False,
         'makes_use_of': set(),
         'long_run_time': False,

--- a/axelrod/tests/strategies/test_meta.py
+++ b/axelrod/tests/strategies/test_meta.py
@@ -294,7 +294,7 @@ class TestMetaMajorityMemoryOne(TestMetaPlayer):
     }
 
     def test_strategy(self):
-        actions = [(C, C), (C, D), (C, C), (C, D), (D, C)]
+        actions = [(C, C), (C, D), (D, C), (C, D), (D, C)]
         self.versus_test(opponent=axelrod.Alternator(),
                          expected_actions=actions)
 

--- a/axelrod/tests/unit/test_classification.py
+++ b/axelrod/tests/unit/test_classification.py
@@ -121,7 +121,6 @@ class TestClassification(unittest.TestCase):
             axl.ForgivingTitForTat,
             axl.GoByMajority20,
             axl.GTFT,
-            axl.Grudger,
             axl.Inverse,
             axl.Random]
 

--- a/axelrod/tests/unit/test_strategy_transformers.py
+++ b/axelrod/tests/unit/test_strategy_transformers.py
@@ -269,7 +269,7 @@ class TestTransformers(unittest.TestCase):
             p1.play(p2)
         self.assertEqual(p2.history, [D, D, C, D, C])
 
-        p3 = InitialTransformer([D, D])(axelrod.Grudger)()
+        p3 = InitialTransformer([D, D])(axelrod.Adaptive)()
         self.assertEqual(p3.classifier["memory_depth"], float('inf'))
 
     def test_final_transformer(self):
@@ -286,7 +286,7 @@ class TestTransformers(unittest.TestCase):
             p1.play(p2)
         self.assertEqual(p2.history, [C, C, C, D, D, D, C, C])
 
-        p3 = FinalTransformer([D, D])(axelrod.Grudger)()
+        p3 = FinalTransformer([D, D])(axelrod.Adaptive)()
         self.assertEqual(p3.classifier["memory_depth"], float('inf'))
 
     def test_final_transformer2(self):

--- a/docs/tutorials/advanced/classification_of_strategies.rst
+++ b/docs/tutorials/advanced/classification_of_strategies.rst
@@ -57,7 +57,7 @@ make a decision::
     ... }
     >>> strategies = axl.filtered_strategies(filterset)
     >>> len(strategies)
-    27
+    28
 
 Multiple filters can be specified within the filterset dictionary. To specify a
 range of memory_depth values, we can use the 'min_memory_depth' and
@@ -69,7 +69,7 @@ range of memory_depth values, we can use the 'min_memory_depth' and
     ... }
     >>> strategies = axl.filtered_strategies(filterset)
     >>> len(strategies)
-    50
+    51
 
 We can also identify strategies that make use of particular properties of the
 tournament. For example, here is the number of strategies that  make use of the


### PR DESCRIPTION
Reclassify. Had to adjust some tests:

- Expected classification ones in doctests and classification tests.
- Adjust a test for a meta player.
- Change some tests for reclassification of transformers (that used
Grudger as an example).

Closes #1064