### PR TITLE
Add ability to pass match attributes in tournament

### DIFF
--- a/axelrod/match_generator.py
+++ b/axelrod/match_generator.py
@@ -2,7 +2,7 @@
 class MatchGenerator(object):
 
     def __init__(self, players, repetitions, turns=None, game=None, noise=0,
-                 prob_end=None, edges=None):
+                 prob_end=None, edges=None, match_attributes=None):
         """
         A class to generate matches. This is used by the Tournament class which
         is in charge of playing the matches and collecting the results.
@@ -23,6 +23,10 @@ class MatchGenerator(object):
             The probability that a player's intended action should be flipped
         edges : list
             A list of edges between players
+        match_attributes : dict
+            Mapping attribute names to values which should be passed to players.
+            The default is to use the correct values for turns, game and noise
+            but these can be overridden if desired.
         """
         self.players = players
         self.turns = turns
@@ -31,6 +35,7 @@ class MatchGenerator(object):
         self.noise = noise
         self.opponents = players
         self.prob_end = prob_end
+        self.match_attributes = match_attributes
 
         self.edges = edges
         if edges is not None:
@@ -68,7 +73,8 @@ class MatchGenerator(object):
         Creates a single set of match parameters.
         """
         return {"turns": self.turns, "game": self.game,
-                "noise": self.noise, "prob_end": self.prob_end}
+                "noise": self.noise, "prob_end": self.prob_end,
+                "match_attributes": self.match_attributes}
 
 
 def complete_graph(players):

--- a/axelrod/tests/unit/test_match_generator.py
+++ b/axelrod/tests/unit/test_match_generator.py
@@ -127,14 +127,15 @@ class TestMatchGenerator(unittest.TestCase):
                                     game=test_game,
                                     repetitions=test_repetitions,
                                     turns=5,
-                                    match_attributes={"length": -1})
+                                    match_attributes={"length": float('inf')})
         match_params = rr.build_single_match_params()
         self.assertIsInstance(match_params, dict)
         self.assertEqual(match_params["turns"], 5)
         self.assertEqual(match_params["game"], test_game)
         self.assertEqual(match_params["prob_end"], None)
         self.assertEqual(match_params["noise"], 0)
-        self.assertEqual(match_params["match_attributes"], {"length": -1})
+        self.assertEqual(match_params["match_attributes"],
+                         {"length": float('inf')})
 
 
         # Check that can build a match
@@ -143,7 +144,7 @@ class TestMatchGenerator(unittest.TestCase):
         match = axelrod.Match(**match_params)
         self.assertIsInstance(match, axelrod.Match)
         self.assertEqual(len(match), 5)
-        self.assertEqual(match.match_attributes, {"length": -1})
+        self.assertEqual(match.match_attributes, {"length": float('inf')})
 
     @given(repetitions=integers(min_value=1, max_value=test_repetitions))
     @example(repetitions=test_repetitions)

--- a/axelrod/tests/unit/test_match_generator.py
+++ b/axelrod/tests/unit/test_match_generator.py
@@ -122,6 +122,29 @@ class TestMatchGenerator(unittest.TestCase):
         self.assertGreater(len(match), 0)
         self.assertLessEqual(len(match), 10)
 
+    def test_build_single_match_params_with_fixed_length_unknown(self):
+        rr = axelrod.MatchGenerator(players=self.players,
+                                    game=test_game,
+                                    repetitions=test_repetitions,
+                                    turns=5,
+                                    match_attributes={"length": -1})
+        match_params = rr.build_single_match_params()
+        self.assertIsInstance(match_params, dict)
+        self.assertEqual(match_params["turns"], 5)
+        self.assertEqual(match_params["game"], test_game)
+        self.assertEqual(match_params["prob_end"], None)
+        self.assertEqual(match_params["noise"], 0)
+        self.assertEqual(match_params["match_attributes"], {"length": -1})
+
+
+        # Check that can build a match
+        players = [axelrod.Cooperator(), axelrod.Defector()]
+        match_params["players"] = players
+        match = axelrod.Match(**match_params)
+        self.assertIsInstance(match, axelrod.Match)
+        self.assertEqual(len(match), 5)
+        self.assertEqual(match.match_attributes, {"length": -1})
+
     @given(repetitions=integers(min_value=1, max_value=test_repetitions))
     @example(repetitions=test_repetitions)
     def test_build_match_chunks(self, repetitions):

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -82,11 +82,13 @@ class TestTournament(unittest.TestCase):
         self.assertEqual(anonymous_tournament.name, 'axelrod')
 
     def test_init_with_match_attributes(self):
-        tournament = axelrod.Tournament(players=self.players,
-                                        match_attributes={"length": -1})
+        tournament = axelrod.Tournament(
+                players=self.players,
+                match_attributes={"length": float('inf')})
         mg = tournament.match_generator
         match_params = mg.build_single_match_params()
-        self.assertEqual(match_params["match_attributes"], {"length": -1})
+        self.assertEqual(match_params["match_attributes"],
+                         {"length": float('inf')})
 
     def test_warning(self):
         tournament = axelrod.Tournament(name=self.test_name,

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -81,6 +81,13 @@ class TestTournament(unittest.TestCase):
         anonymous_tournament = axelrod.Tournament(players=self.players)
         self.assertEqual(anonymous_tournament.name, 'axelrod')
 
+    def test_init_with_match_attributes(self):
+        tournament = axelrod.Tournament(players=self.players,
+                                        match_attributes={"length": -1})
+        mg = tournament.match_generator
+        match_params = mg.build_single_match_params()
+        self.assertEqual(match_params["match_attributes"], {"length": -1})
+
     def test_warning(self):
         tournament = axelrod.Tournament(name=self.test_name,
                                         players=self.players,

--- a/axelrod/tournament.py
+++ b/axelrod/tournament.py
@@ -23,7 +23,8 @@ class Tournament(object):
     def __init__(self, players: List[Player],
                  name: str = 'axelrod', game: Game = None, turns: int = None,
                  prob_end: float = None, repetitions: int = 10,
-                 noise: float = 0, edges: List[Tuple] = None) -> None:
+                 noise: float = 0, edges: List[Tuple] = None,
+                 match_attributes: dict = None) -> None:
         """
         Parameters
         ----------
