### PR TITLE
Improve our test for reset and fix some test bugs.

### DIFF
--- a/axelrod/tests/strategies/test_darwin.py
+++ b/axelrod/tests/strategies/test_darwin.py
@@ -57,7 +57,8 @@ class TestDarwin(TestPlayer):
 
         self.versus_test(axelrod.MindReader(), expected_actions=[(C, D)] * 2, attrs={'genome': [D, C]})
 
-    def test_reset_only_resets_first_move_of_genome(self):
+    def test_reset_history_and_attributes(self):
+        # Overwrite this method because Darwin does not reset
         self.versus_test(axelrod.Defector(), expected_actions=[(C, D)] + [(D, D)] * 4)
 
         p1 = self.player()

--- a/axelrod/tests/strategies/test_meta.py
+++ b/axelrod/tests/strategies/test_meta.py
@@ -331,9 +331,13 @@ class TestMetaMajorityLongMemory(TestMetaPlayer):
     }
 
     def test_strategy(self):
+        actions = [(C, C), (C, D), (C, C), (C, D), (D, C)]
+        self.versus_test(opponent=axelrod.Alternator(),
+                         expected_actions=actions, seed=0)
+
         actions = [(C, C), (C, D), (D, C), (C, D), (D, C)]
         self.versus_test(opponent=axelrod.Alternator(),
-                         expected_actions=actions)
+                         expected_actions=actions, seed=1)
 
 
 class TestMetaWinnerMemoryOne(TestMetaPlayer):

--- a/axelrod/tests/strategies/test_player.py
+++ b/axelrod/tests/strategies/test_player.py
@@ -400,14 +400,15 @@ class TestPlayer(unittest.TestCase):
         """Make sure resetting works correctly."""
         player = self.player()
         clone = player.clone()
-        opponent = axelrod.Random()
+        for opponent in [axelrod.Defector(), axelrod.Random(),
+                         axelrod.Alternator(), axelrod.Cooperator()]:
 
-        for seed in range(10):
-            axelrod.seed(seed)
-            player.play(opponent)
+            for seed in range(10):
+                axelrod.seed(seed)
+                player.play(opponent)
 
