### PR TITLE
Pass fitness function moran process

### DIFF
--- a/axelrod/moran.py
+++ b/axelrod/moran.py
@@ -24,6 +24,7 @@ def fitness_proportionate_selection(
     Parameters
     ----------
     scores: Any sequence of real numbers
+    fitness_function: A function mapping a score to a (non-negative) float
 
     Returns
     -------
@@ -105,6 +106,8 @@ class MoranProcess(object):
         reproduction_graph: Axelrod.graph.Graph
             The reproduction graph, set equal to the interaction graph if not
             given
+        fitness_function:
+            A function mapping a score to a (non-negative) float
         """
         self.turns = turns
         self.prob_end = prob_end

--- a/axelrod/moran.py
+++ b/axelrod/moran.py
@@ -2,8 +2,7 @@
 
 import random
 from collections import Counter
-from types import FunctionType
-from typing import List, Optional, Set, Tuple
+from typing import Callable, List, Optional, Set, Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -17,7 +16,7 @@ from .random_ import randrange
 
 
 def fitness_proportionate_selection(
-    scores: List, fitness_function: FunctionType = None
+    scores: List, fitness_function: Callable = None
 ) -> int:
     """Randomly selects an individual proportionally to score.
 
@@ -57,7 +56,7 @@ class MoranProcess(object):
         mode: str = "bd",
         interaction_graph: Graph = None,
         reproduction_graph: Graph = None,
-        fitness_function: FunctionType = None,
+        fitness_function: Callable = None,
     ) -> None:
         """
         An agent based Moran process class. In each round, each player plays a

--- a/axelrod/tests/unit/test_moran.py
+++ b/axelrod/tests/unit/test_moran.py
@@ -1,22 +1,20 @@
-from collections import Counter
 import itertools
 import random
 import unittest
-
-from hypothesis import given, example, settings
+from collections import Counter
 
 import matplotlib.pyplot as plt
 
 import axelrod
-from axelrod import MoranProcess, ApproximateMoranProcess, Pdf
+from axelrod import ApproximateMoranProcess, MoranProcess, Pdf
 from axelrod.moran import fitness_proportionate_selection
 from axelrod.tests.property import strategy_lists
+from hypothesis import example, given, settings
 
 C, D = axelrod.Action.C, axelrod.Action.D
 
 
 class TestMoranProcess(unittest.TestCase):
-
     def test_init(self):
         players = axelrod.Cooperator(), axelrod.Defector()
         mp = MoranProcess(players)
@@ -26,17 +24,21 @@ class TestMoranProcess(unittest.TestCase):
         self.assertEqual(mp.noise, 0)
         self.assertEqual(mp.initial_players, players)
         self.assertEqual(mp.players, list(players))
-        self.assertEqual(mp.populations,
-                         [Counter({'Cooperator': 1, 'Defector': 1})])
+        self.assertEqual(
+            mp.populations, [Counter({"Cooperator": 1, "Defector": 1})]
+        )
         self.assertIsNone(mp.winning_strategy_name)
         self.assertEqual(mp.mutation_rate, 0)
-        self.assertEqual(mp.mode, 'bd')
+        self.assertEqual(mp.mode, "bd")
         self.assertEqual(mp.deterministic_cache, axelrod.DeterministicCache())
-        self.assertEqual(mp.mutation_targets,
-                         {'Cooperator': [players[1]], 'Defector': [players[0]]})
+        self.assertEqual(
+            mp.mutation_targets,
+            {"Cooperator": [players[1]], "Defector": [players[0]]},
+        )
         self.assertEqual(mp.interaction_graph._edges, [(0, 1), (1, 0)])
-        self.assertEqual(mp.reproduction_graph._edges,
-                         [(0, 1), (1, 0), (0, 0), (1, 1)])
+        self.assertEqual(
+            mp.reproduction_graph._edges, [(0, 1), (1, 0), (0, 0), (1, 1)]
+        )
         self.assertEqual(mp.fitness_function, None)
         self.assertEqual(mp.locations, [0, 1])
         self.assertEqual(mp.index, {0: 0, 1: 1})
@@ -47,11 +49,14 @@ class TestMoranProcess(unittest.TestCase):
         graph = axelrod.graph.Graph(edges, directed=True)
         mp = MoranProcess(players, interaction_graph=graph)
         self.assertEqual(mp.interaction_graph._edges, [(0, 1), (2, 0), (1, 2)])
-        self.assertEqual(sorted(mp.reproduction_graph._edges),
-                         sorted([(0, 1), (2, 0), (1, 2), (0, 0), (1, 1), (2, 2)]))
+        self.assertEqual(
+            sorted(mp.reproduction_graph._edges),
+            sorted([(0, 1), (2, 0), (1, 2), (0, 0), (1, 1), (2, 2)]),
+        )
 
-        mp = MoranProcess(players, interaction_graph=graph,
-                          reproduction_graph=graph)
+        mp = MoranProcess(
+            players, interaction_graph=graph, reproduction_graph=graph
+        )
         self.assertEqual(mp.interaction_graph._edges, [(0, 1), (2, 0), (1, 2)])
         self.assertEqual(mp.reproduction_graph._edges, [(0, 1), (2, 0), (1, 2)])
 
@@ -183,7 +188,7 @@ class TestMoranProcess(unittest.TestCase):
         seeds = range(0, 20)
         for seed in seeds:
             axelrod.seed(seed)
-            mp = MoranProcess((p1, p2), mode='db')
+            mp = MoranProcess((p1, p2), mode="db")
             next(mp)
             self.assertIsNotNone(mp.winning_strategy_name)
 
@@ -198,11 +203,11 @@ class TestMoranProcess(unittest.TestCase):
             players.append(axelrod.Defector())
         for seed, outcome in seeds:
             axelrod.seed(seed)
-            mp = MoranProcess(players, mode='bd')
+            mp = MoranProcess(players, mode="bd")
             mp.play()
             winner = mp.winning_strategy_name
             axelrod.seed(seed)
-            mp = MoranProcess(players, mode='db')
+            mp = MoranProcess(players, mode="db")
             mp.play()
             winner2 = mp.winning_strategy_name
             self.assertEqual((winner == winner2), outcome)
@@ -221,18 +226,21 @@ class TestMoranProcess(unittest.TestCase):
         p1, p2 = axelrod.Cooperator(), axelrod.Defector()
         axelrod.seed(5)
         mp = MoranProcess((p1, p2), mutation_rate=0.2)
-        self.assertDictEqual(mp.mutation_targets,
-                             {str(p1): [p2], str(p2): [p1]})
+        self.assertDictEqual(
+            mp.mutation_targets, {str(p1): [p2], str(p2): [p1]}
+        )
         # Test that mutation causes the population to alternate between
         # fixations
         counters = [
-            Counter({'Cooperator': 2}),
-            Counter({'Defector': 2}),
-            Counter({'Cooperator': 2}),
-            Counter({'Defector': 2})
+            Counter({"Cooperator": 2}),
+            Counter({"Defector": 2}),
+            Counter({"Cooperator": 2}),
+            Counter({"Defector": 2}),
         ]
         for counter in counters:
-            for _ in itertools.takewhile(lambda x: x.population_distribution() != counter, mp):
+            for _ in itertools.takewhile(
+                lambda x: x.population_distribution() != counter, mp
+            ):
                 pass
             self.assertEqual(mp.population_distribution(), counter)
 
@@ -243,8 +251,11 @@ class TestMoranProcess(unittest.TestCase):
             mp.play()
 
     def test_three_players(self):
-        players = [axelrod.Cooperator(), axelrod.Cooperator(),
-                   axelrod.Defector()]
+        players = [
+            axelrod.Cooperator(),
+            axelrod.Cooperator(),
+            axelrod.Defector(),
+        ]
         axelrod.seed(11)
         mp = MoranProcess(players)
         populations = mp.play()
@@ -259,16 +270,17 @@ class TestMoranProcess(unittest.TestCase):
         p3 = axelrod.Defector()
         players = [p1, p2, p3]
         mp = MoranProcess(players, mutation_rate=0.2)
-        self.assertDictEqual(mp.mutation_targets, {
-            str(p1): [p3, p2], str(p2): [p1, p3], str(p3): [p1, p2]})
+        self.assertDictEqual(
+            mp.mutation_targets,
+            {str(p1): [p3, p2], str(p2): [p1, p3], str(p3): [p1, p2]},
+        )
         # Test that mutation causes the population to alternate between
         # fixations
-        counters = [
-            Counter({'Cooperator': 3}),
-            Counter({'Defector': 3}),
-        ]
+        counters = [Counter({"Cooperator": 3}), Counter({"Defector": 3})]
         for counter in counters:
-            for _ in itertools.takewhile(lambda x: x.population_distribution() != counter, mp):
+            for _ in itertools.takewhile(
+                lambda x: x.population_distribution() != counter, mp
+            ):
                 pass
             self.assertEqual(mp.population_distribution(), counter)
 
@@ -315,8 +327,12 @@ class TestMoranProcess(unittest.TestCase):
     def test_constant_fitness_case(self):
         # Scores between an Alternator and Defector will be: (1,  6)
         axelrod.seed(0)
-        players = (axelrod.Alternator(), axelrod.Alternator(),
-                   axelrod.Defector(), axelrod.Defector())
+        players = (
+            axelrod.Alternator(),
+            axelrod.Alternator(),
+            axelrod.Defector(),
+            axelrod.Defector(),
+        )
         mp = MoranProcess(players, turns=2)
         winners = []
         for _ in range(100):
@@ -360,17 +376,20 @@ class TestMoranProcess(unittest.TestCase):
 
     def test_cooperator_can_win_with_fitness_function(self):
         axelrod.seed(689)
-        players = (axelrod.Cooperator(), axelrod.Defector(),
-                   axelrod.Defector(), axelrod.Defector())
+        players = (
+            axelrod.Cooperator(),
+            axelrod.Defector(),
+            axelrod.Defector(),
+            axelrod.Defector(),
+        )
         w = 0.95
         fitness_function = lambda score: 1 - w + w * score
         mp = MoranProcess(players, turns=10, fitness_function=fitness_function)
         populations = mp.play()
-        self.assertEqual(mp.winning_strategy_name, 'Cooperator')
+        self.assertEqual(mp.winning_strategy_name, "Cooperator")
 
 
 class GraphMoranProcess(unittest.TestCase):
-
     def test_complete(self):
         """A complete graph should produce the same results as the default
         case."""
@@ -428,13 +447,15 @@ class GraphMoranProcess(unittest.TestCase):
             players.append(axelrod.Defector())
         for seed, outcome in seeds:
             axelrod.seed(seed)
-            mp = MoranProcess(players, interaction_graph=graph1,
-                              reproduction_graph=graph2)
+            mp = MoranProcess(
+                players, interaction_graph=graph1, reproduction_graph=graph2
+            )
             mp.play()
             winner = mp.winning_strategy_name
             axelrod.seed(seed)
-            mp = MoranProcess(players, interaction_graph=graph2,
-                              reproduction_graph=graph1)
+            mp = MoranProcess(
+                players, interaction_graph=graph2, reproduction_graph=graph1
+            )
             mp.play()
             winner2 = mp.winning_strategy_name
             self.assertEqual((winner == winner2), outcome)
@@ -452,11 +473,11 @@ class GraphMoranProcess(unittest.TestCase):
             players.append(axelrod.Defector())
         for seed, outcome in seeds:
             axelrod.seed(seed)
-            mp = MoranProcess(players, interaction_graph=graph, mode='bd')
+            mp = MoranProcess(players, interaction_graph=graph, mode="bd")
             mp.play()
             winner = mp.winning_strategy_name
             axelrod.seed(seed)
-            mp = MoranProcess(players, interaction_graph=graph, mode='db')
+            mp = MoranProcess(players, interaction_graph=graph, mode="db")
             mp.play()
             winner2 = mp.winning_strategy_name
             self.assertEqual((winner == winner2), outcome)
@@ -464,29 +485,36 @@ class GraphMoranProcess(unittest.TestCase):
 
 class TestApproximateMoranProcess(unittest.TestCase):
     """A suite of tests for the ApproximateMoranProcess"""
+
     players = [axelrod.Cooperator(), axelrod.Defector()]
     cached_outcomes = {}
 
     counter = Counter([(0, 5)])
     pdf = Pdf(counter)
-    cached_outcomes[('Cooperator', 'Defector')] = pdf
+    cached_outcomes[("Cooperator", "Defector")] = pdf
 
     counter = Counter([(3, 3)])
     pdf = Pdf(counter)
-    cached_outcomes[('Cooperator', 'Cooperator')] = pdf
+    cached_outcomes[("Cooperator", "Cooperator")] = pdf
 
     counter = Counter([(1, 1)])
     pdf = Pdf(counter)
-    cached_outcomes[('Defector', 'Defector')] = pdf
+    cached_outcomes[("Defector", "Defector")] = pdf
 
     amp = ApproximateMoranProcess(players, cached_outcomes)
 
     def test_init(self):
         """Test the initialisation process"""
-        self.assertEqual(set(self.amp.cached_outcomes.keys()),
-                         set([('Cooperator', 'Defector'),
-                              ('Cooperator', 'Cooperator'),
-                              ('Defector', 'Defector')]))
+        self.assertEqual(
+            set(self.amp.cached_outcomes.keys()),
+            set(
+                [
+                    ("Cooperator", "Defector"),
+                    ("Cooperator", "Cooperator"),
+                    ("Defector", "Defector"),
+                ]
+            ),
+        )
         self.assertEqual(self.amp.players, self.players)
         self.assertEqual(self.amp.turns, 0)
         self.assertEqual(self.amp.noise, 0)

--- a/axelrod/tests/unit/test_moran.py
+++ b/axelrod/tests/unit/test_moran.py
@@ -37,6 +37,7 @@ class TestMoranProcess(unittest.TestCase):
         self.assertEqual(mp.interaction_graph._edges, [(0, 1), (1, 0)])
         self.assertEqual(mp.reproduction_graph._edges,
                          [(0, 1), (1, 0), (0, 0), (1, 1)])
+        self.assertEqual(mp.fitness_function, None)
         self.assertEqual(mp.locations, [0, 1])
         self.assertEqual(mp.index, {0: 0, 1: 1})
 
@@ -356,6 +357,16 @@ class TestMoranProcess(unittest.TestCase):
         ax = mp.populations_plot()
         self.assertEqual(ax.get_xlim(), (-0.8, 16.8))
         self.assertEqual(ax.get_ylim(), (0, 5.25))
+
+    def test_fitness_to_moran(self):
+        axelrod.seed(0)
+        players = (axelrod.Cooperator(), axelrod.Defector(),
+                   axelrod.Defector(), axelrod.Defector())
+        w = 0.95
+        fitness_function = lambda score: 1 - w + w * score
+        mp = MoranProcess(players, turns=10, fitness_function=fitness_function)
+        populations = mp.play()
+        self.assertEqual(mp.winning_strategy_name, 'Cooperator')
 
 
 class GraphMoranProcess(unittest.TestCase):

--- a/axelrod/tests/unit/test_moran.py
+++ b/axelrod/tests/unit/test_moran.py
@@ -39,7 +39,7 @@ class TestMoranProcess(unittest.TestCase):
         self.assertEqual(
             mp.reproduction_graph._edges, [(0, 1), (1, 0), (0, 0), (1, 1)]
         )
-        self.assertEqual(mp.fitness_function, None)
+        self.assertEqual(mp.fitness_transformation, None)
         self.assertEqual(mp.locations, [0, 1])
         self.assertEqual(mp.index, {0: 0, 1: 1})
 
@@ -374,7 +374,7 @@ class TestMoranProcess(unittest.TestCase):
         self.assertEqual(ax.get_xlim(), (-0.8, 16.8))
         self.assertEqual(ax.get_ylim(), (0, 5.25))
 
-    def test_cooperator_can_win_with_fitness_function(self):
+    def test_cooperator_can_win_with_fitness_transformation(self):
         axelrod.seed(689)
         players = (
             axelrod.Cooperator(),
@@ -383,8 +383,8 @@ class TestMoranProcess(unittest.TestCase):
             axelrod.Defector(),
         )
         w = 0.95
-        fitness_function = lambda score: 1 - w + w * score
-        mp = MoranProcess(players, turns=10, fitness_function=fitness_function)
+        fitness_transformation = lambda score: 1 - w + w * score
+        mp = MoranProcess(players, turns=10, fitness_transformation=fitness_transformation)
         populations = mp.play()
         self.assertEqual(mp.winning_strategy_name, "Cooperator")
 

--- a/axelrod/tests/unit/test_moran.py
+++ b/axelrod/tests/unit/test_moran.py
@@ -358,8 +358,8 @@ class TestMoranProcess(unittest.TestCase):
         self.assertEqual(ax.get_xlim(), (-0.8, 16.8))
         self.assertEqual(ax.get_ylim(), (0, 5.25))
 
-    def test_fitness_to_moran(self):
-        axelrod.seed(0)
+    def test_cooperator_can_win_with_fitness_function(self):
+        axelrod.seed(689)
         players = (axelrod.Cooperator(), axelrod.Defector(),
                    axelrod.Defector(), axelrod.Defector())
         w = 0.95

--- a/docs/reference/bibliography.rst
+++ b/docs/reference/bibliography.rst
@@ -47,6 +47,7 @@ documentation.
 .. [Nowak1990] Nowak, M., & Sigmund, K. (1990). The evolution of stochastic strategies in the Prisoner's Dilemma. Acta Applicandae Mathematica. https://link.springer.com/article/10.1007/BF00049570
 .. [Nowak1992] Nowak, M.., & May, R. M. (1992). Evolutionary games and spatial chaos. Nature. http://doi.org/10.1038/359826a0
 .. [Nowak1993] Nowak, M., & Sigmund, K. (1993). A strategy of win-stay, lose-shift that outperforms tit-for-tat in the Prisoner’s Dilemma game. Nature, 364(6432), 56–58. http://doi.org/10.1038/364056a0
+.. [Ohtsuki2006] Ohtsuki, Hisashi, et al. "A simple rule for the evolution of cooperation on graphs and social networks." Nature 441.7092 (2006): 502.
 .. [PD2017] http://www.prisoners-dilemma.com/competition.html (Accessed: 6 June 2017)
 .. [Press2012] Press, W. H., & Dyson, F. J. (2012). Iterated Prisoner’s Dilemma contains strategies that dominate any evolutionary opponent. Proceedings of the National Academy of Sciences, 109(26), 10409–10413.  http://doi.org/10.1073/pnas.1206569109
 .. [Prison1998] LIFL (1998) PRISON. Available at: http://www.lifl.fr/IPD/ipd.frame.html (Accessed: 19 September 2016).

--- a/docs/tutorials/getting_started/moran.rst
+++ b/docs/tutorials/getting_started/moran.rst
@@ -122,8 +122,8 @@ denotes the intensity of selection::
     >>> axl.seed(689)
     >>> players = (axl.Cooperator(), axl.Defector(), axl.Defector(), axl.Defector())
     >>> w = 0.95
-    >>> fitness_function = lambda score: 1 - w + w * score
-    >>> mp = axl.MoranProcess(players, turns=10, fitness_function=fitness_function)
+    >>> fitness_transformation = lambda score: 1 - w + w * score
+    >>> mp = axl.MoranProcess(players, turns=10, fitness_transformation=fitness_transformation)
     >>> populations = mp.play()
     >>> mp.winning_strategy_name
     'Cooperator'

--- a/docs/tutorials/getting_started/moran.rst
+++ b/docs/tutorials/getting_started/moran.rst
@@ -115,6 +115,19 @@ function like :code:`takewhile` from :code:`itertools`)::
     >>> mp.population_distribution()
     Counter({'Grudger': 4})
 
+It is possible to pass a fitness function that scales the utility values. A common one
+used in the literature, [Ohtsuki2006]_, is :math:`f(s) = 1 - w + ws` where :math:`w`
+denotes the intensity of selection::
+
+    >>> axl.seed(689)
+    >>> players = (axl.Cooperator(), axl.Defector(), axl.Defector(), axl.Defector())
+    >>> w = 0.95
+    >>> fitness_function = lambda score: 1 - w + w * score
+    >>> mp = axl.MoranProcess(players, turns=10, fitness_function=fitness_function)
+    >>> populations = mp.play()
+    >>> mp.winning_strategy_name
+    'Cooperator'
+
 Other types of implemented Moran processes:
 
 - :ref:`moran-process-on-graphs`


### PR DESCRIPTION
Using a fitness function that scales the utility for the Moran process is commonly used in the literature. 

This `PR` implements that feature and now the Moran process has a new argument, the `fitness_function` which is set as `None` as a default. 

I added a test which tests that cooperators can take over a population of defectors when the selection is weak. Also added an example in the documentations.

Please note that after chatting with @drvinceknight,  I run `black` and `isort` on the files 
(commit 4919dd2). This might make the diffs more complicated than needed, please let me know if you want me to undo that :+1: . 