### PR TITLE
Implement a global reset and trim test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
   - cd docs; make html
   # Run the test suit with coverage
   - cd ..
-  - coverage run --source=axelrod -m unittest discover
+  - travis_wait 30 coverage run --source=axelrod -m unittest discover
   - coverage report -m
   # Run the doctests
   - python doctests.py

--- a/axelrod/match.py
+++ b/axelrod/match.py
@@ -132,6 +132,7 @@ class Match(object):
         if self._stochastic or (cache_key not in self._cache):
             for p in self.players:
                 p.reset()
+                p.set_match_attributes(**self.match_attributes)
             for _ in range(turns):
                 self.players[0].play(self.players[1], self.noise)
             result = list(

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -247,13 +247,9 @@ class Player(object):
         This method is called at the beginning of each match (between a pair
         of players) to reset a player's state to its initial starting point.
         It ensures that no 'memory' of previous matches is carried forward.
-
-        The default method resets a player's history, cooperations, defections
-        and state_distribution. Players which have further attributes need to
-        override this method and ensure those additional attributes are also
-        reset.
         """
         self.history = []
         self.cooperations = 0
         self.defections = 0
         self.state_distribution = defaultdict(int)
+        self.__init__(**self.init_kwargs)

--- a/axelrod/strategies/adaptive.py
+++ b/axelrod/strategies/adaptive.py
@@ -53,7 +53,3 @@ class Adaptive(Player):
         if self.scores[C] > self.scores[D]:
             return C
         return D
-
-    def reset(self):
-        super().reset()
-        self.scores = {C: 0, D: 0}

--- a/axelrod/strategies/apavlov.py
+++ b/axelrod/strategies/apavlov.py
@@ -67,10 +67,6 @@ class APavlov2006(Player):
                 return D
         return C
 
-    def reset(self):
-        super().reset()
-        self.opponent_class = None
-
 
 class APavlov2011(Player):
     """
@@ -122,7 +118,3 @@ class APavlov2011(Player):
         if self.opponent_class == "Cooperative":
             # TFT
             return D if opponent.history[-1:] == [D] else C
-
-    def reset(self):
-        super().reset()
-        self.opponent_class = None

--- a/axelrod/strategies/axelrod_first.py
+++ b/axelrod/strategies/axelrod_first.py
@@ -140,15 +140,6 @@ class RevisedDowning(Player):
             move = D
         return move
 
-    def reset(self):
-        super().reset()
-        self.good = 1.0
-        self.bad = 0.0
-        self.nice1 = 0
-        self.nice2 = 0
-        self.total_C = 0 # not the same as self.cooperations
-        self.total_D = 0 # not the same as self.defections
-
 
 class Feld(Player):
     """
@@ -430,12 +421,6 @@ class Shubik(Player):
             return D
         return C
 
-    def reset(self):
-        super().reset()
-        self.is_retaliating = False
-        self.retaliation_length = 0
-        self.retaliation_remaining = 0
-
 
 class Tullock(Player):
     """
@@ -586,9 +571,6 @@ class SteinAndRapoport(Player):
         else:  # TitForTat if opponent plays not randomly
             return opponent.history[-1]
 
-    def reset(self):
-        super().reset()
-        self.opponent_is_random = False
 
 
 class TidemanAndChieruzzi(Player):
@@ -712,13 +694,3 @@ class TidemanAndChieruzzi(Player):
             return D
 
         return C
-
-    def reset(self):
-        super().reset()
-        self.is_retaliating = False
-        self.retaliation_length = 0
-        self.retaliation_remaining = 0
-        self.current_score = 0
-        self.opponent_score = 0
-        self.last_fresh_start = 0
-        self.fresh_start = False

--- a/axelrod/strategies/axelrod_second.py
+++ b/axelrod/strategies/axelrod_second.py
@@ -144,10 +144,6 @@ class Tester(Player):
             # Alternate C and D
             return self.history[-1].flip()
 
-    def reset(self):
-        super().reset()
-        self.is_TFT = False
-
 
 class Gladstein(Player):
     """
@@ -203,7 +199,3 @@ class Gladstein(Player):
         else:
             # Play TFT
             return opponent.history[-1]
-
-    def reset(self):
-        super().reset()
-        self.patsy = True

--- a/axelrod/strategies/calculator.py
+++ b/axelrod/strategies/calculator.py
@@ -50,7 +50,3 @@ class Calculator(Player):
         else:
             # TFT
             return D if opponent.history[-1:] == [D] else C
-
-    def reset(self):
-        super().reset()
-        self.joss_instance = Joss()

--- a/axelrod/strategies/cycler.py
+++ b/axelrod/strategies/cycler.py
@@ -49,11 +49,6 @@ class AntiCycler(Player):
             self.cycle_counter = 0
             return D
 
-    def reset(self):
-        super().reset()
-        self.cycle_length = 1
-        self.cycle_counter = 0
-        self.first_three = self._get_first_three()
 
 
 class Cycler(Player):
@@ -98,9 +93,6 @@ class Cycler(Player):
     def strategy(self, opponent: Player) -> Action:
         return next(self.cycle)
 
-    def reset(self):
-        super(Cycler, self).reset()
-        self.cycle = self.get_new_itertools_cycle()
 
 
 class CyclerDC(Cycler):

--- a/axelrod/strategies/darwin.py
+++ b/axelrod/strategies/darwin.py
@@ -3,6 +3,8 @@ The player class in this module does not obey standard rules of the IPD (as
 indicated by their classifier). We do not recommend putting a lot of time in to
 optimising it.
 """
+from collections import defaultdict
+
 from axelrod.action import Action
 from axelrod.player import Player
 

--- a/axelrod/strategies/dbs.py
+++ b/axelrod/strategies/dbs.py
@@ -111,20 +111,6 @@ class DBS(Player):
             (D, D): ([0], [1])
         }
 
