### PR TITLE
remove float from memory one

### DIFF
--- a/axelrod/strategies/memoryone.py
+++ b/axelrod/strategies/memoryone.py
@@ -82,8 +82,7 @@ class MemoryOnePlayer(Player):
             raise ValueError("An element in the probability vector, {}, is not "
                              "between 0 and 1.".format(str(four_vector)))
 
-        self._four_vector = dict(zip([(C, C), (C, D), (D, C), (D, D)],
-                                     map(float, four_vector)))
+        self._four_vector = dict(zip([(C, C), (C, D), (D, C), (D, D)], four_vector))
         self.classifier['stochastic'] = any(0 < x < 1 for x in set(four_vector))
 
     def strategy(self, opponent: Player) -> Action:


### PR DESCRIPTION
While working on the memory two strategies we observed that when creating the transition rates dict of the strategy there as a float argument. 

The argument seems to have been left there by previous versions, thus I am removing it.