### PR TITLE
Modify/fix initial play of lookerup players.

### DIFF
--- a/axelrod/strategies/lookerup.py
+++ b/axelrod/strategies/lookerup.py
@@ -334,8 +334,9 @@ class LookerUp(Player):
         return initial_actions[:table_depth]
 
     def strategy(self, opponent: Player) -> Reaction:
-        while self._initial_actions_pool:
-            return self._initial_actions_pool.pop(0)
+        turn_index =  len(opponent.history)
+        while turn_index < len(self._initial_actions_pool):
+            return self._initial_actions_pool[turn_index]
 
         player_last_n_plays = get_last_n_plays(player=self,
                                                depth=self._lookup.player_depth)

--- a/axelrod/tests/strategies/test_geller.py
+++ b/axelrod/tests/strategies/test_geller.py
@@ -44,6 +44,17 @@ class TestGeller(TestPlayer):
         self.versus_test(axelrod.Cooperator(), expected_actions=[(C, C)] * 5)
         self.versus_test(axelrod.Alternator(), expected_actions=[(C, C), (D, D)] * 5)
 
+
+    def test_strategy_against_lookerup_players(self):
+        """
+        Regression test for a bug discussed in
+        https://github.com/Axelrod-Python/Axelrod/issues/1185
+        """
+        self.versus_test(axelrod.EvolvedLookerUp1_1_1(),
+                         expected_actions=[(C, C), (C, C)])
+        self.versus_test(axelrod.EvolvedLookerUp2_2_2(),
+                         expected_actions=[(C, C), (C, C)])
+
     def test_returns_foil_inspection_strategy_of_opponent(self):
         seed = 2
         # each Geller type returns the other's foil_inspection_strategy


### PR DESCRIPTION
Closes #1185

Currently, the lookerup players pop from a list of initial plays. This
breaks when playing against the cheating players which simulate their
play (as the list of initial players no longer exists).

This fixes that by ensuring the list of initial plays does not
disappear which I think technically is probably better behaviour anyway?