-    def reset(self):
-        """Reset instance properties."""
-        super().reset()
-        self.Rd = create_policy(1, 1, 0, 0)
-        self.Rc = {}
-        self.Pi = self.Rd   # policy used by move_gen
-        self.violation_counts = {}
-        self.v = 0
-        self.history_by_cond = {
-            (C, C): ([1], [1]),
-            (C, D): ([1], [1]),
-            (D, C): ([0], [1]),
-            (D, D): ([0], [1])
-        }
 
     def should_promote(self, r_plus, promotion_threshold=3):
         """

--- a/axelrod/strategies/finite_state_machines.py
+++ b/axelrod/strategies/finite_state_machines.py
@@ -94,10 +94,6 @@ class FSMPlayer(Player):
             action = self.fsm.move(opponent.history[-1])
             return action
 
-    def reset(self) -> None:
-        super().reset()
-        self.fsm.state = self.initial_state
-
 
 class Fortress3(FSMPlayer):
     """Finite state machine player specified in http://DOI.org/10.1109/CEC.2006.1688322.

--- a/axelrod/strategies/grudger.py
+++ b/axelrod/strategies/grudger.py
@@ -83,12 +83,6 @@ class ForgetfulGrudger(Player):
             return D
         return C
 
-    def reset(self):
-        """Resets scores and history."""
-        super().reset()
-        self.grudged = False
-        self.grudge_memory = 0
-
 
 class OppositeGrudger(Player):
     """
@@ -189,12 +183,6 @@ class SoftGrudger(Player):
             self.grudged = True
             return D
         return C
-
-    def reset(self):
-        """Resets scores and history."""
-        super().reset()
-        self.grudged = False
-        self.grudge_memory = 0
 
 
 class GrudgerAlternator(Player):
@@ -324,12 +312,6 @@ class GeneralSoftGrudger(Player):
             return D
 
         return C
-
-    def reset(self):
-        """Resets scores and history."""
-        super().reset()
-        self.grudged = False
-        self.grudge_memory = 0
 
     def __repr__(self) -> str:
         return "%s: n=%s,d=%s,c=%s" % (self.name, self.n, self.d, self.c)

--- a/axelrod/strategies/grumpy.py
+++ b/axelrod/strategies/grumpy.py
@@ -42,7 +42,6 @@ class Grumpy(Player):
         """
         super().__init__()
         self.state = starting_state
-        self.starting_state = starting_state
         self.grumpy_threshold = grumpy_threshold
         self.nice_threshold = nice_threshold
 
@@ -68,9 +67,3 @@ class Grumpy(Player):
                 self.state = 'Nice'
                 return C
             return D
-
-    def reset(self):
-        """Resets score, history and state for the next round of the
-        tournament."""
-        super().reset()
-        self.state = self.starting_state

--- a/axelrod/strategies/hmm.py
+++ b/axelrod/strategies/hmm.py
@@ -150,11 +150,6 @@ class HMMPlayer(Player):
             self.state = self.hmm.state
             return action
 
-    def reset(self) -> None:
-        super().reset()
-        self.hmm.state = self.initial_state
-        self.state = self.hmm.state
-
 
 class EvolvedHMM5(HMMPlayer):
     """

--- a/axelrod/strategies/hunter.py
+++ b/axelrod/strategies/hunter.py
@@ -97,10 +97,6 @@ class AlternatorHunter(Player):
             return D
         return C
 
-    def reset(self):
-        super().reset()
-        self.is_alt = False
-
 
 class CycleHunter(Player):
     """Hunts strategies that play cyclically, like any of the Cyclers,
@@ -135,10 +131,6 @@ class CycleHunter(Player):
                 self.cycle = cycle
                 return D
         return C
-
-    def reset(self):
-        super().reset()
-        self.cycle = None
 
 
 class EventualCycleHunter(CycleHunter):
@@ -256,8 +248,3 @@ class RandomHunter(Player):
             if probabilities and all([abs(p - 0.5) < 0.25 for p in probabilities]):
                 return D
         return C
-
-    def reset(self):
-        self.countCC = 0
-        self.countDD = 0
-        super().reset()

--- a/axelrod/strategies/lookerup.py
+++ b/axelrod/strategies/lookerup.py
@@ -349,9 +349,6 @@ class LookerUp(Player):
                                 opponent_last_n_plays,
                                 opponent_initial_plays)
 
-    def reset(self) -> None:
-        super(LookerUp, self).reset()
-        self._initial_actions_pool = list(self.initial_actions)
 
     @property
     def lookup_dict(self):

--- a/axelrod/strategies/memorytwo.py
+++ b/axelrod/strategies/memorytwo.py
@@ -61,11 +61,3 @@ class MEM2(Player):
                 self.play_as = "ALLD"
                 self.alld_counter += 1
         return self.players[self.play_as].strategy(opponent)
-
-    def reset(self):
-        super().reset()
-        for v in self.players.values():
-            v.reset()
-        self.play_as = "TFT"
-        self.shift_counter = 3
-        self.alld_counter = 0

--- a/axelrod/strategies/meta.py
+++ b/axelrod/strategies/meta.py
@@ -49,7 +49,7 @@ class MetaPlayer(Player):
         self.team = [t for t in self.team if not issubclass(t, MetaPlayer)]
         self.nteam = len(self.team)
 
-        # Initiate all the player in out team.
+        # Initiate all the player in our team.
         self.team = [t() for t in self.team]
 
         # This player inherits the classifiers of its team.
@@ -83,12 +83,6 @@ class MetaPlayer(Player):
         """Determine the meta result based on results of all players.
         Override this function in child classes."""
         return C
-
-    def reset(self):
-        super().reset()
-        # Reset each player as well
-        for player in self.team:
-            player.reset()
 
 
 class MetaMajority(MetaPlayer):
@@ -167,10 +161,6 @@ class MetaWinner(MetaPlayer):
         bestproposals = [results[i] for i in beststrategies]
         bestresult = C if C in bestproposals else D
         return bestresult
-
-    def reset(self):
-        super().reset()
-        self.scores = [0] * len(self.team)
 
 
 NiceMetaWinner = NiceTransformer()(MetaWinner)

--- a/axelrod/strategies/oncebitten.py
+++ b/axelrod/strategies/oncebitten.py
@@ -52,11 +52,6 @@ class OnceBitten(Player):
             return D
         return C
 
