### PR TITLE
Fixes initialisation bug for memory one

### DIFF
--- a/axelrod/strategies/memoryone.py
+++ b/axelrod/strategies/memoryone.py
@@ -87,8 +87,6 @@ class MemoryOnePlayer(Player):
         self.classifier['stochastic'] = any(0 < x < 1 for x in set(four_vector))
 
     def strategy(self, opponent: Player) -> Action:
-        if not hasattr(self, "_four_vector"):
-            raise ValueError("_four_vector not yet set")
         if len(opponent.history) == 0:
             return self._initial
         # Determine which probability to use

--- a/axelrod/strategies/zero_determinant.py
+++ b/axelrod/strategies/zero_determinant.py
@@ -44,6 +44,9 @@ class LRPlayer(MemoryOnePlayer):
         self.l = l
         super().__init__()
 
+    def set_initial_four_vector(self, four_vector):
+        pass
+
     def receive_match_attributes(self):
         """
         Parameters

--- a/axelrod/tests/strategies/test_memoryone.py
+++ b/axelrod/tests/strategies/test_memoryone.py
@@ -1,6 +1,7 @@
 """Tests for the Memoryone strategies."""
 
 import unittest
+import warnings
 
 import axelrod
 from axelrod import Game
@@ -226,6 +227,16 @@ class TestMemoryOnePlayer(unittest.TestCase):
         player = MemoryOnePlayer()
         self.assertEqual(player._four_vector, {(C, C): 1.0, (C, D): 0.0,
                                                (D, C): 0.0, (D, D): 1.0})
+
+    def test_exception_if_four_vector_not_set(self):
+        with warnings.catch_warnings(record=True) as warning:
+            warnings.simplefilter("always")
+            player = MemoryOnePlayer()
+
+            self.assertEqual(len(warning), 1)
+            self.assertEqual(warning[-1].category, UserWarning)
+            self.assertEqual(str(warning[-1].message),
+                              "Memory one player is set to default (1, 0, 0, 1).")
 
     def test_exception_if_probability_vector_outside_valid_values(self):
         player = MemoryOnePlayer()

--- a/axelrod/tests/strategies/test_memoryone.py
+++ b/axelrod/tests/strategies/test_memoryone.py
@@ -222,11 +222,10 @@ class TestStochasticWSLS(TestPlayer):
 
 class TestMemoryOnePlayer(unittest.TestCase):
 
-    def test_exception_if_four_vector_not_set(self):
+    def test_default_if_four_vector_not_set(self):
         player = MemoryOnePlayer()
-        opponent = axelrod.Player()
-        with self.assertRaises(ValueError):
-            player.strategy(opponent)
+        self.assertEqual(player._four_vector, {(C, C): 1.0, (C, D): 0.0,
+                                               (D, C): 0.0, (D, D): 1.0})
 
     def test_exception_if_probability_vector_outside_valid_values(self):
         player = MemoryOnePlayer()


### PR DESCRIPTION
This closes issue #1169.

The issue has been that if `four_vector` was not set the player would not
break. This is fixed by having a default `four_vector` which corresponds
to the strategy Win-Stay Lose-Shift. Note that when this happens a
warning message is raised to let the user know (using the library
warnings).

A test has been altered to test that the default values are passed correctly.
Test: `test_default_if_four_vector_not_set`.

An issue has been that the players that inherited from `MemoryOnePlayer`
were breaking. This was because several classes were initialising with
an empty vector and were setting the vector are retrieving information
on the game.

This was addressed using the function `get_initial_four_vector`, which
will only set a default and raise an error for the general case and
will ignore the fact that `four_vector` is empty for the classes which
have been breaking.