### PR TITLE
Remove hypothesis from setup.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,10 @@ from setuptools import setup
 
 # Read in the requirements.txt file
 with open('requirements.txt') as f:
-    requirements = f.read().splitlines()
+    requirements = []
+    for library in f.read().splitlines():
+        if "hypothesis" not in library:  # Skip: used only for dev
+            requirements.append(library)
 
 # Read in the version number
 exec(open('axelrod/version.py', 'r').read())
@@ -13,7 +16,7 @@ setup(
     install_requires=requirements,
     author='Vince Knight, Owen Campbell, Karol Langner, Marc Harper',
     author_email=('axelrod-python@googlegroups.com'),
-    packages=['axelrod', 'axelrod.strategies', 'axelrod.tests', 'axelrod.data'],
+    packages=['axelrod', 'axelrod.strategies', 'axelrod.data'],
     url='http://axelrod.readthedocs.org/',
     license='The MIT License (MIT)',
     description='Reproduce the Axelrod iterated prisoners dilemma tournament',


### PR DESCRIPTION
Currently when we pip install axelrod we also install hypothesis.

This is however only used for development. I've added a tweak to the
setup.py file to just remove it from the read in requirements.

I don't think we need to adjust the contributing documentation as `pip
install -r requirements` will still install hypothesis.