-    def reset(self):
-        """Resets grudge memory and history."""
-        super().reset()
-        self.grudged = False
-        self.grudge_memory = 0
 
 
 class FoolMeOnce(Player):

--- a/axelrod/strategies/prober.py
+++ b/axelrod/strategies/prober.py
@@ -209,12 +209,6 @@ class Prober4(Player):
                 return C
             return D if opponent.history[-1] == D else C
 
-    def reset(self):
-        super().reset()
-        self.just_Ds = 0
-        self.unjust_Ds = 0
-        self.turned_defector = False
-
 
 class HardProber(Player):
     """
@@ -349,7 +343,3 @@ class RemorsefulProber(NaiveProber):
 
         self.probing = True
         return D
-
-    def reset(self):
-        super().reset()
-        self.probing = False

--- a/axelrod/strategies/punisher.py
+++ b/axelrod/strategies/punisher.py
@@ -60,15 +60,6 @@ class Punisher(Player):
 
         return C
 
-    def reset(self):
-        """
-        Resets scores and history
-        """
-        super().reset()
-        self.grudged = False
-        self.grudge_memory = 1
-        self.mem_length = 1
-
 
 class InversePunisher(Player):
     """
@@ -122,12 +113,6 @@ class InversePunisher(Player):
             return D
         return C
 
-    def reset(self):
-        """Resets internal variables and history"""
-        super().reset()
-        self.grudged = False
-        self.grudge_memory = 1
-        self.mem_length = 1
 
 class LevelPunisher(Player):
     """

--- a/axelrod/strategies/qlearner.py
+++ b/axelrod/strategies/qlearner.py
@@ -114,17 +114,6 @@ class RiskyQLearner(Player):
             opp_prev_action = opponent.history[-1]
         return self.payoff_matrix[self.prev_action][opp_prev_action]
 
-    def reset(self):
-        """
-        Resets scores and history
-        """
-        super().reset()
-
-        self.Qs = {'': {C: 0, D: 0}}
-        self.Vs = {'': 0}
-        self.prev_state = ''
-        self.prev_action = None
-        self.original_prev_action = None
 
 
 class ArrogantQLearner(RiskyQLearner):

--- a/axelrod/strategies/retaliate.py
+++ b/axelrod/strategies/retaliate.py
@@ -51,10 +51,6 @@ class Retaliate(Player):
                 return D
         return C
 
-    def reset(self):
-        super().reset()
-        self.play_counts = defaultdict(int)
-
 
 class Retaliate2(Retaliate):
     """
@@ -154,12 +150,6 @@ class LimitedRetaliate(Player):
                 self.retaliating = False
 
         return C
-
-    def reset(self):
-        super().reset()
-        self.play_counts = defaultdict(int)
-        self.retaliating = False
-        self.retaliation_count = 0
 
 
 class LimitedRetaliate2(LimitedRetaliate):

--- a/axelrod/strategies/sequence_player.py
+++ b/axelrod/strategies/sequence_player.py
@@ -39,10 +39,6 @@ class SequencePlayer(Player):
         for s in self.sequence_generator:
             return self.meta_strategy(s)
 
-    def reset(self):
-        # Be sure to reset the sequence generator
-        super().reset()
-        self.sequence_generator = self.generator_function(*self.generator_args)
 
     def __getstate__(self):
         return_dict = self.__dict__.copy()

--- a/axelrod/strategies/stalker.py
+++ b/axelrod/strategies/stalker.py
@@ -79,7 +79,3 @@ class Stalker(Player):
             return D
 
         return random_choice()
-
-    def reset(self):
-        super().reset()
-        self.current_score = 0

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -377,10 +377,6 @@ class OmegaTFT(Player):
                     self.deadlock_counter = 0
         return move
 
-    def reset(self):
-        super().reset()
-        self.randomness_counter = 0
-        self.deadlock_counter = 0
 
 
 class Gradual(Player):
@@ -437,12 +433,6 @@ class Gradual(Player):
 
         return C
 
-    def reset(self):
-        super().reset()
-        self.calming = False
-        self.punishing = False
-        self.punishment_count = 0
-        self.punishment_limit = 0
 
 
 @TrackHistoryTransformer(name_prefix=None)
@@ -491,10 +481,6 @@ class ContriteTitForTat(Player):
 
         return opponent.history[-1]
 
-    def reset(self):
-        super().reset()
-        self.contrite = False
-        self._recorded_history = []
 
 
 class AdaptiveTitForTat(Player):
@@ -544,7 +530,8 @@ class AdaptiveTitForTat(Player):
 
     def __init__(self, rate: float = 0.5) -> None:
         super().__init__()
-        self.rate, self.starting_rate = rate, rate
+        self.rate = rate
+        self.world = rate
 
     def strategy(self, opponent: Player) -> Action:
 
@@ -561,11 +548,6 @@ class AdaptiveTitForTat(Player):
 
         return D
 
-    def reset(self):
-
-        super().reset()
-        self.world = 0.5
-        self.rate = self.starting_rate
 
 
 class SpitefulTitForTat(Player):
@@ -610,9 +592,6 @@ class SpitefulTitForTat(Player):
                 return D
             return C
 
-    def reset(self):
-        super().reset()
-        self.retaliating = False
 
 
 class SlowTitForTwoTats2(Player):
@@ -715,9 +694,6 @@ class EugineNier(Player):
             return D
         return opponent.history[-1]
 
-    def reset(self):
-        super().reset()
-        self.is_defector = False
 
 
 class NTitsForMTats(Player):
@@ -775,9 +751,6 @@ class NTitsForMTats(Player):
             return D
         return C
 
-    def reset(self):
-        super().reset()
-        self.retaliate_count = 0
 
 
 @FinalTransformer((D,), name_prefix=None)
@@ -823,7 +796,3 @@ class Michaelos(Player):
                 return D
 
         return opponent.history[-1]
-
-    def reset(self):
-        super().reset()
-        self.is_defector = False

