### PR TITLE
Implemented White strategy, k72r from Axelrod's Second

### DIFF
--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -10,7 +10,7 @@ from .axelrod_first import (
 from .axelrod_second import (
     Champion, Eatherley, Tester, Gladstein, Tranquilizer, MoreGrofman,
     Kluepfel, Borufsen, Cave, WmAdams, GraaskampKatzen, Weiner, Harrington,
-    MoreTidemanAndChieruzzi, Getzler, Leyvraz)
+    MoreTidemanAndChieruzzi, Getzler, Leyvraz, White)
 from .backstabber import BackStabber, DoubleCrosser
 from .better_and_better import BetterAndBetter
 from .bush_mosteller import BushMosteller
@@ -276,6 +276,7 @@ all_strategies = [
     TwoTitsForTat,
     VeryBad,
     Weiner,
+    White,
     Willing,
     Winner12,
     Winner21,

--- a/axelrod/strategies/axelrod_second.py
+++ b/axelrod/strategies/axelrod_second.py
@@ -1512,15 +1512,13 @@ class Leyvraz(Player):
 
 class White(Player):
     """
-    Strategy submitted to Axelrod's second tournament by Edward C Whtie (K72R)
+    Strategy submitted to Axelrod's second tournament by Edward C White (K72R)
     and came in thirteenth in that tournament.
 
-    If the opponent Cooperated last turn or in the first ten turns, then
-    Cooperate.
-
-    Otherwise Defect if and only if:
-
-    floor(log(turn)) * opponent Defections >= turn
+    * If the opponent Cooperated last turn or in the first ten turns, then
+      Cooperate.
+    * Otherwise Defect if and only if:
+        floor(log(turn)) * opponent Defections >= turn
 
     Names:
 

--- a/axelrod/strategies/axelrod_second.py
+++ b/axelrod/strategies/axelrod_second.py
@@ -1137,7 +1137,7 @@ class Harrington(Player):
         In this function, the statistic is non-standard in that it excludes
         summands where E_i <= 1.
         """
-        
+
         denom = turn - 2
 
         expected_matrix = np.outer(self.move_history.sum(axis=1),
@@ -1165,7 +1165,7 @@ class Harrington(Player):
         self.history, and returns True (is random) if and only if the statistic
         is less than or equal to 3.
         """
-        
+
         denom = turn - 2
 
         if self.move_history[0, 0] / denom >= 0.8:
@@ -1300,7 +1300,7 @@ class Harrington(Player):
         if self.burned or random.random() > self.prob:
             # Tit-for-Tat with probability 1-`prob`
             return self.try_return(opponent.history[-1], inc_parity=True)
-        
+
         # Otherwise Defect, Cooperate, Cooperate, and increase `prob`
         self.prob += 0.05
         self.more_coop, self.last_generous_n_turns_ago = 2, 1
@@ -1506,3 +1506,42 @@ class Leyvraz(Player):
                 recent_history[-go_back] = opponent.history[-go_back]
 
         return random_choice(self.prob_coop[tuple(recent_history)])
+
+
+class White(Player):
+    """
+    Strategy submitted to Axelrod's second tournament by Edward C Whtie (K72R)
+    and came in twelfth in that tournament.
+
+    If the opponent Cooperated last turn or in the first ten turns, then
+    Cooperate.
+
+    Otherwise Defect if and only if:
+
+    floor(log(turn)) * opponent Defections >= turn
+
+    Names:
+
+    - White: [Axelrod1980b]_
+    """
+
+    name = 'White'
+    classifier = {
+        'memory_depth': float("inf"),
+        'stochastic': False,
+        'makes_use_of': set(),
+        'long_run_time': False,
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+
+    def strategy(self, opponent: Player) -> Action:
+        turn = len(self.history) + 1
+
+        if turn <= 10 or opponent.history[-1] == C:
+            return C
+
+        if np.floor(np.log(turn)) * opponent.defections >= turn:
+            return D
+        return C

--- a/axelrod/strategies/axelrod_second.py
+++ b/axelrod/strategies/axelrod_second.py
@@ -1421,7 +1421,7 @@ class MoreTidemanAndChieruzzi(Player):
 class Getzler(Player):
     """
     Strategy submitted to Axelrod's second tournament by Abraham Getzler (K35R)
-    and came in tenth in that tournament.
+    and came in eleventh in that tournament.
 
     Strategy Defects with probability `flack`, where `flack` is calculated as
     the sum over opponent Defections of 0.5 ^ (turns ago Defection happened).
@@ -1459,7 +1459,7 @@ class Getzler(Player):
 class Leyvraz(Player):
     """
     Strategy submitted to Axelrod's second tournament by Fransois Leyvraz
-    (K68R) and came in eleventh in that tournament.
+    (K68R) and came in twelfth in that tournament.
 
     The strategy uses the opponent's last three moves to decide on an action
     based on the following ordered rules.
@@ -1513,7 +1513,7 @@ class Leyvraz(Player):
 class White(Player):
     """
     Strategy submitted to Axelrod's second tournament by Edward C Whtie (K72R)
-    and came in twelfth in that tournament.
+    and came in thirteenth in that tournament.
 
     If the opponent Cooperated last turn or in the first ten turns, then
     Cooperate.

--- a/axelrod/tests/strategies/test_axelrod_second.py
+++ b/axelrod/tests/strategies/test_axelrod_second.py
@@ -960,3 +960,34 @@ class TestLeyvraz(TestPlayer):
         self.versus_test(axelrod.Alternator(), expected_actions=actions, seed=2)
         actions = [(C, C), (C, D), (C, C)] + [(D, D), (C, C)] * 3
         self.versus_test(axelrod.Alternator(), expected_actions=actions, seed=3)
+
+
+class TestWhite(TestPlayer):
+    name = 'White'
+    player = axelrod.White
+    expected_classifier = {
+        'memory_depth': float("inf"),
+        'stochastic': False,
+        'makes_use_of': set(),
+        'long_run_time': False,
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+
+    def test_strategy(self):
+        actions = [(C, C)] * 30
+        self.versus_test(axelrod.Cooperator(), expected_actions=actions)
+
+        actions = [(C, D)] * 10 + [(D, D)] * 20
+        self.versus_test(axelrod.Defector(), expected_actions=actions)
+
+        actions = [(C, D), (C, D), (C, C), (C, C), (C, C), (C, D), (C, C),
+                   (C, D), (C, C), (C, D), (C, C), (C, D), (C, D), (D, C),
+                   (C, D), (D, D), (D, C), (C, D), (D, D), (D, C)]
+        self.versus_test(axelrod.Random(0.5), expected_actions=actions, seed=6)
+        actions = [(C, C), (C, D), (C, D), (C, C), (C, C), (C, C), (C, C),
+                   (C, D), (C, D), (C, D), (C, D), (D, D), (D, C), (C, C),
+                   (C, C), (C, D), (C, C), (C, D), (C, C), (C, D)]
+        self.versus_test(axelrod.Random(0.5), expected_actions=actions, seed=12)
+

--- a/docs/reference/overview_of_strategies.rst
+++ b/docs/reference/overview_of_strategies.rst
@@ -140,7 +140,7 @@ repository.
    "K69R_", "Johann Joss", "Not Implemented"
    "K70R_", "Robert Pebly", "Not Implemented"
    "K71R_", "James E Hall", "Not Implemented"
-   "K72R_", "Edward C White Jr", "Not Implemented"
+   "K72R_", "Edward C White Jr", ":class:`White <axelrod.strategies.axelrod_second.White>`"
    "K73R_", "George Zimmerman", "Not Implemented"
    "K74R_", "Edward Friedland", "Not Implemented"
    "K74RXX_", "Edward Friedland", "Not Implemented"


### PR DESCRIPTION
Fingerprints below.

Notes on refactor from https://github.com/Axelrod-Python/TourExec/blob/v0.3.0/src/strategies/k72r.f :
N, M, and JCOUNT are all integers, so everything gets rounded.  So the probability statement (line 12) actually only ever gets run with 0% or 100% (evidenced by the basic-strategy fingerprints).  And actually unless the if-statement in line 11 gets run, then the probability statement always Cooperates, since JCOUNT can be at most M-1.

![random_fortran](https://user-images.githubusercontent.com/5215426/34102740-332ccf6e-e3b8-11e7-8043-375e64347f8c.png)
![basic_python](https://user-images.githubusercontent.com/5215426/34102741-334a7a82-e3b8-11e7-8f1c-5458ce503fd5.png)
![basic_fortran](https://user-images.githubusercontent.com/5215426/34102744-3364ca68-e3b8-11e7-8275-4e183fac6611.png)
![random_python](https://user-images.githubusercontent.com/5215426/34102746-338290a2-e3b8-11e7-84b9-32ecf9a9c717.png)
