### PR TITLE
Implemented MoreTidemanAndChieruzzi, K84R from Axelrod's second

### DIFF
--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -9,7 +9,8 @@ from .axelrod_first import (
     UnnamedStrategy, SteinAndRapoport, TidemanAndChieruzzi)
 from .axelrod_second import (
     Champion, Eatherley, Tester, Gladstein, Tranquilizer, MoreGrofman,
-    Kluepfel, Borufsen, Cave, WmAdams, GraaskampKatzen, Weiner, Harrington)
+    Kluepfel, Borufsen, Cave, WmAdams, GraaskampKatzen, Weiner, Harrington,
+    MoreTidemanAndChieruzzi)
 from .backstabber import BackStabber, DoubleCrosser
 from .better_and_better import BetterAndBetter
 from .bush_mosteller import BushMosteller
@@ -208,6 +209,7 @@ all_strategies = [
     MindWarper,
     MirrorMindReader,
     MoreGrofman,
+    MoreTidemanAndChieruzzi,
     Negation,
     NiceAverageCopier,
     NTitsForMTats,

--- a/axelrod/strategies/axelrod_second.py
+++ b/axelrod/strategies/axelrod_second.py
@@ -1312,7 +1312,7 @@ class MoreTidemanAndChieruzzi(Player):
     Strategy submitted to Axelrod's second tournament by T. Nicolaus Tideman
     and Paula Chieruzzi (K84R) and came in ninth in that tournament.
 
-    This strategy Cooperates if this player's socre exceeds the opponent's
+    This strategy Cooperates if this player's score exceeds the opponent's
     score by at least `score_to_beat`.  `score_to_beat` starts at zero and
     increases by `score_to_beat_inc` every time the opponent's last two moves
     are a Cooperation and Defection in that order.  `score_to_beat_inc` itself

--- a/axelrod/strategies/axelrod_second.py
+++ b/axelrod/strategies/axelrod_second.py
@@ -1305,3 +1305,114 @@ class Harrington(Player):
             self.prob += 0.05
             self.more_coop, self.last_generous_n_turns_ago = 2, 1
             return self.try_return(D, lower_flags=False)
+
+
+class MoreTidemanAndChieruzzi(Player):
+    """
+    Strategy submitted to Axelrod's second tournament by T. Nicolaus Tideman
+    and Paula Chieruzzi (K84R) and came in ninth in that tournament.
+
+    This strategy Cooperates if this player's socre exceeds the opponent's
+    score by at least `score_to_beat`.  `score_to_beat` starts at zero and
+    increases by `score_to_beat_inc` every time the opponent's last two moves
+    are a Cooperation and Defection in that order.  `score_to_beat_inc` itself
+    increase by 5 every time the opponent's last two moves are a Cooperation
+    and Defection in that order.
+
+    Additionally, the strategy executes a "fresh start" if the following hold:
+
+    - The strategy would Defect by score (difference less than `score_to_beat`)
+    - The opponent did not Cooperate and Defect (in order) in the last two
+      turns.
+    - It's been at least 10 turns since the last fresh start.  Or since the
+      match started if there hasn't been a fresh start yet.
+
+    A "fresh start" entails two Cooperations and resetting scores,
+    `scores_to_beat` and `scores_to_beat_inc`.
+
+    Names:
+
+    - MoreTidemanAndChieruzzi: [Axelrod1980b]_
+    """
+
+    name = 'More Tideman and Chieruzzi'
+    classifier = {
+        'memory_depth': float('inf'),
+        'stochastic': False,
+        'makes_use_of': {"game"},
+        'long_run_time': False,
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.current_score = 0
+        self.opponent_score = 0
+        self.last_fresh_start = 0
+        self.fresh_start = False
+        self.score_to_beat = 0
+        self.score_to_beat_inc = 0
+
+    def _fresh_start(self):
+        """Give the opponent a fresh start by forgetting the past"""
+        self.current_score = 0
+        self.opponent_score = 0
+        self.score_to_beat = 0
+        self.score_to_beat_inc = 0
+
+    def _score_last_round(self, opponent: Player):
+        """Updates the scores for each player."""
+        # Load the default game if not supplied by a tournament.
+        game = self.match_attributes["game"]
+        last_round = (self.history[-1], opponent.history[-1])
+        scores = game.score(last_round)
+        self.current_score += scores[0]
+        self.opponent_score += scores[1]
+
+    def strategy(self, opponent: Player) -> Action:
+        current_round = len(self.history) + 1
+
+        if current_round == 1:
+            return C
+
+        # Calculate the scores.
+        self._score_last_round(opponent)
+
+        # Check if we have recently given the strategy a fresh start.
+        if self.fresh_start:
+            self._fresh_start()
+            self.last_fresh_start = current_round
+            self.fresh_start = False
+            return C  # Second cooperation
+
+        opponent_CDd = False
+
+        opponent_two_turns_ago = C # Default value for second turn.
+        if len(opponent.history) >= 2:
+            opponent_two_turns_ago = opponent.history[-2]
+        # If opponent's last two turns are C and D in that order.
+        if opponent_two_turns_ago == C and opponent.history[-1] == D:
+            opponent_CDd = True
+            self.score_to_beat += self.score_to_beat_inc
+            self.score_to_beat_inc += 5
+
+        # Cooperate if we're beating opponent by at least `score_to_beat`
+        if self.current_score - self.opponent_score >= self.score_to_beat:
+            return C
+
+        # Wait at least ten turns for another fresh start.
+        if (not opponent_CDd) and current_round - self.last_fresh_start >= 10:
+            # 50-50 split is based off the binomial distribution.
+            N = opponent.cooperations + opponent.defections
+            # std_dev = sqrt(N*p*(1-p)) where p is 1 / 2.
+            std_deviation = (N ** (1 / 2)) / 2
+            lower = N / 2 - 3 * std_deviation
+            upper = N / 2 + 3 * std_deviation
+            if opponent.defections <= lower or opponent.defections >= upper:
+                # Opponent deserves a fresh start
+                self.fresh_start = True
+                return C  # First cooperation
+
+        return D

--- a/axelrod/tests/strategies/test_axelrod_second.py
+++ b/axelrod/tests/strategies/test_axelrod_second.py
@@ -742,10 +742,10 @@ class TestHarrington(TestPlayer):
         actions = [(C, D), (D, C)] + [(C, C)] * 34 + [(D, C)]
         # Two cooperations scheduled after the 37-turn defection
         actions += [(C, C)] * 2
-        # TFT twice, then low-random # yields a DCC combo.
+        # TFT twice, then random number yields a DCC combo.
         actions += [(C, C)] * 2
         actions += [(D, C), (C, C), (C, C)]
-        # Don't draw next random # until now.  Again DCC.
+        # Don't draw next random number until now.  Again DCC.
         actions += [(D, C), (C, C), (C, C)]
         self.versus_test(Defect1, expected_actions=actions, seed=2)
 
@@ -803,7 +803,7 @@ class TestHarrington(TestPlayer):
         actions += [(D, C), (C, D), (D, C), (C, D), (C, C)]
         # This is the seventh time we've hit the limit.  So do it once more.
         actions += [(C, D), (D, C), (C, D), (D, C), (C, D), (C, C)]
-        # Now hit thi limit sooner
+        # Now hit the limit sooner
         actions += [(C, D), (D, C), (C, D), (C, C)] * 5
         self.versus_test(AsyncAlternator, expected_actions=actions, attrs={"parity_limit": 3})
 
@@ -835,7 +835,7 @@ class TestHarrington(TestPlayer):
         # The history matrix will be [[0, 2], [5, 6], [3, 6], [4, 2]]
         actions = match.play()
         self.assertEqual(actions, expected_actions)  # Just to be consistant with the current test.
-        self.assertEqual(round(player.calculate_chi_squared(len(expected_actions)),3), 2.395)
+        self.assertEqual(player.calculate_chi_squared(len(expected_actions)), 2.395, places=3)
 
         # Come back out of defect mode
         opponent_actions = [D, C, D, C, D, D, D, C, D, C, C, D, D, C, D, D, C,
@@ -852,5 +852,5 @@ class TestHarrington(TestPlayer):
         actions += [(D, D)] * 14
         # Mutual defect for a while, then exit Defect mode with two coops
         actions += [(C, D)] * 2
-        self.versus_test(Rand_Then_Def, expected_actions=actions, seed=10, \
+        self.versus_test(Rand_Then_Def, expected_actions=actions, seed=10,
                         attrs={"mode": "Normal", "was_defective": True})

--- a/docs/reference/overview_of_strategies.rst
+++ b/docs/reference/overview_of_strategies.rst
@@ -153,7 +153,7 @@ repository.
    "K81R_", "Martyn Jones", "Not Implemented"
    "K82R_", "Robert A Leyland", "Not Implemented"
    "K83R_", "Paul E Black", "Not Implemented"
-   "K84R_", "T Nicolaus Tideman and Paula Chieruzz", "Not Implemented"
+   "K84R_", "T Nicolaus Tideman and Paula Chieruzzi", ":class:`More Tideman And Chieruzzi <axelrod.strategies.axelrod_second.MoreTidemanAndChieruzzi>`"
    "K85R_", "Robert B Falk and James M Langsted", "Not Implemented"
    "K86R_", "Bernard Grofman", "Not Implemented"
    "K87R_", "E E H Schurmann",  "Not Implemented"

--- a/docs/reference/overview_of_strategies.rst
+++ b/docs/reference/overview_of_strategies.rst
@@ -36,8 +36,6 @@ An indication is given as to whether or not this strategy is implemented in the
 Tideman and Chieruzzi
 ^^^^^^^^^^^^^^^^^^^^^
 
-**Not implemented yet**
-
 This strategy begins by playing Tit For Tat and then things get slightly
 complicated:
 


### PR DESCRIPTION
FPs below.

This was similar in some ways to TidemanAndChieruzzi from the first tournament, so I tried to make my function implementation similar to the that one.

The biggest change in my refactoring was to change the way JDR was used, by calculating this as a triangle number:  https://github.com/Axelrod-Python/TourExec/blob/v0.3.0/src/strategies/k84r.f#L18

![basic_fortran](https://user-images.githubusercontent.com/5215426/33810716-58163d5c-ddd6-11e7-9027-909887dfd748.png)
![basic_python](https://user-images.githubusercontent.com/5215426/33810717-5831741e-ddd6-11e7-81e0-ea38cb643014.png)
![random_python](https://user-images.githubusercontent.com/5215426/33810718-584c13f0-ddd6-11e7-8da3-4c2dc898cff3.png)
![random_fortran](https://user-images.githubusercontent.com/5215426/33810719-58661318-ddd6-11e7-8d0a-d6f82258a3d1.png)