--- a/axelrod/tests/integration/test_filtering.py
+++ b/axelrod/tests/integration/test_filtering.py
@@ -37,6 +37,7 @@ class TestFiltersAgainstComprehensions(unittest.TestCase):
         min_memory_depth=float('inf'),
         max_memory_depth=float('inf'),
         memory_depth=float('inf'))
+    @settings(max_examples=5, max_iterations=20)
     def test_memory_depth_filtering(self, min_memory_depth, max_memory_depth,
                                     memory_depth):
 
@@ -68,7 +69,7 @@ class TestFiltersAgainstComprehensions(unittest.TestCase):
         self.assertEqual(comprehension, filtered)
 
     @given(seed_=integers(min_value=0, max_value=4294967295))
-    @settings(max_examples=10)
+    @settings(max_examples=5, max_iterations=20)
     def test_makes_use_of_filtering(self, seed_):
         """
         Test equivalent filtering using two approaches.

--- a/axelrod/tests/integration/test_matches.py
+++ b/axelrod/tests/integration/test_matches.py
@@ -2,15 +2,15 @@
 import unittest
 import axelrod
 
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis.strategies import integers
 from axelrod.tests.property import strategy_lists
 
 C, D = axelrod.Action.C, axelrod.Action.D
 
-deterministic_strategies = [s for s in axelrod.strategies
+deterministic_strategies = [s for s in axelrod.short_run_time_strategies
                             if not s().classifier['stochastic']]
-stochastic_strategies = [s for s in axelrod.strategies
+stochastic_strategies = [s for s in axelrod.short_run_time_strategies
                          if s().classifier['stochastic']]
 
 
@@ -19,6 +19,7 @@ class TestMatchOutcomes(unittest.TestCase):
     @given(strategies=strategy_lists(strategies=deterministic_strategies,
                                      min_size=2, max_size=2),
            turns=integers(min_value=1, max_value=20))
+    @settings(max_examples=5, max_iterations=20)
     def test_outcome_repeats(self, strategies, turns):
         """A test that if we repeat 3 matches with deterministic and well
         behaved strategies then we get the same result"""
@@ -31,6 +32,7 @@ class TestMatchOutcomes(unittest.TestCase):
                                      min_size=2, max_size=2),
            turns=integers(min_value=1, max_value=20),
            seed=integers(min_value=0, max_value=4294967295))
+    @settings(max_examples=5, max_iterations=20)
     def test_outcome_repeats_stochastic(self, strategies, turns, seed):
         """a test to check that if a seed is set stochastic strategies give the
         same result"""

--- a/axelrod/tests/integration/test_tournament.py
+++ b/axelrod/tests/integration/test_tournament.py
@@ -17,14 +17,14 @@ class TestTournament(unittest.TestCase):
             axelrod.GoByMajority()]
         cls.player_names = [str(p) for p in cls.players]
         cls.test_name = 'test'
-        cls.test_repetitions = 5
+        cls.test_repetitions = 3
 
         cls.expected_outcome = [
-            ('Cooperator', [180, 180, 180, 180, 180]),
-            ('Defector', [172, 172, 172, 172, 172]),
-            ('Grudger', [199, 199, 199, 199, 199]),
-            ('Soft Go By Majority', [199, 199, 199, 199, 199]),
-            ('Tit For Tat', [199, 199, 199, 199, 199])]
+            ('Cooperator', [45, 45, 45]),
+            ('Defector', [52, 52, 52]),
+            ('Grudger', [49, 49, 49]),
+            ('Soft Go By Majority', [49, 49, 49]),
+            ('Tit For Tat', [49, 49, 49])]
         cls.expected_outcome.sort()
 
     def test_full_tournament(self):
@@ -32,7 +32,7 @@ class TestTournament(unittest.TestCase):
         strategies = [strategy() for strategy in axelrod.strategies]
         tournament = axelrod.Tournament(name='test', players=strategies,
                                         game=self.game, turns=2,
-                                        repetitions=2)
+                                        repetitions=1)
         filename = "test_outputs/test_tournament.csv"
         self.assertIsNone(tournament.play(progress_bar=False,
                                           filename=filename,
@@ -43,7 +43,7 @@ class TestTournament(unittest.TestCase):
             name=self.test_name,
             players=self.players,
             game=self.game,
-            turns=20,
+            turns=5,
             repetitions=self.test_repetitions)
         scores = tournament.play(progress_bar=False).scores
         actual_outcome = sorted(zip(self.player_names, scores))
@@ -54,7 +54,7 @@ class TestTournament(unittest.TestCase):
             name=self.test_name,
             players=self.players,
             game=self.game,
-            turns=20,
+            turns=5,
             repetitions=self.test_repetitions)
         scores = tournament.play(processes=2, progress_bar=False).scores
         actual_outcome = sorted(zip(self.player_names, scores))
@@ -62,7 +62,7 @@ class TestTournament(unittest.TestCase):
 
     def test_repeat_tournament_deterministic(self):
         """A test to check that tournament gives same results."""
-        deterministic_players = [s() for s in axelrod.strategies
+        deterministic_players = [s() for s in axelrod.short_run_time_strategies
                                  if not s().classifier['stochastic']]
         files = []
         for _ in range(2):
@@ -82,7 +82,7 @@ class TestTournament(unittest.TestCase):
         files = []
         for _ in range(2):
             axelrod.seed(0)
-            stochastic_players = [s() for s in axelrod.strategies
+            stochastic_players = [s() for s in axelrod.short_run_time_strategies
                                   if s().classifier['stochastic']]
             tournament = axelrod.Tournament(name='test',
                                             players=stochastic_players,
@@ -98,14 +98,14 @@ class TestNoisyTournament(unittest.TestCase):
     def test_noisy_tournament(self):
         # Defector should win for low noise
         players = [axelrod.Cooperator(), axelrod.Defector()]
-        tournament = axelrod.Tournament(players, turns=20, repetitions=10,
+        tournament = axelrod.Tournament(players, turns=5, repetitions=3,
                                         noise=0.)
         results = tournament.play(progress_bar=False)
         self.assertEqual(results.ranked_names[0], "Defector")
 
         # If the noise is large enough, cooperator should win
         players = [axelrod.Cooperator(), axelrod.Defector()]
-        tournament = axelrod.Tournament(players, turns=20, repetitions=10,
+        tournament = axelrod.Tournament(players, turns=5, repetitions=3,
                                         noise=0.75)
         results = tournament.play(progress_bar=False)
         self.assertEqual(results.ranked_names[0], "Cooperator")
@@ -119,7 +119,7 @@ class TestProbEndTournament(unittest.TestCase):
         p1 = FinalTransformer(['D', 'D'])(axelrod.Cooperator)()
         p2 = FinalTransformer(['D', 'D'])(axelrod.Cooperator)()
         players = [p1, p2]
-        tournament = axelrod.Tournament(players, prob_end=.1, repetitions=1)
+        tournament = axelrod.Tournament(players, prob_end=.5, repetitions=1)
         results = tournament.play(progress_bar=False)
         # Check that both plays always cooperated
         for rating in results.cooperating_rating:
@@ -135,7 +135,7 @@ class TestProbEndTournament(unittest.TestCase):
         p3 = axelrod.Cooperator()
         players = [p1, p2, p3]
         axelrod.seed(0)
-        tournament = axelrod.Tournament(players, prob_end=.1, repetitions=2)
+        tournament = axelrod.Tournament(players, prob_end=.5, repetitions=2)
         results = tournament.play(progress_bar=False)
         # Check that match length are different across the repetitions
         self.assertNotEqual(results.match_lengths[0], results.match_lengths[1])

--- a/axelrod/tests/property.py
+++ b/axelrod/tests/property.py
@@ -1,7 +1,11 @@
 """
 A module for creating hypothesis based strategies for property based testing
 """
-from axelrod import strategies, Match, Game, Tournament
+from axelrod import (short_run_time_strategies,
+                     strategies,
+                     Match,
+                     Game,
+                     Tournament)
 from hypothesis.strategies import (composite, sampled_from, integers,
                                    floats, lists)
 
@@ -9,7 +13,7 @@ import itertools
 
 
 @composite
-def strategy_lists(draw, strategies=strategies, min_size=1,
+def strategy_lists(draw, strategies=short_run_time_strategies, min_size=1,
                    max_size=len(strategies)):
     """
     A hypothesis decorator to return a list of strategies
