### PR TITLE
Add lower bound for python in setup.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ a peer reviewed paper introducing the library (22 authors).
 Installation
 ------------
 
-The library requires Python 3.4 or greater. It will not run on Python 2.
+The library requires Python 3.5 or greater.
 
 The simplest way to install is::
 
@@ -127,7 +127,7 @@ Publications
 * Vincent Knight, Owen Campbell, Marc Harper, Karol Langner et al. `An Open Framework for the Reproducible Study of the Iterated Prisoner’s Dilemma. <https://openresearchsoftware.metajnl.com/articles/10.5334/jors.125/>`_ Journal of Open Research Software 4, no. 1 (2016). (`ArXiv Preprint <https://arxiv.org/abs/1604.00896>`_)
 
 
-Contributors 
+Contributors
 ------------
 
 The library has had many awesome contributions from many `great

--- a/docs/tutorials/getting_started/installation.rst
+++ b/docs/tutorials/getting_started/installation.rst
@@ -3,7 +3,7 @@
 Installation
 ============
 
-The library requires Python 3.4 or greater. It will not run on Python 2.
+The library requires Python 3.5.
 
 The simplest way to install the package is to obtain it from the PyPi
 repository::

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,5 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3 :: Only',
         ],
-    python_requires='>=3.0',
+    python_requires='>=3.5',
 )


### PR DESCRIPTION
This ensures that if you pip install axelrod with an unsupported verion
of python that you get an error message:

```
(test-axelrod-on-3.4) ~: pip install ~/src/Axelrod
Processing ./src/Axelrod
Axelrod requires Python '>=3.5' but the running Python is 3.4.5
```