### PR TITLE
Unpin sphinx on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - sh -e /etc/init.d/xvfb start
 install:
   - pip install -r requirements.txt
-  - pip install sphinx==1.7.6
+  - pip install sphinx
   - pip install sphinx_rtd_theme
   - pip install docutils==0.12
   - pip install coverage
@@ -21,7 +21,7 @@ install:
   - pip install mypy
 script:
   # Build the documentation
-  - cd docs; make html
+  - cd docs; make clean; make html
   # Run the test suit with coverage
   - cd ..
   - travis_wait 60 coverage run --source=axelrod -m unittest discover


### PR DESCRIPTION
I am able to build the docs locally using sphinx `v1.7.8`.

After wiping the build on readthedocs they built correclty
(https://docs.readthedocs.io/en/latest/guides/wipe-environment.html).

I have added a `make clean` to `.travis.yml` so that travis now tests
that it can build a completely clean set of docs.

Closes #1202