@@ -27,7 +31,7 @@ def strategy_lists(draw, strategies=strategies, min_size=1,
 
 
 @composite
-def matches(draw, strategies=strategies,
+def matches(draw, strategies=short_run_time_strategies,
             min_turns=1, max_turns=200,
             min_noise=0, max_noise=1):
     """
@@ -59,7 +63,7 @@ def matches(draw, strategies=strategies,
 
 
 @composite
-def tournaments(draw, strategies=strategies,
+def tournaments(draw, strategies=short_run_time_strategies,
                 min_size=1, max_size=10,
                 min_turns=1, max_turns=200,
                 min_noise=0, max_noise=1,
@@ -101,7 +105,7 @@ def tournaments(draw, strategies=strategies,
 
 
 @composite
-def prob_end_tournaments(draw, strategies=strategies,
+def prob_end_tournaments(draw, strategies=short_run_time_strategies,
                          min_size=1, max_size=10,
                          min_prob_end=0, max_prob_end=1,
                          min_noise=0, max_noise=1,
@@ -143,7 +147,7 @@ def prob_end_tournaments(draw, strategies=strategies,
 
 
 @composite
-def spatial_tournaments(draw, strategies=strategies,
+def spatial_tournaments(draw, strategies=short_run_time_strategies,
                         min_size=1, max_size=10,
                         min_turns=1, max_turns=200,
                         min_noise=0, max_noise=1,
@@ -201,7 +205,7 @@ def spatial_tournaments(draw, strategies=strategies,
 
 
 @composite
-def prob_end_spatial_tournaments(draw, strategies=strategies,
+def prob_end_spatial_tournaments(draw, strategies=short_run_time_strategies,
                                 min_size=1, max_size=10,
                                 min_prob_end=0, max_prob_end=1,
                                 min_noise=0, max_noise=1,

--- a/axelrod/tests/unit/test_filters.py
+++ b/axelrod/tests/unit/test_filters.py
@@ -1,6 +1,6 @@
 import operator
 import unittest
-from hypothesis import given, example
+from hypothesis import given, example, settings
 from hypothesis.strategies import integers
 from axelrod.strategies._filters import *
 from axelrod import filtered_strategies
@@ -35,6 +35,7 @@ class TestFilters(unittest.TestCase):
         larger=integers(min_value=11, max_value=100),
     )
     @example(smaller=0, larger=float('inf'))
+    @settings(max_examples=5, max_iterations=20)
     def test_inequality_filter(self, smaller, larger):
         self.assertTrue(passes_operator_filter(
             self.TestStrategy, 'memory_depth', smaller, operator.ge))
@@ -60,6 +61,7 @@ class TestFilters(unittest.TestCase):
         larger=integers(min_value=11, max_value=100),
     )
     @example(smaller=0, larger=float('inf'))
+    @settings(max_examples=5, max_iterations=20)
     def test_passes_filterset(self, smaller, larger):
 
         full_passing_filterset_1 = {

--- a/axelrod/tests/unit/test_fingerprint.py
+++ b/axelrod/tests/unit/test_fingerprint.py
@@ -2,7 +2,7 @@ import os
 from tempfile import mkstemp
 import unittest
 from unittest.mock import patch
-from hypothesis import given
+from hypothesis import given, settings
 import axelrod as axl
 from axelrod.fingerprint import (create_points, create_jossann, create_probes,
                                  create_edges, generate_data, reshape_data,
@@ -373,6 +373,7 @@ class TestFingerprint(unittest.TestCase):
             self.assertAlmostEqual(value, test_data[key], places=2)
 
     @given(strategy_pair=strategy_lists(min_size=2, max_size=2))
+    @settings(max_examples=5, max_iterations=20)
     def test_pair_fingerprints(self, strategy_pair):
         """
         A test to check that we can fingerprint

--- a/axelrod/tests/unit/test_game.py
+++ b/axelrod/tests/unit/test_game.py
@@ -1,5 +1,5 @@
 import unittest
-from hypothesis import given
+from hypothesis import given, settings
 
 import axelrod
 from axelrod.tests.property import *
@@ -42,6 +42,7 @@ class TestGame(unittest.TestCase):
         self.assertNotEqual(Game(), 'wrong class')
 
     @given(r=integers(), p=integers(), s=integers(), t=integers())
+    @settings(max_examples=5, max_iterations=20)
     def test_property_init(self, r, p, s, t):
         """Use the hypothesis library to test init"""
         expected_scores = {(C, D): (s, t), (D, C): (t, s),
@@ -50,12 +51,14 @@ class TestGame(unittest.TestCase):
         self.assertEqual(game.scores, expected_scores)
 
     @given(r=integers(), p=integers(), s=integers(), t=integers())
+    @settings(max_examples=5, max_iterations=20)
     def test_property_RPST(self, r, p, s, t):
         """Use the hypothesis library to test RPST"""
         game = axelrod.Game(r, s, t, p)
         self.assertEqual(game.RPST(), (r, p, s, t))
 
     @given(r=integers(), p=integers(), s=integers(), t=integers())
+    @settings(max_examples=5, max_iterations=20)
     def test_property_score(self, r, p, s, t):
         """Use the hypothesis library to test score"""
         game = axelrod.Game(r, s, t, p)
@@ -65,6 +68,7 @@ class TestGame(unittest.TestCase):
         self.assertEqual(game.score((D, C)), (t, s))
 
     @given(game=games())
+    @settings(max_examples=5, max_iterations=20)
     def test_repr(self, game):
         expected_repr = "Axelrod game: (R,P,S,T) = {}".format(game.RPST())
         self.assertEqual(expected_repr, game.__repr__())

--- a/axelrod/tests/unit/test_match_generator.py
+++ b/axelrod/tests/unit/test_match_generator.py
@@ -1,6 +1,6 @@
 import unittest
 
-from hypothesis import given, example
+from hypothesis import given, example, settings
 from hypothesis.strategies import floats, integers
 
 import axelrod
@@ -147,6 +147,7 @@ class TestMatchGenerator(unittest.TestCase):
         self.assertEqual(match.match_attributes, {"length": float('inf')})
 
     @given(repetitions=integers(min_value=1, max_value=test_repetitions))
+    @settings(max_examples=5, max_iterations=20)
     @example(repetitions=test_repetitions)
     def test_build_match_chunks(self, repetitions):
         rr = axelrod.MatchGenerator(players=self.players,
@@ -163,6 +164,7 @@ class TestMatchGenerator(unittest.TestCase):
                          sorted(expected_match_definitions))
 
     @given(repetitions=integers(min_value=1, max_value=test_repetitions))
+    @settings(max_examples=5, max_iterations=20)
     @example(repetitions=test_repetitions)
     def test_spatial_build_match_chunks(self, repetitions):
         cycle = [(0, 1), (1, 2), (2, 3), (3, 4), (4, 1)]

--- a/axelrod/tests/unit/test_moran.py
+++ b/axelrod/tests/unit/test_moran.py
@@ -271,7 +271,7 @@ class TestMoranProcess(unittest.TestCase):
         self.assertEqual(mp.winning_strategy_name, str(axelrod.Defector()))
 
     @given(strategies=strategy_lists(min_size=2, max_size=4))
-    @settings(max_examples=5, timeout=0)  # Very low number of examples
+    @settings(max_examples=5, max_iterations=20)
 
     # Two specific examples relating to cloning of strategies
     @example(strategies=[axelrod.BackStabber, axelrod.MindReader])

--- a/axelrod/tests/unit/test_property.py
+++ b/axelrod/tests/unit/test_property.py
@@ -20,7 +20,7 @@ class TestStrategyList(unittest.TestCase):
             self.assertIsInstance(p(), axelrod.Player)
 
     @given(strategies=strategy_lists(min_size=1, max_size=50))
-    @settings(max_examples=10, timeout=0)
+    @settings(max_examples=5, max_iterations=20)
     def test_decorator(self, strategies):
         self.assertIsInstance(strategies, list)
         self.assertGreaterEqual(len(strategies), 1)
@@ -29,7 +29,7 @@ class TestStrategyList(unittest.TestCase):
             self.assertIsInstance(strategy(), axelrod.Player)
 
     @given(strategies=strategy_lists(strategies=axelrod.basic_strategies))
-    @settings(max_examples=10, timeout=0)
+    @settings(max_examples=5, max_iterations=20)
     def test_decorator_with_given_strategies(self, strategies):
         self.assertIsInstance(strategies, list)
         basic_player_names = [str(s()) for s in axelrod.basic_strategies]
@@ -50,7 +50,7 @@ class TestMatch(unittest.TestCase):
 
     @given(match=matches(min_turns=10, max_turns=50,
                          min_noise=0, max_noise=1))
-    @settings(max_examples=10, timeout=0)
+    @settings(max_examples=5, max_iterations=20)
     def test_decorator(self, match):
 
         self.assertIsInstance(match, axelrod.Match)
@@ -61,7 +61,7 @@ class TestMatch(unittest.TestCase):
 
     @given(match=matches(min_turns=10, max_turns=50,
                          min_noise=0, max_noise=0))
-    @settings(max_examples=10, timeout=0)
+    @settings(max_examples=5, max_iterations=20)
     def test_decorator_with_no_noise(self, match):
 
         self.assertIsInstance(match, axelrod.Match)
@@ -80,7 +80,7 @@ class TestTournament(unittest.TestCase):
                                   max_noise=1, min_repetitions=2,
                                   max_repetitions=50,
                                   max_size=3))
-    @settings(max_examples=10, timeout=0)
+    @settings(max_examples=5, max_iterations=20)
     def test_decorator(self, tournament):
         self.assertIsInstance(tournament, axelrod.Tournament)
         self.assertLessEqual(tournament.turns, 50)
@@ -92,7 +92,7 @@ class TestTournament(unittest.TestCase):
 
     @given(tournament=tournaments(strategies=axelrod.basic_strategies,
                                   max_size=3))
-    @settings(max_examples=10, timeout=0)
+    @settings(max_examples=5, max_iterations=20)
     def test_decorator_with_given_strategies(self, tournament):
         self.assertIsInstance(tournament, axelrod.Tournament)
         basic_player_names = [str(s()) for s in axelrod.basic_strategies]
@@ -112,7 +112,7 @@ class TestProbEndTournament(unittest.TestCase):
                                            min_repetitions=2,
                                            max_repetitions=50,
                                            max_size=3))