@@ -45,6 +46,10 @@ class Tournament(object):
             The probability of a given turn ending a match
         edges : list
             A list of edges between players
+        match_attributes : dict
+            Mapping attribute names to values which should be passed to players.
+            The default is to use the correct values for turns, game and noise
+            but these can be overridden if desired.
         """
         if game is None:
             self.game = Game()
@@ -67,7 +72,8 @@ class Tournament(object):
                                               repetitions=self.repetitions,
                                               prob_end=prob_end,
                                               noise=self.noise,
-                                              edges=edges)
+                                              edges=edges,
+                                              match_attributes=match_attributes)
         self._logger = logging.getLogger(__name__)
 
     def setup_output(self, filename=None, in_memory=False):

--- a/docs/tutorials/advanced/index.rst
+++ b/docs/tutorials/advanced/index.rst
@@ -16,5 +16,6 @@ Contents:
    parallel_processing.rst
    using_the_cache.rst
    setting_a_seed.rst
+   player_information.rst
    player_equality.rst
    games.rst

--- a/docs/tutorials/advanced/player_information.rst
+++ b/docs/tutorials/advanced/player_information.rst
@@ -22,10 +22,10 @@ turns::
 
 We can also pass this information to a tournament. Let us create a
 tournament with 5 turns but ensure the players believe the match length is
-infinite::
+infinite (unknown)::
 
     >>> tournament = axl.Tournament(players, turns=5,
-    ...                             match_attributes={"length": -1})
+    ...                             match_attributes={"length": float('inf')})
 
 The :code:`match_attributes` dictionary can also be used to pass :code:`game`
 and :code:`noise`.

--- a/docs/tutorials/advanced/player_information.rst
+++ b/docs/tutorials/advanced/player_information.rst
@@ -1,0 +1,31 @@
+.. _player_information:
+
+Player information
+==================
+
+It is possible to determine what information players know about their matches.
+By default all known information is given.
+For example let us create a match with 5 turns between :code:`SteinAndRapoport`
+and :code:`Aternator`. The latter of these two always defects on the last 2
+turns::
+
+    >>> import axelrod as axl
+    >>> players = (axl.Alternator(), axl.SteinAndRapoport())
+    >>> axl.Match(players, turns=5).play()
+    [(C, C), (D, C), (C, C), (D, D), (C, D)]
+
+We can play the same match but let us tell the players that the match lasts 6
+turns::
+
+    >>> axl.Match(players, turns=5, match_attributes={"length": 6}).play()
+    [(C, C), (D, C), (C, C), (D, C), (C, D)]
+
+We can also pass this information to a tournament. Let us create a
+tournament with 5 turns but ensure the players believe the match length is
+infinite::
+
+    >>> tournament = axl.Tournament(players, turns=5,
+    ...                             match_attributes={"length": -1})
+
+The :code:`match_attributes` dictionary can also be used to pass :code:`game`
+and :code:`noise`.

--- a/docs/tutorials/advanced/player_information.rst
+++ b/docs/tutorials/advanced/player_information.rst
@@ -6,7 +6,7 @@ Player information
 It is possible to determine what information players know about their matches.
 By default all known information is given.
 For example let us create a match with 5 turns between :code:`SteinAndRapoport`
-and :code:`Aternator`. The latter of these two always defects on the last 2
+and :code:`Alternator`. The latter of these two always defects on the last 2
 turns::
 
     >>> import axelrod as axl


### PR DESCRIPTION
It is possible to pass a dictionary to `axelrod.Match` is
`match_attributes` which correspond to the information given to players.

This is motivated by wanting to reproduce Axelrod's second tournament in
which all matches were 1 of 5 values.