### PR TITLE
Add Tricky Level Punisher

### DIFF
--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -65,7 +65,7 @@ from .negation import Negation
 from .oncebitten import OnceBitten, FoolMeOnce, ForgetfulFoolMeOnce, FoolMeForever
 from .prober import (CollectiveStrategy, Prober, Prober2, Prober3, Prober4,
                      HardProber, NaiveProber, RemorsefulProber)
-from .punisher import Punisher, InversePunisher, LevelPunisher
+from .punisher import Punisher, InversePunisher, LevelPunisher, TrickyLevelPunisher
 from .qlearner import (
     RiskyQLearner, ArrogantQLearner, HesitantQLearner, CautiousQLearner)
 from .rand import Random
@@ -279,6 +279,7 @@ all_strategies = [
     Tranquilizer,
     TrickyCooperator,
     TrickyDefector,
+    TrickyLevelPunisher
     Tullock,
     TwoTitsForTat,
     VeryBad,

--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -279,7 +279,7 @@ all_strategies = [
     Tranquilizer,
     TrickyCooperator,
     TrickyDefector,
-    TrickyLevelPunisher
+    TrickyLevelPunisher,
     Tullock,
     TwoTitsForTat,
     VeryBad,

--- a/axelrod/strategies/punisher.py
+++ b/axelrod/strategies/punisher.py
@@ -168,14 +168,14 @@ class TrickyLevelPunisher(Player):
     }
 
     def strategy(self, opponent: Player) -> Action:
+        if len(opponent.history) == 0:
+            return C
         if len(opponent.history) < 10:
             if opponent.defections / len(opponent.history) > 0.2:
                 return D
-            return C
         if len(opponent.history) < 50:
             if opponent.defections / len(opponent.history) > 0.1:
                 return D
-            return C
         if len(opponent.history) < 100:
             if opponent.defections / len(opponent.history) > 0.05:
                 return D

--- a/axelrod/strategies/punisher.py
+++ b/axelrod/strategies/punisher.py
@@ -178,7 +178,7 @@ class TrickyLevelPunisher(Player):
             return D
         elif len(opponent.history) < 100:
             return C
-        elif len((len(opponent.history) - opponent.cooperations) / len(opponent.history) > 0.05:
+        elif (len(opponent.history) - opponent.cooperations) / len(opponent.history) > 0.05:
             return D
         else:
             return C

--- a/axelrod/strategies/punisher.py
+++ b/axelrod/strategies/punisher.py
@@ -147,9 +147,9 @@ class LevelPunisher(Player):
 
 class TrickyLevelPunisher(Player):
     """
-    A player starts by cooperating however, after 10 rounds
+    A player starts by cooperating however, after 10, 50 and 100 rounds
     will defect if at any point the number of defections
-    by an opponent is greater than 20%.
+    by an opponent is greater than 20%, 10% and 5% respectively.
 
     Names:
 
@@ -170,15 +170,15 @@ class TrickyLevelPunisher(Player):
     def strategy(self, opponent: Player) -> Action:
         if len(opponent.history) < 10:
             return C
-        elif (len(opponent.history) - opponent.cooperations) / len(opponent.history) > 0.2:
+        if opponent.defections / (opponent.defections + opponent.cooperations) > 0.2:
             return D
-        elif len(opponent.history) < 50:
+        if len(opponent.history) < 50:
             return C
-        elif (len(opponent.history) - opponent.cooperations) / len(opponent.history) > 0.1:
+        if opponent.defections / (opponent.defections + opponent.cooperations) > 0.1:
             return D
-        elif len(opponent.history) < 100:
+        if len(opponent.history) < 100:
             return C
-        elif (len(opponent.history) - opponent.cooperations) / len(opponent.history) > 0.05:
+        if opponent.defections / (opponent.defections + opponent.cooperations) > 0.05:
             return D
         else:
             return C

--- a/axelrod/strategies/punisher.py
+++ b/axelrod/strategies/punisher.py
@@ -153,10 +153,10 @@ class TrickyLevelPunisher(Player):
 
     Names:
 
-    - Level Punisher: [Eckhart2015]_
+    - Tricky Level Punisher: [Eckhart2015]_
     """
 
-    name = 'Level Punisher'
+    name = 'Tricky Level Punisher'
     classifier = {
         'memory_depth': float('inf'), # Long Memory
         'stochastic': False,

--- a/axelrod/strategies/punisher.py
+++ b/axelrod/strategies/punisher.py
@@ -148,7 +148,7 @@ class LevelPunisher(Player):
 class TrickyLevelPunisher(Player):
     """
     A player starts by cooperating however, after 10, 50 and 100 rounds
-    will defect if at any point the number of defections
+    will defect if at any point the percentage of defections
     by an opponent is greater than 20%, 10% and 5% respectively.
 
     Names:
@@ -169,16 +169,14 @@ class TrickyLevelPunisher(Player):
 
     def strategy(self, opponent: Player) -> Action:
         if len(opponent.history) < 10:
+            if opponent.defections / len(opponent.history) > 0.2:
+                return D
             return C
-        if opponent.defections / (opponent.defections + opponent.cooperations) > 0.2:
-            return D
         if len(opponent.history) < 50:
+            if opponent.defections / len(opponent.history) > 0.1:
+                return D
             return C
-        if opponent.defections / (opponent.defections + opponent.cooperations) > 0.1:
-            return D
         if len(opponent.history) < 100:
-            return C
-        if opponent.defections / (opponent.defections + opponent.cooperations) > 0.05:
-            return D
-        else:
-            return C
+            if opponent.defections / len(opponent.history) > 0.05:
+                return D
+        return C

--- a/axelrod/strategies/punisher.py
+++ b/axelrod/strategies/punisher.py
@@ -143,3 +143,42 @@ class LevelPunisher(Player):
             return D
         else:
             return C
+
+
+class TrickyLevelPunisher(Player):
+    """
+    A player starts by cooperating however, after 10 rounds
+    will defect if at any point the number of defections
+    by an opponent is greater than 20%.
+
+    Names:
+
+    - Level Punisher: [Eckhart2015]_
+    """
+
+    name = 'Level Punisher'
+    classifier = {
+        'memory_depth': float('inf'), # Long Memory
+        'stochastic': False,
+        'makes_use_of': set(),
+        'long_run_time': False,
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+
+    def strategy(self, opponent: Player) -> Action:
+        if len(opponent.history) < 10:
+            return C
+        elif (len(opponent.history) - opponent.cooperations) / len(opponent.history) > 0.2:
+            return D
+        elif len(opponent.history) < 50:
+            return C
+        elif (len(opponent.history) - opponent.cooperations) / len(opponent.history) > 0.1:
+            return D
+        elif len(opponent.history) < 100:
+            return C
+        elif len((len(opponent.history) - opponent.cooperations) / len(opponent.history) > 0.05:
+            return D
+        else:
+            return C

--- a/axelrod/tests/strategies/test_meta.py
+++ b/axelrod/tests/strategies/test_meta.py
@@ -335,7 +335,7 @@ class TestMetaMajorityLongMemory(TestMetaPlayer):
         self.versus_test(opponent=axelrod.Alternator(),
                          expected_actions=actions, seed=0)
 
-        actions = [(C, C), (C, D), (C, C), (C, D), (D, C)]
+        actions = [(C, C), (C, D), (D, C), (C, D), (D, C)]
         self.versus_test(opponent=axelrod.Alternator(),
                          expected_actions=actions, seed=1)
 

--- a/axelrod/tests/strategies/test_punisher.py
+++ b/axelrod/tests/strategies/test_punisher.py
@@ -166,7 +166,7 @@ class TestTrickyLevelPunisher(TestPlayer):
         # After 10 rounds
         # Check if number of defections by opponent is greater than 5%
         opponent = axelrod.MockPlayer([C] * 4 + [D] + [C] * 5)
-        actions = [(C, C)] * 4 + [(C, D)] + [(C, C)] * 5]
+        actions = [(C, C)] * 4 + [(C, D)] + [(C, C)] * 5
         self.versus_test(opponent=opponent, expected_actions=actions)
 
         # Check if number of defections by opponent is less than 5%

--- a/axelrod/tests/strategies/test_punisher.py
+++ b/axelrod/tests/strategies/test_punisher.py
@@ -130,3 +130,46 @@ class TestLevelPunisher(TestPlayer):
         opponent = axelrod.MockPlayer([C] * 4 + [D] + [C] * 4 + [D])
         actions = [(C, C)] * 4 + [(C, D)] + [(C, C)] * 4 + [(C, D), (C, C)]
         self.versus_test(opponent=opponent, expected_actions=actions)
+
+
+class TestTrickyLevelPunisher(TestPlayer):
+
+    name = "Level Punisher"
+    player = axelrod.LevelPunisher
+    expected_classifier = {
+        'memory_depth': float('inf'),  # Long memory
+        'stochastic': False,
+        'makes_use_of': set(),
+        'long_run_time': False,
+        'inspects_source': False,
+        'manipulates_source': False,
+        'manipulates_state': False
+    }
+
+    def test_strategy(self):
+        # Cooperates if the turns played are less than 10.
+        actions = [(C, C)] * 9
+        self.versus_test(opponent=axelrod.Cooperator(),
+                         expected_actions=actions)
+
+        # After 10 rounds
+        # Check if number of defections by opponent is greater than 20%
+        opponent = axelrod.MockPlayer([C] * 4 + [D] * 2 + [C] * 3 + [D])
+        actions = [(C, C)] * 4 + [(C, D)] * 2 + [(C, C)] * 3 + [(C, D), (D, C)]
+        self.versus_test(opponent=opponent, expected_actions=actions)
+
+        # Check if number of defections by opponent is greater than 10%
+        opponent = axelrod.MockPlayer([C] * 4 + [D] + [C] * 4 + [D])
+        actions = [(C, C)] * 4 + [(C, D)] + [(C, C)] * 4 + [(C, D), (C, C)]
+        self.versus_test(opponent=opponent, expected_actions=actions)
+
+        # After 10 rounds
+        # Check if number of defections by opponent is greater than 5%
+        opponent = axelrod.MockPlayer([C] * 4 + [D] + [C] * 5)
+        actions = [(C, C)] * 4 + [(C, D)] + [(C, C)] * 5]
+        self.versus_test(opponent=opponent, expected_actions=actions)
+
+        # Check if number of defections by opponent is less than 5%
+        opponent = axelrod.MockPlayer([C]*10)
+        actions = [(C, C)] * 5
+        self.versus_test(opponent=opponent, expected_actions=actions)


### PR DESCRIPTION
I picked up #1132 which implements a strategy called Tricky Level Punisher. 

The `pr` was failing due a division by zero error. Moreover, I had to tweak the tests of `MetaMajorityLongMemory` because now `TrickyLevelPunisher` is in the strategy's team.

```
>> import axelrod as axl

>> player = axl.MetaMajorityLongMemory()
>> tricky = axl.TrickyLevelPunisher()
>> tricky in player.team
True
```

Note that this `pr` will fail due to #1176, I will rebase once #1177 is merged. 