-    @settings(max_examples=10, timeout=0)
+    @settings(max_examples=5, max_iterations=20)
     def test_decorator(self, tournament):
         self.assertIsInstance(tournament, axelrod.Tournament)
         self.assertLessEqual(tournament.prob_end, 1)
@@ -124,7 +124,7 @@ class TestProbEndTournament(unittest.TestCase):
 
     @given(tournament=prob_end_tournaments(strategies=axelrod.basic_strategies,
                                            max_size=3))
-    @settings(max_examples=10, timeout=0)
+    @settings(max_examples=5, max_iterations=20)
     def test_decorator_with_given_strategies(self, tournament):
         self.assertIsInstance(tournament, axelrod.Tournament)
         basic_player_names = [str(s()) for s in axelrod.basic_strategies]
@@ -144,7 +144,7 @@ class TestSpatialTournament(unittest.TestCase):
                                           min_repetitions=2,
                                           max_repetitions=50,
                                           max_size=3))
-    @settings(max_examples=10, timeout=0)
+    @settings(max_examples=5, max_iterations=20)
     def test_decorator(self, tournament):
         self.assertIsInstance(tournament, axelrod.Tournament)
         self.assertLessEqual(tournament.turns, 50)
@@ -156,7 +156,7 @@ class TestSpatialTournament(unittest.TestCase):
 
     @given(tournament=spatial_tournaments(strategies=axelrod.basic_strategies,
                                           max_size=3))
