### PR TITLE
Implemented Harrington (k75r from Axelrod's Second)

### DIFF
--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -9,7 +9,7 @@ from .axelrod_first import (
     UnnamedStrategy, SteinAndRapoport, TidemanAndChieruzzi)
 from .axelrod_second import (
     Champion, Eatherley, Tester, Gladstein, Tranquilizer, MoreGrofman,
-    Kluepfel, Borufsen, Cave, WmAdams, GraaskampKatzen, Weiner)
+    Kluepfel, Borufsen, Cave, WmAdams, GraaskampKatzen, Weiner, Harrington)
 from .backstabber import BackStabber, DoubleCrosser
 from .better_and_better import BetterAndBetter
 from .bush_mosteller import BushMosteller
@@ -186,6 +186,7 @@ all_strategies = [
     HardProber,
     HardTitFor2Tats,
     HardTitForTat,
+    Harrington,
     HesitantQLearner,
     Hopeless,
     Inverse,

--- a/axelrod/strategies/axelrod_second.py
+++ b/axelrod/strategies/axelrod_second.py
@@ -979,10 +979,11 @@ class Weiner(Player):
 
 class Harrington(Player):
     """
-    Strategy submitted to Axelrod's second tournament by Paul Harringtn (K75R),
+    Strategy submitted to Axelrod's second tournament by Paul Harrington (K75R)
     and came in eighth in that tournament.
 
-    This strategy has three modes:  Normal, and Fair-weather, Defect.
+    This strategy has three modes:  Normal, Fair-weather, and Defect.  These
+    mode names were not present in Harrington's submission.
 
     In Normal and Fair-weather modes, the strategy begins by:
 
@@ -1013,13 +1014,17 @@ class Harrington(Player):
     The player mostly plays Tit-for-Tat for the first 36 moves, then defects on
     the 37th move.  If the opponent cooperates on the first 36 moves, and
     defects on the 37th move also, then enter Fair-weather mode and cooperate
-    this turn.
+    this turn.  Entering Fair-weather mode is extremely rare, since this can
+    only happen if the opponent cooperates for the first 36 then defects
+    unprovoked on the 37th.  (That is, this player's first 36 moves are also
+    Cooperations, so there's nothing really to trigger an opponent Defection.)
 
     Next in Normal Mode:
 
     1. Check for defect and parity streaks.
     2. Check if cooperations are scheduled.
     3. Otherwise,
+
        - If turn < 37, Tit-for-Tat.
        - If turn = 37, defect, mark this move as generous, and schedule two
          more cooperations**.
@@ -1224,10 +1229,6 @@ class Harrington(Player):
 
         if turn == 38 and opponent.history[-1] == D and opponent.cooperations == 36:
             self.mode = "Fair-weather"
-            # These flags would already be set from turn == 37 logic below.
-            # Just take care to not lower this turn.
-            # self.more_coop = 2
-            # self.generous_n_turns_ago = 1 # 1 turn ago since this turn is ending.
             return self.try_return(to_return=C, lower_flags=False)
 
 
@@ -1256,13 +1257,12 @@ class Harrington(Player):
 
         if turn < 37:
             return self.try_return(opponent.history[-1], inc_parity=True)
-        elif turn == 37:
+        if turn == 37:
             self.more_coop, self.generous_n_turns_ago = 2, 1
             return self.try_return(D, lower_flags=False)
+        if self.burned or random.random() > self.prob:
+            return self.try_return(opponent.history[-1], inc_parity=True)
         else:
-            if self.burned or random.random() > self.prob:
-                return self.try_return(opponent.history[-1], inc_parity=True)
-            else:
-                self.prob += 0.05
-                self.more_coop, self.generous_n_turns_ago = 2, 1
-                return self.try_return(D, lower_flags=False)
+            self.prob += 0.05
+            self.more_coop, self.generous_n_turns_ago = 2, 1
+            return self.try_return(D, lower_flags=False)

--- a/axelrod/strategies/axelrod_second.py
+++ b/axelrod/strategies/axelrod_second.py
@@ -1025,13 +1025,13 @@ class Harrington(Player):
     2. Check if cooperations are scheduled.
     3. Otherwise,
 
-       - If turn < 37, Tit-for-Tat.
-       - If turn = 37, defect, mark this move as generous, and schedule two
-         more cooperations**.
-       - If turn > 37, then if `burned` flag is raised, then Tit-for-Tat.
-         Otherwise, Tit-for-Tat with probability 1 - `prob`.  And with
-         probability `prob`, defect, schedule two cooperations, mark this move
-         as generous, and increase `prob` by 5%.
+    - If turn < 37, Tit-for-Tat.
+    - If turn = 37, defect, mark this move as generous, and schedule two
+      more cooperations**.
+    - If turn > 37, then if `burned` flag is raised, then Tit-for-Tat.
+      Otherwise, Tit-for-Tat with probability 1 - `prob`.  And with
+      probability `prob`, defect, schedule two cooperations, mark this move
+      as generous, and increase `prob` by 5%.
 
     ** Scheduling two cooperations means to set `more_coop` flag to two.  If in
     Normal mode and no streaks are detected, then the player will cooperate and

--- a/axelrod/strategies/axelrod_second.py
+++ b/axelrod/strategies/axelrod_second.py
@@ -1094,6 +1094,7 @@ class Harrington(Player):
         self.prob = 0.25
 
         self.move_history = np.zeros([4, 2])
+        self.chi_squared = None
         self.history_row = 0
 
         self.more_coop = 0
@@ -1154,6 +1155,8 @@ class Harrington(Player):
                 expct = expected_matrix[i, j] / denom
                 if expct > 1.0:
                     chi_squared += (expct - self.move_history[i, j]) ** 2 / expct
+
+        self.chi_squared = round(chi_squared, 3) # For testing
 
         if chi_squared > 3:
             return False

--- a/axelrod/tests/strategies/test_axelrod_second.py
+++ b/axelrod/tests/strategies/test_axelrod_second.py
@@ -834,7 +834,7 @@ class TestHarrington(TestPlayer):
         match = axelrod.Match((player, axelrod.Random()), turns=len(expected_actions))
         # The history matrix will be [[0, 2], [5, 6], [3, 6], [4, 2]]
         actions = match.play()
-        self.assertEqual(actions, expected_actions)  # Just to be consistant with the current test.
+        self.assertEqual(actions, expected_actions)
         self.assertAlmostEqual(player.calculate_chi_squared(len(expected_actions)), 2.395, places=3)
 
         # Come back out of defect mode

--- a/axelrod/tests/strategies/test_axelrod_second.py
+++ b/axelrod/tests/strategies/test_axelrod_second.py
@@ -1,6 +1,7 @@
 """Tests for the Second Axelrod strategies."""
 
 import random
+import numpy as np
 
 import axelrod
 from .test_player import TestPlayer
@@ -819,3 +820,32 @@ class TestHarrington(TestPlayer):
         # doesn't reset.  This logic comes before parity streaks or the turn-
         # based logic.
         self.versus_test(axelrod.Defector(), expected_actions=actions, attrs={"recorded_defects": 119})
+
+        # Detect random
+        actions = [(C, D), (D, C), (C, D), (D, C), (C, D), (C, D), (D, D),
+                   (D, C), (C, D), (D, C), (C, C), (C, D), (D, D), (D, C),
+                   (C, D), (D, D), (D, C), (C, C), (C, D), (D, C), (C, D),
+                   (D, D), (D, C), (C, D), (D, D), (D, D), (C, D), (D, C),
+                   (C, C)]
+        # Enter defect mode.
+        actions += [(D, C)]
+        self.versus_test(axelrod.Random(0.5), expected_actions=actions, seed=10, attrs={"chi_squared": 2.395})
+        # The history matrix will be [[0, 2], [5, 6], [3, 6], [4, 2]]
+
+        # Come back out of defect mode
+        opponent_actions = [D, C, D, C, D, D, D, C, D, C, C, D, D, C, D, D, C,
+                            C, D, C, D, D, C, D, D, D, D, C, C, C]
+        opponent_actions += [D] * 16
+        Rand_Then_Def = axelrod.MockPlayer(actions=opponent_actions)
+        actions = [(C, D), (D, C), (C, D), (D, C), (C, D), (C, D), (D, D),
+                   (D, C), (C, D), (D, C), (C, C), (C, D), (D, D), (D, C),
+                   (C, D), (D, D), (D, C), (C, C), (C, D), (D, C), (C, D),
+                   (D, D), (D, C), (C, D), (D, D), (D, D), (C, D), (D, C),
+                   (C, C)]
+        actions += [(D, C)]
+        # Enter defect mode.
+        actions += [(D, D)] * 14
+        # Mutual defect for a while, then exit Defect mode with two coops
+        actions += [(C, D)] * 2
+        self.versus_test(Rand_Then_Def, expected_actions=actions, seed=10, \
+                        attrs={"mode": "Normal", "was_defective": True})

--- a/axelrod/tests/strategies/test_axelrod_second.py
+++ b/axelrod/tests/strategies/test_axelrod_second.py
@@ -822,15 +822,20 @@ class TestHarrington(TestPlayer):
         self.versus_test(axelrod.Defector(), expected_actions=actions, attrs={"recorded_defects": 119})
 
         # Detect random
-        actions = [(C, D), (D, C), (C, D), (D, C), (C, D), (C, D), (D, D),
+        expected_actions = [(C, D), (D, C), (C, D), (D, C), (C, D), (C, D), (D, D),
                    (D, C), (C, D), (D, C), (C, C), (C, D), (D, D), (D, C),
                    (C, D), (D, D), (D, C), (C, C), (C, D), (D, C), (C, D),
                    (D, D), (D, C), (C, D), (D, D), (D, D), (C, D), (D, C),
                    (C, C)]
         # Enter defect mode.
-        actions += [(D, C)]
-        self.versus_test(axelrod.Random(0.5), expected_actions=actions, seed=10, attrs={"chi_squared": 2.395})
+        expected_actions += [(D, C)]
+        random.seed(10)
+        player = self.player()
+        match = axelrod.Match((player, axelrod.Random()), turns=len(expected_actions))
         # The history matrix will be [[0, 2], [5, 6], [3, 6], [4, 2]]
+        actions = match.play()
+        self.assertEqual(actions, expected_actions)  # Just to be consistant with the current test.
+        self.assertEqual(round(player.calculate_chi_squared(len(expected_actions)),3), 2.395)
 
         # Come back out of defect mode
         opponent_actions = [D, C, D, C, D, D, D, C, D, C, C, D, D, C, D, D, C,

--- a/axelrod/tests/strategies/test_axelrod_second.py
+++ b/axelrod/tests/strategies/test_axelrod_second.py
@@ -742,10 +742,10 @@ class TestHarrington(TestPlayer):
         actions = [(C, D), (D, C)] + [(C, C)] * 34 + [(D, C)]
         # Two cooperations scheduled after the 37-turn defection
         actions += [(C, C)] * 2
-        # TFT twice, then low-random # yields a DCC combo.
+        # TFT twice, then random number yields a DCC combo.
         actions += [(C, C)] * 2
         actions += [(D, C), (C, C), (C, C)]
-        # Don't draw next random # until now.  Again DCC.
+        # Don't draw next random number until now.  Again DCC.
         actions += [(D, C), (C, C), (C, C)]
         self.versus_test(Defect1, expected_actions=actions, seed=2)
 
@@ -803,7 +803,7 @@ class TestHarrington(TestPlayer):
         actions += [(D, C), (C, D), (D, C), (C, D), (C, C)]
         # This is the seventh time we've hit the limit.  So do it once more.
         actions += [(C, D), (D, C), (C, D), (D, C), (C, D), (C, C)]
-        # Now hit thi limit sooner
+        # Now hit the limit sooner
         actions += [(C, D), (D, C), (C, D), (C, C)] * 5
         self.versus_test(AsyncAlternator, expected_actions=actions, attrs={"parity_limit": 3})
 
@@ -835,7 +835,7 @@ class TestHarrington(TestPlayer):
         # The history matrix will be [[0, 2], [5, 6], [3, 6], [4, 2]]
         actions = match.play()
         self.assertEqual(actions, expected_actions)  # Just to be consistant with the current test.
-        self.assertEqual(round(player.calculate_chi_squared(len(expected_actions)),3), 2.395)
+        self.assertAlmostEqual(player.calculate_chi_squared(len(expected_actions)), 2.395, places=4)
 
         # Come back out of defect mode
         opponent_actions = [D, C, D, C, D, D, D, C, D, C, C, D, D, C, D, D, C,
@@ -852,5 +852,5 @@ class TestHarrington(TestPlayer):
         actions += [(D, D)] * 14
         # Mutual defect for a while, then exit Defect mode with two coops
         actions += [(C, D)] * 2
-        self.versus_test(Rand_Then_Def, expected_actions=actions, seed=10, \
+        self.versus_test(Rand_Then_Def, expected_actions=actions, seed=10,
                         attrs={"mode": "Normal", "was_defective": True})

--- a/axelrod/tests/strategies/test_axelrod_second.py
+++ b/axelrod/tests/strategies/test_axelrod_second.py
@@ -835,7 +835,7 @@ class TestHarrington(TestPlayer):
         # The history matrix will be [[0, 2], [5, 6], [3, 6], [4, 2]]
         actions = match.play()
         self.assertEqual(actions, expected_actions)  # Just to be consistant with the current test.
-        self.assertAlmostEqual(player.calculate_chi_squared(len(expected_actions)), 2.395, places=4)
+        self.assertAlmostEqual(player.calculate_chi_squared(len(expected_actions)), 2.395, places=3)
 
         # Come back out of defect mode
         opponent_actions = [D, C, D, C, D, D, D, C, D, C, C, D, D, C, D, D, C,

--- a/axelrod/tests/strategies/test_axelrod_second.py
+++ b/axelrod/tests/strategies/test_axelrod_second.py
@@ -717,7 +717,7 @@ class TestHarrington(TestPlayer):
         Defect37 = axelrod.MockPlayer(actions=opponent_actions)
         # Activate the Fair-weather flag
         actions = [(C, C)] * 36 + [(D, D)] + [(C, C)] * 100
-        self.versus_test(Defect37, expected_actions=actions)
+        self.versus_test(Defect37, expected_actions=actions, attrs={"mode": "Fair-weather"})
 
         # Defect on 37th turn to activate Fair-weather, then later defect to
         # exit Fair-weather
@@ -727,12 +727,12 @@ class TestHarrington(TestPlayer):
         actions += [(C, D)]
         #Immediately exit Fair-weather
         actions += [(D, C), (C, C), (D, C), (C, C)]
-        self.versus_test(Defect37_big, expected_actions=actions, seed=2)
+        self.versus_test(Defect37_big, expected_actions=actions, seed=2, attrs={"mode": "Normal"})
         actions = [(C, C)] * 36 + [(D, D)] + [(C, C)] * 100
         actions += [(C, D)]
         #Immediately exit Fair-weather
         actions += [(D, C), (C, C), (C, C), (C, C)]
-        self.versus_test(Defect37_big, expected_actions=actions, seed=1)
+        self.versus_test(Defect37_big, expected_actions=actions, seed=1, attrs={"mode": "Normal"})
 
         # Opponent defects on 1st turn
         opponent_actions = [D] + [C] * 46
@@ -767,7 +767,7 @@ class TestHarrington(TestPlayer):
         actions += [(C, D), (C, C)]
         # TFT from then on, since burned
         actions += [(C, C)] * 8
-        self.versus_test(Defect1_38, expected_actions=actions, seed=2)
+        self.versus_test(Defect1_38, expected_actions=actions, seed=2, attrs={"burned": True})
 
         # Use alternator to test parity flags.
         actions = [(C, C), (C, D)]
@@ -804,7 +804,7 @@ class TestHarrington(TestPlayer):
         actions += [(C, D), (D, C), (C, D), (D, C), (C, D), (C, C)]
         # Now hit thi limit sooner
         actions += [(C, D), (D, C), (C, D), (C, C)] * 5
-        self.versus_test(AsyncAlternator, expected_actions=actions)
+        self.versus_test(AsyncAlternator, expected_actions=actions, attrs={"parity_limit": 3})
 
         # Use a Defector to test the 20-defect streak
         actions = [(C, D), (D, D), (D, D), (D, D), (D, D)]
@@ -812,10 +812,10 @@ class TestHarrington(TestPlayer):
         actions += [(C, D), (C, D)]
         # Repeat
         actions += [(D, D), (D, D), (D, D), (D, D), (C, D), (C, D)] * 2
-        actions += [(D, D)]
-        # 20 D have passed
+        actions += [(D, D), (D, D)]
+        # 20 D have passed (first isn't record)
         actions += [(D, D)] * 100
         # The defect streak will always be detected from here on, because it
         # doesn't reset.  This logic comes before parity streaks or the turn-
         # based logic.
-        self.versus_test(axelrod.Defector(), expected_actions=actions)
+        self.versus_test(axelrod.Defector(), expected_actions=actions, attrs={"recorded_defects": 119})

--- a/axelrod/tests/strategies/test_axelrod_second.py
+++ b/axelrod/tests/strategies/test_axelrod_second.py
@@ -694,3 +694,128 @@ class TestWeiner(TestPlayer):
         actions += [(C, C), (C, D), (D, C)]
         actions += [(C, D)] # Raise flag
         actions += [(C, C)] # Use flag to change outcome
+        self.versus_test(Time_Passer, expected_actions=actions)
+
+
+class TestHarrington(TestPlayer):
+    name = "Harrington"
+    player = axelrod.Harrington
+    expected_classifier = {
+        'memory_depth': float('inf'),
+        'stochastic': True,
+        'makes_use_of': set(),
+        'long_run_time': False,
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+
+    def test_strategy(self):
+        # Build an opponent that will cooperate the first 36 turns and
+        # defect on the 37th turn
+        opponent_actions = [C] * 36 + [D] + [C] * 100
+        Defect37 = axelrod.MockPlayer(actions=opponent_actions)
+        # Activate the Fair-weather flag
+        actions = [(C, C)] * 36 + [(D, D)] + [(C, C)] * 100
+        self.versus_test(Defect37, expected_actions=actions)
+
+        # Defect on 37th turn to activate Fair-weather, then later defect to
+        # exit Fair-weather
+        opponent_actions = [C] * 36 + [D] + [C] * 100 + [D] + [C] * 4
+        Defect37_big = axelrod.MockPlayer(actions=opponent_actions)
+        actions = [(C, C)] * 36 + [(D, D)] + [(C, C)] * 100
+        actions += [(C, D)]
+        #Immediately exit Fair-weather
+        actions += [(D, C), (C, C), (D, C), (C, C)]
+        self.versus_test(Defect37_big, expected_actions=actions, seed=2)
+        actions = [(C, C)] * 36 + [(D, D)] + [(C, C)] * 100
+        actions += [(C, D)]
+        #Immediately exit Fair-weather
+        actions += [(D, C), (C, C), (C, C), (C, C)]
+        self.versus_test(Defect37_big, expected_actions=actions, seed=1)
+
+        # Opponent defects on 1st turn
+        opponent_actions = [D] + [C] * 46
+        Defect1 = axelrod.MockPlayer(actions=opponent_actions)
+        # Tit-for-Tat on the first, but no streaks, no Fair-weather flag.
+        actions = [(C, D), (D, C)] + [(C, C)] * 34 + [(D, C)]
+        # Two cooperations scheduled after the 37-turn defection
+        actions += [(C, C)] * 2
+        # TFT twice, then low-random # yields a DCC combo.
+        actions += [(C, C)] * 2
+        actions += [(D, C), (C, C), (C, C)]
+        # Don't draw next random # until now.  Again DCC.
+        actions += [(D, C), (C, C), (C, C)]
+        self.versus_test(Defect1, expected_actions=actions, seed=2)
+
+        # Defection on turn 37 by opponent doesn't have an effect here
+        opponent_actions = [D] + [C] * 35 + [D] + [C] * 10
+        Defect1_37 = axelrod.MockPlayer(actions=opponent_actions)
+        actions = [(C, D), (D, C)] + [(C, C)] * 34 + [(D, D)]
+        actions += [(C, C)] * 2
+        actions += [(C, C)] * 2
+        actions += [(D, C), (C, C), (C, C)]
+        actions += [(D, C), (C, C), (C, C)]
+        self.versus_test(Defect1_37, expected_actions=actions, seed=2)
+
+        # However a defect on turn 38 would be considered a burn.
+        opponent_actions = [D] + [C] * 36 + [D] + [C] * 9
+        Defect1_38 = axelrod.MockPlayer(actions=opponent_actions)
+        # Tit-for-Tat on the first, but no streaks, no Fair-weather flag.
+        actions = [(C, D), (D, C)] + [(C, C)] * 34 + [(D, C)]
+        # Two cooperations scheduled after the 37-turn defection
+        actions += [(C, D), (C, C)]
+        # TFT from then on, since burned
+        actions += [(C, C)] * 8
+        self.versus_test(Defect1_38, expected_actions=actions, seed=2)
+
+        # Use alternator to test parity flags.
+        actions = [(C, C), (C, D)]
+        # Even streak is set to 2, one for the opponent's defect and one for
+        # our defect.
+        actions += [(D, C)]
+        actions += [(C, D)]
+        # Even streak is increased two more.
+        actions += [(D, C)]
+        actions += [(C, D)]
+        # Opponent's defect increments even streak to 5, so we cooperate.
+        actions += [(C, C)]
+        actions += [(C, D), (D, C), (C, D), (D, C), (C, D)]
+        # Another 5 streak
+        actions += [(C, C)]
+        # Repeat
+        actions += [(C, D), (D, C), (C, D), (D, C), (C, D), (C, C)] * 3
+        # Repeat.  Notice that the last turn is the 37th move, but we do not
+        # defect.
+        actions += [(C, D), (D, C), (C, D), (D, C), (C, D), (C, C)]
+        self.versus_test(axelrod.Alternator(), expected_actions=actions)
+
+        # Test for parity limit shortening.
+        opponent_actions = [D, C] * 1000
+        AsyncAlternator = axelrod.MockPlayer(actions=opponent_actions)
+        actions = [(C, D), (D, C), (C, D), (D, C), (C, D), (C, C)] * 6
+        # Defect on 37th move
+        actions += [(D, D)]
+        actions += [(C, C)]
+        # This triggers the burned flag.  We should just Tit-for-Tat from here.
+        actions += [(C, D)]
+        actions += [(D, C), (C, D), (D, C), (C, D), (C, C)]
+        # This is the seventh time we've hit the limit.  So do it once more.
+        actions += [(C, D), (D, C), (C, D), (D, C), (C, D), (C, C)]
+        # Now hit thi limit sooner
+        actions += [(C, D), (D, C), (C, D), (C, C)] * 5
+        self.versus_test(AsyncAlternator, expected_actions=actions)
+
+        # Use a Defector to test the 20-defect streak
+        actions = [(C, D), (D, D), (D, D), (D, D), (D, D)]
+        # Now the two parity flags are used
+        actions += [(C, D), (C, D)]
+        # Repeat
+        actions += [(D, D), (D, D), (D, D), (D, D), (C, D), (C, D)] * 2
+        actions += [(D, D)]
+        # 20 D have passed
+        actions += [(D, D)] * 100
+        # The defect streak will always be detected from here on, because it
+        # doesn't reset.  This logic comes before parity streaks or the turn-
+        # based logic.
+        self.versus_test(axelrod.Defector(), expected_actions=actions)

--- a/docs/reference/overview_of_strategies.rst
+++ b/docs/reference/overview_of_strategies.rst
@@ -146,7 +146,7 @@ repository.
    "K73R_", "George Zimmerman", "Not Implemented"
    "K74R_", "Edward Friedland", "Not Implemented"
    "K74RXX_", "Edward Friedland", "Not Implemented"
-   "K75R_", "Paul D Harrington", "Not Implemented"
+   "K75R_", "Paul D Harrington", ":class:`Harrington <axelrod.strategies.axelrod_second.Harrington>`"
    "K76R_", "David Gladstein", ":class:`Gladstein <axelrod.strategies.axelrod_second.Gladstein>`"
    "K77R_", "Scott Feld", "Not Implemented"
    "K78R_", "Fred Mauk", "Not Implemented"

--- a/docs/tutorials/advanced/classification_of_strategies.rst
+++ b/docs/tutorials/advanced/classification_of_strategies.rst
@@ -47,7 +47,7 @@ strategies::
     ... }
     >>> strategies = axl.filtered_strategies(filterset)
     >>> len(strategies)
-    78
+    79
 
 Or, to find out how many strategies only use 1 turn worth of memory to
 make a decision::


### PR DESCRIPTION
Below are the fingerprints for the basic strategies, the random, and against the six custom strategies that I used in the test file.

I've also attached a PDF that bridges the gap from the Fortran to what I have, along with some small amount of commentary on the code.

[HarringtonNotes.pdf](https://github.com/Axelrod-Python/Axelrod/files/1527303/HarringtonNotes.pdf)

![additional_fortran](https://user-images.githubusercontent.com/5215426/33556068-b825422a-d8d0-11e7-87d6-a081172781ad.png)
![additional_python](https://user-images.githubusercontent.com/5215426/33556069-b8612344-d8d0-11e7-8273-79b9ea66a123.png)
![basic_fortran](https://user-images.githubusercontent.com/5215426/33556070-b881acd6-d8d0-11e7-894d-a95306e43080.png)
![basic_python](https://user-images.githubusercontent.com/5215426/33556071-b899c0aa-d8d0-11e7-8a1c-74d425f250bd.png)
![prob_fortran](https://user-images.githubusercontent.com/5215426/33556072-b8b7fc6e-d8d0-11e7-9873-538d249c3560.png)
![prob_python](https://user-images.githubusercontent.com/5215426/33556074-b8d1ae8e-d8d0-11e7-98f6-708512e8eec9.png)
