### PR TITLE
Implemented Yamachi, k64r from Axelrod's Second.

### DIFF
--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -10,7 +10,8 @@ from .axelrod_first import (
 from .axelrod_second import (
     Champion, Eatherley, Tester, Gladstein, Tranquilizer, MoreGrofman,
     Kluepfel, Borufsen, Cave, WmAdams, GraaskampKatzen, Weiner, Harrington,
-    MoreTidemanAndChieruzzi, Getzler, Leyvraz, White, Black, RichardHufford)
+    MoreTidemanAndChieruzzi, Getzler, Leyvraz, White, Black, RichardHufford,
+    Yamachi)
 from .backstabber import BackStabber, DoubleCrosser
 from .better_and_better import BetterAndBetter
 from .bush_mosteller import BushMosteller
@@ -288,6 +289,7 @@ all_strategies = [
     WorseAndWorse,
     WorseAndWorse2,
     WorseAndWorse3,
+    Yamachi,
     ZDExtortion,
     ZDExtort2,
     ZDExtort3,

--- a/axelrod/strategies/axelrod_second.py
+++ b/axelrod/strategies/axelrod_second.py
@@ -1709,3 +1709,96 @@ class RichardHufford(Player):
         elif proportion_agree >= 0.625 and last_four_num >= 2:
             return opponent.history[-1]
         return D
+
+
+class Yamachi(Player):
+    """
+    Strategy submitted to Axelrod's second tournament by Brian Yamachi (K64R)
+    and came in seventeenth in that tournament.
+
+    The strategy keeps track of play history through a variable called
+    `count_them_us_them`, which is a dict indexed by (X, Y, Z), where X is an
+    opponent's move and Y and Z are the following moves by this player and the
+    opponent, respectively.  Each turn, we look at our opponent's move two
+    turns ago, call X, and our move last turn, call Y.  If (X, Y, C) has
+    occurred more often (or as often) as (X, Y, D), then Cooperate.  Otherwise
+    Defect.  [Note that this reflects likelihood of Cooperations or Defections
+    in opponent's previous move; we don't update `count_them_us_them` with
+    previous move until next turn.]
+
+    Starting with the 41st turn, there's a possibility to override this
+    behavior.  If `portion_defect` is between 45% and 55% (exclusive), then
+    Defect, where `portion_defect` equals number of opponent defects plus 0.5
+    divided by the turn number (indexed by 1).  When overriding this way, still
+    record `count_them_us_them` as though the strategy didn't override.
+
+    Names:
+
+    - Yamachi: [Axelrod1980b]_
+    """
+
+    name = 'Yamachi'
+    classifier = {
+        'memory_depth': float("inf"),
+        'stochastic': False,
+        'makes_use_of': set(),
+        'long_run_time': False,
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.count_them_us_them = {(C, C, C): 0,
+                                   (C, C, D): 0,
+                                   (C, D, C): 0,
+                                   (C, D, D): 0,
+                                   (D, C, C): 0,
+                                   (D, C, D): 0,
+                                   (D, D, C): 0,
+                                   (D, D, D): 0}
+        self.mod_history = list()
+
+    def try_return(self, to_return, opp_def):
+        """
+        Return `to_return`, unless the turn is greater than 40 AND
+        `portion_defect` is between 45% and 55%.
+
+        In this case, still record the history as `to_return` so that the
+        modified behavior doesn't affect the calculation of `count_us_them_us`.
+        """
+        turn = len(self.history) + 1
+
+        self.mod_history.append(to_return)
+
+        # In later turns, check if the opponent is close to 50/50
+        # If so, then override
+        if turn > 40:
+            portion_defect = (opp_def + 0.5) / turn
+            if 0.45 < portion_defect and portion_defect < 0.55:
+                return D
+
+        return to_return
+
+    def strategy(self, opponent: Player) -> Action:
+        turn = len(self.history) + 1
+        if turn == 1:
+            return self.try_return(C, 0)
+
+        us_last = self.mod_history[-1]
+        them_two_ago, us_two_ago, them_three_ago = C, C, C
+        if turn >= 3:
+            them_two_ago = opponent.history[-2]
+            us_two_ago = self.mod_history[-2]
+        if turn >= 4:
+            them_three_ago = opponent.history[-3]
+
+        # Update history
+        if turn >= 3:
+            self.count_them_us_them[(them_three_ago, us_two_ago, them_two_ago)] += 1
+
+        if self.count_them_us_them[(them_two_ago, us_last, C)] >= \
+           self.count_them_us_them[(them_two_ago, us_last, D)]:
+            return self.try_return(C, opponent.defections)
+        return self.try_return(D, opponent.defections)

--- a/axelrod/strategies/axelrod_second.py
+++ b/axelrod/strategies/axelrod_second.py
@@ -4,6 +4,7 @@ Additional strategies from Axelrod's second tournament.
 
 import random
 import numpy as np
+from typing import List
 
 from axelrod.action import Action
 from axelrod.player import Player
@@ -1758,7 +1759,7 @@ class Yamachi(Player):
                                    (D, C, D): 0,
                                    (D, D, C): 0,
                                    (D, D, D): 0}
-        self.mod_history = list()
+        self.mod_history = list() # type: List[Action]
 
     def try_return(self, to_return, opp_def):
         """

--- a/docs/reference/overview_of_strategies.rst
+++ b/docs/reference/overview_of_strategies.rst
@@ -132,7 +132,7 @@ repository.
    "K61R_", "Danny C Champion", ":class:`Champion <axelrod.strategies.axelrod_second.Champion>`"
    "K62R_", "Howard R Hollander", "Not Implemented"
    "K63R_", "George Duisman", "Not Implemented"
-   "K64R_", "Brian Yamachi", "Not Implemented"
+   "K64R_", "Brian Yamachi", ":class:`Yamachi <axelrod.strategies.axelrod_second.Yamachi>`"
    "K65R_", "Mark F Batell", "Not Implemented"
    "K66R_", "Ray Mikkelson", "Not Implemented"
    "K67R_", "Craig Feathers", ":class:`Tranquilizer <axelrod.strategies.axelrod_second.Tranquilizer>`"


### PR DESCRIPTION
Fingerprints below.

![basic_fortran](https://user-images.githubusercontent.com/5215426/35484037-d1f29190-0417-11e8-9811-a77ea3cff091.png)
![basic_python](https://user-images.githubusercontent.com/5215426/35484038-d20ca13e-0417-11e8-916d-b2cbf975c027.png)

The refactoring is somewhat straight-forward with the exception of https://github.com/Axelrod-Python/TourExec/blob/v0.3.0/src/strategies/k64r.f#L30.  Here, I refactored as
P = |E-F|, but E+F = M-1, so that P = |2E+1-M|.  Then 10*P < M iff P/(2M) < 0.05.  Equivalently, |(E+0.5)/M - 0.5| < 0.05.  I called (E+0.5)/M as `portion_defect` and bounded by 0.45 and 0.55.
Also a little different is I update history _before_ deciding on a move, so to emulate the Fortan (which does after), I wait until the third turn to start (instead of the second) and look back one extra turn.

I think count_them_us_them was intended to be indexed by them_three_ago, us_two_ago, them_last, so that it predicts the opponent's next turn.  It kind of predicts the opponents last move instead...  [If you look at lines 22 and 23 of the Fortan, it's moving A(X,Y) based on J, but J can't be in response to Y, our own last move.]
