### PR TITLE
Pin prompt toolkit because of backwards comp.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.9.2
 matplotlib>=1.4.2
 tqdm>=3.4.0
-prompt-toolkit==1.0.15
+prompt-toolkit>=1.0.7,<2.0.0
 scipy>=0.19.0
 hypothesis==3.2
 dask>=0.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.9.2
 matplotlib>=1.4.2
 tqdm>=3.4.0
-prompt-toolkit>=1.0.7
+prompt-toolkit==1.0.15
 scipy>=0.19.0
 hypothesis==3.2
 dask>=0.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-numpy>=1.9.2
+cloudpickle>=0.2.1
+dask>=0.11.0
+hypothesis==3.2
 matplotlib>=1.4.2
-tqdm>=3.4.0
+numpy>=1.9.2
+pandas>=0.18.1
 prompt-toolkit>=1.0.7,<2.0.0
 scipy>=0.19.0
-hypothesis==3.2
-dask>=0.11.0
-pandas>=0.18.1
 toolz>=0.8.0
-cloudpickle>=0.2.1
+tqdm>=3.4.0


### PR DESCRIPTION
This is related to #1183 . Currently a clean install of Axelrod will fail because of backwards incompatible change to `prompt_toolkit` version 2+. This pins `prompt_toolkit`.

(I suggest we merge this but leave #1182 open as a place holder, there's no rush with unpinning `prompt_toolkit` as ipython pins this too I believe: https://github.com/ipython/ipython/blob/master/setup.py#L193.)