-    @settings(max_examples=10, timeout=0)
+    @settings(max_examples=5, max_iterations=20)
     def test_decorator_with_given_strategies(self, tournament):
         self.assertIsInstance(tournament, axelrod.Tournament)
         basic_player_names = [str(s()) for s in axelrod.basic_strategies]
@@ -177,7 +177,7 @@ class TestProbEndSpatialTournament(unittest.TestCase):
                                                    min_repetitions=2,
                                                    max_repetitions=50,
                                                    max_size=3))
-    @settings(max_examples=10, timeout=0)
+    @settings(max_examples=5, max_iterations=20)
     def test_decorator(self, tournament):
         self.assertIsInstance(tournament, axelrod.Tournament)
         self.assertLessEqual(tournament.prob_end, 1)
@@ -189,7 +189,7 @@ class TestProbEndSpatialTournament(unittest.TestCase):
 
     @given(tournament=prob_end_spatial_tournaments(strategies=axelrod.basic_strategies,
                                           max_size=3))
-    @settings(max_examples=10, timeout=0)
+    @settings(max_examples=5, max_iterations=20)
     def test_decorator_with_given_strategies(self, tournament):
         self.assertIsInstance(tournament, axelrod.Tournament)
         basic_player_names = [str(s()) for s in axelrod.basic_strategies]
@@ -204,13 +204,13 @@ class TestGame(unittest.TestCase):
         self.assertIsInstance(game, axelrod.Game)
 
     @given(game=games())
-    @settings(max_examples=10, timeout=0)
+    @settings(max_examples=5, max_iterations=20)
     def test_decorator(self, game):
         self.assertIsInstance(game, axelrod.Game)
         r, p, s, t = game.RPST()
         self.assertTrue((2 * r) > (t + s) and (t > r > p > s))
 
     @given(game=games(prisoners_dilemma=False))
-    @settings(max_examples=10, timeout=0)
+    @settings(max_examples=5, max_iterations=20)
     def test_decorator_unconstrained(self, game):
         self.assertIsInstance(game, axelrod.Game)

--- a/axelrod/tests/unit/test_resultset.py
+++ b/axelrod/tests/unit/test_resultset.py
@@ -640,7 +640,7 @@ class TestResultSetFromFile(unittest.TestCase):
                                   max_turns=5,
                                   max_noise=0,
                                   max_repetitions=3))
