### PR TITLE
Add test for memory depth

### DIFF
--- a/axelrod/strategies/axelrod_first.py
+++ b/axelrod/strategies/axelrod_first.py
@@ -529,7 +529,7 @@ class SteinAndRapoport(Player):
 
     name = 'Stein and Rapoport'
     classifier = {
-        'memory_depth': 15,
+        'memory_depth': float("inf"),
         'stochastic': False,
         'makes_use_of': {"length"},
         'long_run_time': False,

--- a/axelrod/strategies/geller.py
+++ b/axelrod/strategies/geller.py
@@ -40,7 +40,7 @@ class Geller(Player):
 
     name = 'Geller'
     classifier = {
-        'memory_depth': -1,
+        'memory_depth': float("inf"),
         'stochastic': True,
         'makes_use_of': set(),
         'long_run_time': False,
@@ -74,7 +74,7 @@ class GellerCooperator(Geller):
     """
     name = 'Geller Cooperator'
     classifier = {
-        'memory_depth': -1,
+        'memory_depth': float("inf"),
         'stochastic': False,
         'makes_use_of': set(),
         'long_run_time': False,
@@ -101,7 +101,7 @@ class GellerDefector(Geller):
     """
     name = 'Geller Defector'
     classifier = {
-        'memory_depth': -1,
+        'memory_depth': float("inf"),
         'stochastic': False,
         'makes_use_of': set(),
         'long_run_time': False,

--- a/axelrod/strategies/mindreader.py
+++ b/axelrod/strategies/mindreader.py
@@ -22,7 +22,7 @@ class MindReader(Player):
 
     name = 'Mind Reader'
     classifier = {
-        'memory_depth': -10,
+        'memory_depth': float("inf"),
         'stochastic': False,
         'makes_use_of': set(),
         'long_run_time': False,
@@ -60,7 +60,7 @@ class ProtectedMindReader(MindReader):
 
     name = 'Protected Mind Reader'
     classifier = {
-        'memory_depth': -10,
+        'memory_depth': float("inf"),
         'stochastic': False,
         'makes_use_of': set(),
         'long_run_time': False,
@@ -90,7 +90,7 @@ class MirrorMindReader(ProtectedMindReader):
     name = 'Mirror Mind Reader'
 
     classifier = {
-        'memory_depth': -10,
+        'memory_depth': float("inf"),
         'stochastic': False,
         'makes_use_of': set(),
         'long_run_time': False,

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -826,6 +826,7 @@ class RandomTitForTat(Player):
         """
         super().__init__()
         self.p = p
+        self.act_random = False
         if p in [0, 1]:
             self.classifier['stochastic'] = False
 
@@ -834,6 +835,10 @@ class RandomTitForTat(Player):
         """This is the actual strategy"""
         if not self.history:
             return C
-        if len(opponent.history) % 2 == 0:
+
+        if self.act_random:
+            self.act_random = False
             return random_choice(self.p)
+
+        self.act_random = True
         return opponent.history[-1]

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -114,7 +114,7 @@ class DynamicTwoTitsForTat(Player):
 
     name = 'Dynamic Two Tits For Tat'
     classifier = {
-        'memory_depth': 2,  # Long memory, memory-2
+        'memory_depth': float("inf"),
         'stochastic': True,
         'makes_use_of': set(),
         'long_run_time': False,
@@ -127,7 +127,7 @@ class DynamicTwoTitsForTat(Player):
     def strategy(opponent):
         # First move
         if not opponent.history:
-            # Make sure we cooporate first turn
+            # Make sure we cooperate first turn
             return C
         if D in opponent.history[-2:]:
             # Probability of cooperating regardless

--- a/axelrod/tests/strategies/test_axelrod_first.py
+++ b/axelrod/tests/strategies/test_axelrod_first.py
@@ -370,7 +370,7 @@ class TestSteinAndRapoport(TestPlayer):
     name = "Stein and Rapoport: 0.05: (D, D)"
     player = axelrod.SteinAndRapoport
     expected_classifier = {
-        'memory_depth': 15,
+        'memory_depth': float("inf"),
         'long_run_time': False,
         'stochastic': False,
         'makes_use_of': {'length'},
@@ -524,11 +524,11 @@ class TestTidemanAndChieruzzi(TestPlayer):
                          attrs={'fresh_start': False})
 
         # check the fresh start condition: least 20 rounds since the last ‘fresh start’
-        opponent = axelrod.Cycler('CCCCD') 
-        actions = [(C, C), (C, C), (C, C), (C, C), (C, D), (D, C), (C, C), 
-                   (C, C), (C, C), (C, D), (D, C), (D, C), (C, C), (C, C), 
-                   (C, D), (D, C), (D, C), (D, C), (C, C), (C, D), (D, C), 
-                   (D, C), (D, C), (C, C), (C, D), (D, C), (C, C), (C, C), 
+        opponent = axelrod.Cycler('CCCCD')
+        actions = [(C, C), (C, C), (C, C), (C, C), (C, D), (D, C), (C, C),
+                   (C, C), (C, C), (C, D), (D, C), (D, C), (C, C), (C, C),
+                   (C, D), (D, C), (D, C), (D, C), (C, C), (C, D), (D, C),
+                   (D, C), (D, C), (C, C), (C, D), (D, C), (C, C), (C, C),
                    (C, C), (C, D), (D, C), (D, C), (C, C), (C, C), (C, D)]
         self.versus_test(opponent, expected_actions=actions,
                          match_attributes={'length': 35},

--- a/axelrod/tests/strategies/test_geller.py
+++ b/axelrod/tests/strategies/test_geller.py
@@ -11,7 +11,7 @@ class TestGeller(TestPlayer):
     name = "Geller"
     player = axelrod.Geller
     expected_classifier = {
-        'memory_depth': -1,
+        'memory_depth': float("inf"),
         'stochastic': True,
         'makes_use_of': set(),
         'long_run_time': False,
@@ -59,7 +59,7 @@ class TestGellerCooperator(TestGeller):
     name = "Geller Cooperator"
     player = axelrod.GellerCooperator
     expected_classifier = {
-        'memory_depth': -1,
+        'memory_depth': float("inf"),
         'stochastic': False,
         'makes_use_of': set(),
         'long_run_time': False,
@@ -85,7 +85,7 @@ class TestGellerDefector(TestGeller):
     name = "Geller Defector"
     player = axelrod.GellerDefector
     expected_classifier = {
-        'memory_depth': -1,
+        'memory_depth': float("inf"),
         'stochastic': False,
         'makes_use_of': set(),
         'long_run_time': False,

--- a/axelrod/tests/strategies/test_meta.py
+++ b/axelrod/tests/strategies/test_meta.py
@@ -563,7 +563,7 @@ class TestNMWELongMemory(TestMetaPlayer):
     }
 
     def test_strategy(self):
-        actions = [(C, C), (C, D), (D, C), (C, D), (D, C)]
+        actions = [(C, C), (C, D), (D, C), (D, D), (D, C)]
         self.versus_test(opponent=axelrod.Alternator(),
                          expected_actions=actions)
 

--- a/axelrod/tests/strategies/test_mindreader.py
+++ b/axelrod/tests/strategies/test_mindreader.py
@@ -13,7 +13,7 @@ class TestMindReader(TestPlayer):
     name = "Mind Reader"
     player = axelrod.MindReader
     expected_classifier = {
-        'memory_depth': -10,
+        'memory_depth': float("inf"),
         'stochastic': False,
         'makes_use_of': set(),
         'long_run_time': False,
@@ -104,7 +104,7 @@ class TestProtectedMindReader(TestPlayer):
     name = "Protected Mind Reader"
     player = axelrod.ProtectedMindReader
     expected_classifier = {
-        'memory_depth': -10,
+        'memory_depth': float("inf"),
         'stochastic': False,
         'makes_use_of': set(),
         'long_run_time': False,
@@ -148,7 +148,7 @@ class TestMirrorMindReader(TestPlayer):
     name = 'Mirror Mind Reader'
     player = axelrod.MirrorMindReader
     expected_classifier = {
-        'memory_depth': -10,
+        'memory_depth': float("inf"),
         'stochastic': False,
         'makes_use_of': set(),
         'long_run_time': False,

--- a/axelrod/tests/strategies/test_player.py
+++ b/axelrod/tests/strategies/test_player.py
@@ -600,7 +600,7 @@ def test_memory(player, opponent, memory_length, seed=0, turns=10):
     """
     axelrod.seed(seed)
     match = axelrod.Match((player, opponent), turns=turns)
-    expected_results = match.play()
+    expected_results = [turn[0] for turn in match.play()]
 
     axelrod.seed(seed)
     player.reset()
@@ -612,7 +612,7 @@ def test_memory(player, opponent, memory_length, seed=0, turns=10):
         opponent.history = opponent.history[-memory_length:]
         player.play(opponent)
         results.append(player.history[-1])
-    return results == [interactions[0] for interactions in expected_results]
+    return results == expected_results
 
 class TestMemoryTest(unittest.TestCase):
     """

--- a/axelrod/tests/strategies/test_player.py
+++ b/axelrod/tests/strategies/test_player.py
@@ -593,19 +593,16 @@ def test_four_vector(test_class, expected_dictionary):
             player1._four_vector[key], expected_dictionary[key])
 
 
-def test_memory(player, opponent, memory_length, seed=None, turns=10):
+def test_memory(player, opponent, memory_length, seed=0, turns=10):
     """
     Checks if a player reacts to the plays of an opponent in the same way if
     only the given amount of memory is used.
     """
-    if seed is not None:
-        axelrod.seed(seed)
-
+    axelrod.seed(seed)
     match = axelrod.Match((player, opponent), turns=turns)
     expected_results = match.play()
 
-    if seed is not None:
-        axelrod.seed(seed)
+    axelrod.seed(seed)
     player.reset()
     opponent.reset()
 

--- a/axelrod/tests/strategies/test_titfortat.py
+++ b/axelrod/tests/strategies/test_titfortat.py
@@ -124,7 +124,7 @@ class TestDynamicTwoTitsForTat(TestPlayer):
     name = 'Dynamic Two Tits For Tat'
     player = axelrod.DynamicTwoTitsForTat
     expected_classifier = {
-        'memory_depth': 2,
+        'memory_depth': float("inf"),
         'stochastic': True,
         'makes_use_of': set(),
         'inspects_source': False,

--- a/docs/tutorials/advanced/classification_of_strategies.rst
+++ b/docs/tutorials/advanced/classification_of_strategies.rst
@@ -69,7 +69,7 @@ range of memory_depth values, we can use the 'min_memory_depth' and
     ... }
     >>> strategies = axl.filtered_strategies(filterset)
     >>> len(strategies)
-    57
+    56
 
 We can also identify strategies that make use of particular properties of the
 tournament. For example, here is the number of strategies that  make use of the


### PR DESCRIPTION
This writes a test that verifies that the memory depth given in `player.classifier` is an upper bound.

It's done using a hypothesis test that only checks a single set of 5 opponents each time so it's not overly expensive (still benefiting from hypothesis's failure database).

This is the commit that writes the test: e9da4f9

Note that it picked up a few mis classifications, that I've fixed here (I'm actually surprised it wasn't more):

- c612c1e: `DynamicTwoTitsForTat` (strategy makes use of the cooperation count, so it's infinite memory)
- f6479f7: `RandomTitForTat`: classified correctly, I've just tweaked the implementation.
- ef130c2: `SteinAndRapoport`: defects on last two rounds: so it's infinite memory.
- 483d96e: all the cheating strategies had different (weird/negative) memory depths, I've set them as infinite.

This closes #1156 
  