-        player.reset()
-        self.assertEqual(player, clone)
+            player.reset()
+            self.assertEqual(player, clone)
 
     def test_reset_clone(self):
         """Make sure history resetting with cloning works correctly, regardless

--- a/axelrod/tests/strategies/test_player.py
+++ b/axelrod/tests/strategies/test_player.py
@@ -398,11 +398,11 @@ class TestPlayer(unittest.TestCase):
 
     def test_reset_history_and_attributes(self):
         """Make sure resetting works correctly."""
-        player = self.player()
-        clone = player.clone()
         for opponent in [axelrod.Defector(), axelrod.Random(),
                          axelrod.Alternator(), axelrod.Cooperator()]:
 
+            player = self.player()
+            clone = player.clone()
             for seed in range(10):
                 axelrod.seed(seed)
                 player.play(opponent)

--- a/axelrod/tests/strategies/test_selfsteem.py
+++ b/axelrod/tests/strategies/test_selfsteem.py
@@ -22,36 +22,39 @@ class TestSelfSteem(TestPlayer):
     def test_strategy(self):
 
         # Check for f > 0.95, defect
-        actions = [(C, C), (C, C), (D, C), (D, C)]
-        self.versus_test(axelrod.Cooperator(), expected_actions=actions)
-
         actions = [(C, C), (C, C), (D, C),
-                   (D, C), (C, C), (D, C)] + [(C, C)] * 6 + [(D, C)]
-        self.versus_test(axelrod.Cooperator(), expected_actions=actions)
+                   (D, C), (C, C), (D, C)] + [(C, C)] * 4 + [(D, C)]
+        self.versus_test(axelrod.Cooperator(), expected_actions=actions,
+                         seed=1)
 
         # Check for f < -0.95, cooperate
-        actions = [(D, C), (C, C), (D, C),(D, C),
+        actions = [(D, C), (C, C), (D, C), (D, C),
                    (C, C), (D, C), (C, C), (C, C)]
-        self.versus_test(opponent=axelrod.MockPlayer(actions=[C]), expected_actions=actions)
+        self.versus_test(opponent=axelrod.MockPlayer(actions=[C]),
+                         expected_actions=actions, seed=0)
 
-        actions = [(C, D)] + [(D, D)] * 6 + [(C, D),
-                   (C, D)] + [(D, D)] * 6 + [(C, D)]
-        self.versus_test(opponent=axelrod.MockPlayer(actions=[D]), expected_actions=actions)
+        actions = [(D, D)] + [(D, D)] * 5 + [(D, D), (C, D), (C, D)]
+        self.versus_test(opponent=axelrod.MockPlayer(actions=[D]),
+                         expected_actions=actions, seed=0)
 
         # Check for -0.3 < f < 0.3, random
         actions = [(D, C), (C, C), (D, C), (D, C),
                    (C, C), (D, C)] + [(C, C)] * 6 + [(D, C),(D, C)] + [(C, C)] * 7
-        self.versus_test(opponent=axelrod.MockPlayer(actions=[C]), expected_actions=actions, seed=6)
+        self.versus_test(opponent=axelrod.MockPlayer(actions=[C]),
+                         expected_actions=actions, seed=6)
 
         actions = [(D, D)] * 7 + [(C, D), (C, D)] + [(D, D)] * 8 + [(C, D),
                    (C, D), (D, D), (D, D), (D, D)]
-        self.versus_test(opponent=axelrod.MockPlayer(actions=[D]), expected_actions=actions, seed=5)
+        self.versus_test(opponent=axelrod.MockPlayer(actions=[D]),
+                         expected_actions=actions, seed=5)
 
         # Check for 0.95 > abs(f) > 0.3, follows TitForTat
         actions = [(D, D)] * 5 + [(C, D), (D, D), (C, D),
                    (C, D), (D, D), (C, D)] + [(D, D)] * 5
-        self.versus_test(opponent=axelrod.MockPlayer(actions=[D]), expected_actions=actions)
+        self.versus_test(opponent=axelrod.MockPlayer(actions=[D]),
+                         expected_actions=actions)
 
         actions = [(D, C), (C, C), (D, C), (D, C),
                    (C, C), (D, C), (C, C), (C, C), (C, C), (C, C)]
-        self.versus_test(opponent=axelrod.MockPlayer(actions=[C]), expected_actions=actions)
+        self.versus_test(opponent=axelrod.MockPlayer(actions=[C]),
+                         expected_actions=actions)

--- a/axelrod/tests/strategies/test_selfsteem.py
+++ b/axelrod/tests/strategies/test_selfsteem.py
@@ -30,31 +30,31 @@ class TestSelfSteem(TestPlayer):
         # Check for f < -0.95, cooperate
         actions = [(D, C), (C, C), (D, C), (D, C),
                    (C, C), (D, C), (C, C), (C, C)]
-        self.versus_test(opponent=axelrod.MockPlayer(actions=[C]),
+        self.versus_test(opponent=axelrod.Cooperator(),
                          expected_actions=actions, seed=0)
 
         actions = [(D, D)] + [(D, D)] * 5 + [(D, D), (C, D), (C, D)]
-        self.versus_test(opponent=axelrod.MockPlayer(actions=[D]),
+        self.versus_test(opponent=axelrod.Defector(),
                          expected_actions=actions, seed=0)
 
         # Check for -0.3 < f < 0.3, random
         actions = [(D, C), (C, C), (D, C), (D, C),
                    (C, C), (D, C)] + [(C, C)] * 6 + [(D, C),(D, C)] + [(C, C)] * 7
-        self.versus_test(opponent=axelrod.MockPlayer(actions=[C]),
+        self.versus_test(opponent=axelrod.Cooperator(),
                          expected_actions=actions, seed=6)
 
         actions = [(D, D)] * 7 + [(C, D), (C, D)] + [(D, D)] * 8 + [(C, D),
                    (C, D), (D, D), (D, D), (D, D)]
-        self.versus_test(opponent=axelrod.MockPlayer(actions=[D]),
+        self.versus_test(opponent=axelrod.Defector(),
                          expected_actions=actions, seed=5)
 
         # Check for 0.95 > abs(f) > 0.3, follows TitForTat
         actions = [(D, D)] * 5 + [(C, D), (D, D), (C, D),
                    (C, D), (D, D), (C, D)] + [(D, D)] * 5
-        self.versus_test(opponent=axelrod.MockPlayer(actions=[D]),
+        self.versus_test(opponent=axelrod.Defector(),
                          expected_actions=actions)
 
         actions = [(D, C), (C, C), (D, C), (D, C),
                    (C, C), (D, C), (C, C), (C, C), (C, C), (C, C)]
-        self.versus_test(opponent=axelrod.MockPlayer(actions=[C]),
+        self.versus_test(opponent=axelrod.Cooperator(),
                          expected_actions=actions)

--- a/axelrod/tests/strategies/test_stalker.py
+++ b/axelrod/tests/strategies/test_stalker.py
@@ -21,10 +21,6 @@ class TestStalker(TestPlayer):
     }
 
     def test_strategy(self):
-        actions = [(C, D)] * 2 + [(C, C), (D, C), (C, C), (C, C), (D, D)]
-        self.versus_test(opponent=axl.MockPlayer([D] * 2 + [C] * 4),
-                         expected_actions=actions)
-
         actions = [(C, C)] * 3 + [(D, C)]
         self.versus_test(opponent=axl.Cooperator(), expected_actions=actions)
 


### PR DESCRIPTION
We were only playing against Random, @marcharper found and fixed a bug via
hypothesis on it here:
https://github.com/Axelrod-Python/Axelrod/pull/1097

This catches the bug too:

```
Axelrod(pass-match-attributes) ✗: python -m unittest
axelrod.tests.strategies.test_titfortat
...............................................................................F................................................................
======================================================================
FAIL: test_reset_history_and_attributes
(axelrod.tests.strategies.test_titfortat.TestNTitsForMTats)
Make sure resetting works correctly.
----------------------------------------------------------------------
Traceback (most recent call last):
  File
  "/home/vince/src/Axelrod/axelrod/tests/strategies/test_player.py",
  line 411, in test_reset_history_and_attributes
      self.assertEqual(player, clone)
      AssertionError: N Tit(s) For M Tat(s): 3, 2 != N Tit(s) For M
      Tat(s): 3, 2
```