### PR TITLE
Alter inequality condition to match docstring

### DIFF
--- a/axelrod/strategies/axelrod_second.py
+++ b/axelrod/strategies/axelrod_second.py
@@ -52,7 +52,7 @@ class Champion(Player):
         defection_prop = opponent.defections / len(opponent.history)
         if opponent.history[-1] == D:
             r = random.random()
-            if defection_prop > max(0.4, r):
+            if defection_prop >= max(0.4, r):
                 return D
         return C
 

--- a/docs/reference/overview_of_strategies.rst
+++ b/docs/reference/overview_of_strategies.rst
@@ -131,7 +131,7 @@ repository.
    "K58R_", "Glen Rowsam", "Not Implemented"
    "K59R_", "Leslie Downing", "Not Implemented"
    "K60R_", "Jim Graaskamp and Ken Katzen", "Not Implemented"
-   "K61R_", "Danny C Champion", "Not Implemented"
+   "K61R_", "Danny C Champion", ":class:`Champion <axelrod.strategies.axelrod_second.Champion>`"
    "K62R_", "Howard R Hollander", "Not Implemented"
    "K63R_", "George Duisman", "Not Implemented"
    "K64R_", "Brian Yamachi", "Not Implemented"


### PR DESCRIPTION
The docstring text (from the original paper) and the K61R code in axelrod-fortran both test whether the cooperation rate is less than 0.6.

We use the defection rate, so the equivalent condition should test whether it is greater than or equal to 0.6

In the current implementation, it is simply testing whether the defection rate is greater than 0.6