-    @settings(max_examples=50, timeout=0)
+    @settings(max_examples=5, max_iterations=20)
     def test_equality_with_round_robin(self, tournament):
         filename = "test_outputs/test_results.csv"
         tournament.play(filename=filename, progress_bar=False,
@@ -664,7 +664,7 @@ class TestResultSetFromFile(unittest.TestCase):
     @given(tournament=prob_end_tournaments(max_size=5,
                                            min_prob_end=.7,
                                            max_repetitions=3))
-    @settings(max_examples=50, timeout=0)
+    @settings(max_examples=5, max_iterations=20)
     def test_equality_with_prob_end(self, tournament):
         filename = "test_outputs/test_results.csv"
         tournament.play(filename=filename, progress_bar=False,
@@ -1424,7 +1424,7 @@ class TestSummary(unittest.TestCase):
     @given(tournament=tournaments(max_size=5,
                                   max_turns=5,
                                   max_repetitions=3))
-    @settings(max_examples=50, timeout=0)
+    @settings(max_examples=5, max_iterations=20)
     def test_summarise_without_failure(self, tournament):
         results = tournament.play(progress_bar=False)
         sd = results.summarise()

--- a/axelrod/tests/unit/test_strategy_utils.py
+++ b/axelrod/tests/unit/test_strategy_utils.py
@@ -4,7 +4,7 @@ import unittest
 
 import axelrod
 
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis.strategies import sampled_from, lists, integers
 
 from axelrod import Action
@@ -17,6 +17,7 @@ class TestDetectCycle(unittest.TestCase):
     """Test the detect cycle function"""
     @given(cycle=lists(sampled_from([C, D]), min_size=2, max_size=10),
            period=integers(min_value=3, max_value=10))
+    @settings(max_examples=5, max_iterations=20)
     def test_finds_cycle(self, cycle, period):
         history = cycle * period
         self.assertIsNotNone(detect_cycle(history))

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -37,7 +37,7 @@ test_prob_end = .5
 
 test_edges = [(0, 1), (1, 2), (3, 4)]
 
-deterministic_strategies = [s for s in axelrod.strategies
+deterministic_strategies = [s for s in axelrod.short_run_time_strategies
                             if not s().classifier['stochastic']]
 
 
@@ -238,9 +238,10 @@ class TestTournament(unittest.TestCase):
 
     def test_get_file_object_with_filename(self):
         self.test_tournament.filename = self.filename
-        file, writer = self.test_tournament._get_file_objects()
-        self.assertIsInstance(file, io.TextIOWrapper)
+        file_object, writer = self.test_tournament._get_file_objects()
+        self.assertIsInstance(file_object, io.TextIOWrapper)
         self.assertEqual(writer.__class__.__name__, 'writer')
+        file_object.close()
 
     def test_get_progress_bar(self):
         self.test_tournament.use_progress_bar = False
@@ -406,9 +407,9 @@ class TestTournament(unittest.TestCase):
         self.assert_play_pbar_correct_total_and_finished(play_pbar, total=15)
 
     @given(tournament=tournaments(min_size=2, max_size=5, min_turns=2,
-                                  max_turns=10, min_repetitions=2,
+                                  max_turns=5, min_repetitions=2,
                                   max_repetitions=4))
-    @settings(max_examples=10, timeout=0)
+    @settings(max_examples=5, max_iterations=20)
     @example(tournament=axelrod.Tournament(players=[s() for s in
         test_strategies], turns=test_turns, repetitions=test_repetitions)
         )
@@ -628,6 +629,7 @@ class TestTournament(unittest.TestCase):
         self.assertIsInstance(results, axelrod.ResultSet)
 
     @given(turns=integers(min_value=1, max_value=200))
+    @settings(max_examples=5, max_iterations=20)
     @example(turns=3)
     @example(turns=axelrod.DEFAULT_TURNS)
     def test_play_matches(self, turns):
@@ -783,7 +785,7 @@ class TestProbEndTournament(unittest.TestCase):
                                            max_prob_end=.9,
                                            min_repetitions=2,
                                            max_repetitions=4))
-    @settings(max_examples=50, timeout=0)
+    @settings(max_examples=5, max_iterations=20)
     @example(tournament=
         axelrod.Tournament(players=[s() for s in test_strategies],
                            prob_end=.2, repetitions=test_repetitions))
@@ -844,7 +846,7 @@ class TestSpatialTournament(unittest.TestCase):
            repetitions=integers(min_value=1, max_value=5),
            noise=floats(min_value=0, max_value=1),
            seed=integers(min_value=0, max_value=4294967295))
-    @settings(max_examples=50, timeout=0)
+    @settings(max_examples=5, max_iterations=20)
     def test_complete_tournament(self, strategies, turns, repetitions,
                                  noise, seed):
         """
@@ -946,7 +948,7 @@ class TestProbEndingSpatialTournament(unittest.TestCase):
            prob_end=floats(min_value=.1, max_value=.9),
            reps=integers(min_value=1, max_value=3),
            seed=integers(min_value=0, max_value=4294967295))
-    @settings(max_examples=50, timeout=0)
+    @settings(max_examples=5, max_iterations=20)
     def test_complete_tournament(self, strategies, prob_end,
                                  seed, reps):
         """
@@ -983,7 +985,7 @@ class TestProbEndingSpatialTournament(unittest.TestCase):
                                           max_turns=1, max_noise=0,
                                           max_repetitions=3),
            seed=integers(min_value=0, max_value=4294967295))
-    @settings(max_examples=50, timeout=0)
+    @settings(max_examples=5, max_iterations=20)
     def test_one_turn_tournament(self, tournament, seed):
         """
         Tests that gives same result as the corresponding spatial round robin

--- a/axelrod/tests/unit/test_version.py
+++ b/axelrod/tests/unit/test_version.py
@@ -5,4 +5,4 @@ from axelrod import __version__
 
 class TestVersion(unittest.TestCase):
     def test_version(self):
-        self.assertIsInstance(__version__, int)
+        self.assertIsInstance(__version__, str)

--- a/axelrod/tests/unit/test_version.py
+++ b/axelrod/tests/unit/test_version.py
@@ -5,4 +5,4 @@ from axelrod import __version__
 
 class TestVersion(unittest.TestCase):
     def test_version(self):
-        self.assertIsInstance(__version__, str)
+        self.assertIsInstance(__version__, int)

--- a/docs/tutorials/contributing/strategy/writing_the_new_strategy.rst
+++ b/docs/tutorials/contributing/strategy/writing_the_new_strategy.rst
@@ -117,10 +117,6 @@ opponent.history[-1]`)::
 
 The variables :code:`C` and :code:`D` represent the cooperate and defect actions respectively.
 
-If your strategy creates any particular attribute along the way you need to make
-sure that there is a :code:`reset` method that takes account of it.  An example
-of this is the :code:`ForgetfulGrudger` strategy.
-
 You can also modify the name of the strategy with the :code:`__repr__` method,
 which is invoked when :code:`str` is applied to a player instance. For example,
 the :code:`Random` strategy takes a parameter :code:`p` for how often it
@@ -143,7 +139,7 @@ Now we have separate names for different instantiations::
 This helps distinguish players in tournaments that have multiple instances of the
 same strategy. If you modify the :code:`__repr__` method of player, be sure to
 add an appropriate test.
-    
+
 There are various examples of helpful functions and properties that make
 writing strategies easier. Do not hesitate to get in touch with the
 Axelrod-Python team for guidance.


### PR DESCRIPTION
This makes use of the `init_kwargs` and in fact we no longer need to
write reset methods (unless we want them for cheating strategies etc).

There are two relevant (simple) changes:

- Modify `player.reset` to call `self.__init__(**self.kwargs)`
- Tweak the match to pass the match attributes to the player just after resetting it.

The rest are me just removing the `reset` method except for the `Darwin` strategy which does things it's own way (and is classified as such).

Closes #1119