### PR TITLE
Fix the data set dimensions for the sdvplot.

### DIFF
--- a/axelrod/plot.py
+++ b/axelrod/plot.py
@@ -112,8 +112,8 @@ class Plot(object):
     @property
     def _sdv_plot_dataset(self):
         ordering = self._sd_ordering
-        diffs = [[diff for repetition in diffs for diff in repetition]
-                 for diffs in self.result_set.score_diffs]
+        diffs = [[score_diff for opponent in player for score_diff in opponent]
+                 for player in self.result_set.score_diffs]
         # Reorder and grab names
         diffs = [diffs[i] for i in ordering]
         ranked_names = [str(self.players[i]) for i in ordering]

--- a/axelrod/plot.py
+++ b/axelrod/plot.py
@@ -112,7 +112,8 @@ class Plot(object):
     @property
     def _sdv_plot_dataset(self):
         ordering = self._sd_ordering
-        diffs = self.result_set.score_diffs
+        diffs = [[diff for repetition in diffs for diff in repetition]
+                 for diffs in self.result_set.score_diffs]
         # Reorder and grab names
         diffs = [diffs[i] for i in ordering]
         ranked_names = [str(self.players[i]) for i in ordering]

--- a/axelrod/tests/unit/test_plot.py
+++ b/axelrod/tests/unit/test_plot.py
@@ -70,6 +70,12 @@ class TestPlot(unittest.TestCase):
             [[2, 2, 2], [0, 0, 0], [0, 0, 0]],
             ['Defector', 'Tit For Tat', 'Alternator'])
 
+        cls.expected_sdvplot_dataset = (
+            [[3, 3, 3, 1, 1, 1, 0, 0, 0],
+             [0, 0, 0, 0, 0, 0, -1, -1, -1],
+             [0, 0, 0, 0, 0, 0, -3, -3, -3]],
+            ['Defector', 'Tit For Tat', 'Alternator'])
+
     def test_default_cmap(self):
         cmap = axelrod.plot.default_cmap('0.0')
         self.assertEqual(cmap, 'YlGnBu')
@@ -172,6 +178,12 @@ class TestPlot(unittest.TestCase):
         fig = plot.winplot()
         self.assertIsInstance(fig, matplotlib.pyplot.Figure)
         plt.close(fig)
+
+    def test_sdvplot_dataset(self):
+        plot = axelrod.Plot(self.test_result_set)
+        self.assertSequenceEqual(
+            plot._sdv_plot_dataset,
+            self.expected_sdvplot_dataset)
 
     def test_sdvplot(self):
         plot = axelrod.Plot(self.test_result_set)

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -251,7 +251,7 @@ class TestTournament(unittest.TestCase):
         self.test_tournament.use_progress_bar = True
         pbar = self.test_tournament._get_progress_bar()
         self.assertIsInstance(pbar, tqdm)
-        self.assertEqual(pbar.desc, 'Playing matches: ')
+        self.assertEqual(pbar.desc, 'Playing matches')
         self.assertEqual(pbar.n, 0)
         self.assertEqual(pbar.total, self.test_tournament.match_generator.size)
 
@@ -260,7 +260,7 @@ class TestTournament(unittest.TestCase):
                                             edges=new_edges)
         new_tournament.use_progress_bar = True
         pbar = new_tournament._get_progress_bar()
-        self.assertEqual(pbar.desc, 'Playing matches: ')
+        self.assertEqual(pbar.desc, 'Playing matches')
         self.assertEqual(pbar.n, 0)
         self.assertEqual(pbar.total, len(new_edges))
 
@@ -327,7 +327,7 @@ class TestTournament(unittest.TestCase):
         self.assertIsInstance(results, axelrod.ResultSet)
 
     def assert_play_pbar_correct_total_and_finished(self, pbar, total):
-        self.assertEqual(pbar.desc, 'Playing matches: ')
+        self.assertEqual(pbar.desc, 'Playing matches')
         self.assertEqual(pbar.total, total)
         self.assertEqual(pbar.n, total)
         self.assertTrue(pbar.disable, True)

--- a/axelrod/tournament.py
+++ b/axelrod/tournament.py
@@ -255,8 +255,8 @@ class Tournament(object):
         """
         # At first sight, it might seem simpler to use the multiprocessing Pool
         # Class rather than Processes and Queues. However, this way is faster.
-        work_queue = Queue()
-        done_queue = Queue()
+        work_queue = Queue() # type: Queue
+        done_queue = Queue() # type: Queue
         workers = self._n_workers(processes=processes)
 
         chunks = self.match_generator.build_match_chunks()

--- a/axelrod/tournament.py
+++ b/axelrod/tournament.py
@@ -255,8 +255,8 @@ class Tournament(object):
         """
         # At first sight, it might seem simpler to use the multiprocessing Pool
         # Class rather than Processes and Queues. However, this way is faster.
-        work_queue = Queue() # type: Queue
-        done_queue = Queue() # type: Queue
+        work_queue = Queue()  # type: Queue
+        done_queue = Queue()  # type: Queue
         workers = self._n_workers(processes=processes)
 
         chunks = self.match_generator.build_match_chunks()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.9.2
 matplotlib>=1.4.2
-hypothesis>=3.2
 tqdm>=3.4.0
 prompt-toolkit>=1.0.7
 scipy>=0.19.0
+hypothesis==3.2


### PR DESCRIPTION
This closes #1129.

I could not find anything in the release notes
<http://matplotlib.org/users/whats_new.html> however I think this is due to the fact that mpl 2.1 got rid of the ability to handle the unflattened sub list (so this fix will still work with previous versions of mpl).