### PR TITLE
Fix minor typo in docstring.

### DIFF
--- a/axelrod/strategies/axelrod_first.py
+++ b/axelrod/strategies/axelrod_first.py
@@ -220,7 +220,7 @@ class Grofman(Player):
     Cooperate on the first two rounds and
     returns the opponent's last action for the next 5. For the rest of the game
     Grofman cooperates if both players selected the same action in the previous
-    round, and otherwise cooperates randomly with probability :math:`frac{2}{7}`.
+    round, and otherwise cooperates randomly with probability 2/7.
 
     This strategy came 4th in Axelrod's original tournament.
 


### PR DESCRIPTION
The LaTeX doesn't render as intended now that this has been moved to the
docstring (it wasn't probably overkill anyway):
http://axelrod.readthedocs.io/en/stable/reference/all_strategies.html#axelrod.strategies.axelrod_first.Grofman