### PR TITLE
add Eatherley reference to k46r.

### DIFF
--- a/docs/reference/overview_of_strategies.rst
+++ b/docs/reference/overview_of_strategies.rst
@@ -116,7 +116,7 @@ repository.
    "K43R_", "R D Anderson", "Not Implemented"
    "K44R_", "William Adams", "Not Implemented"
    "K45R_", "Michael F McGurrin", "Not Implemented"
-   "K46R_", "Graham J Eatherley", "Not Implemented"
+   "K46R_", "Graham J Eatherley", ":class:`Eatherley <axelrod.strategies.axelrod_second.Eatherley>`"
    "K47R_", "Richard Hufford", "Not Implemented"
    "K48R_", "George Hufford", "Not Implemented"
    "K49R_", "Rob Cave", "Not Implemented"


### PR DESCRIPTION
The original FORTRAN strategy k46r is the strategy called Eatherley in the library.

Original submitted by Graham Eatherley. The description can be found in Axelrod's second tournament
paper.

Updated #1095 and I did run the fingerprints to make sure that the strategies match:

**k46r fingerprints:**

![k46r_fingerprint](https://user-images.githubusercontent.com/19708408/32172593-0e139fc4-bd74-11e7-85df-1f58133dffa2.png)
![k46r_tr_fingerprint](https://user-images.githubusercontent.com/19708408/32172604-16041e66-bd74-11e7-813d-dda788c65468.png)
![k46r_tr_fingerprint](https://user-images.githubusercontent.com/19708408/32175104-c1ec8c70-bd7b-11e7-9dce-8a594175a959.png)


 **Eatherley fingerprints:**

![eatherley_fingerprint](https://user-images.githubusercontent.com/19708408/32175034-7ebeeb1e-bd7b-11e7-9318-bd18e803d1f4.png)
![eatherley_tr_fingerprint](https://user-images.githubusercontent.com/19708408/32175037-810dc778-bd7b-11e7-8908-da49ebfeaece.png)
![download](https://user-images.githubusercontent.com/19708408/32175048-8b185ac6-bd7b-11e7-925b-5d7191893f2c.png)
