### PR TITLE
Sprice up graph and its unit tests

### DIFF
--- a/axelrod/moran.py
+++ b/axelrod/moran.py
@@ -144,20 +144,20 @@ class MoranProcess(object):
             interaction_graph = complete_graph(len(players), loops=False)
         if reproduction_graph is None:
             reproduction_graph = Graph(
-                interaction_graph.edges(), directed=interaction_graph.directed
+                interaction_graph.edges, directed=interaction_graph.directed
             )
             reproduction_graph.add_loops()
         # Check equal vertices
-        v1 = interaction_graph.vertices()
-        v2 = reproduction_graph.vertices()
+        v1 = interaction_graph.vertices
+        v2 = reproduction_graph.vertices
         assert list(v1) == list(v2)
         self.interaction_graph = interaction_graph
         self.reproduction_graph = reproduction_graph
         self.fitness_transformation = fitness_transformation
         # Map players to graph vertices
-        self.locations = sorted(interaction_graph.vertices())
+        self.locations = sorted(interaction_graph.vertices)
         self.index = dict(
-            zip(sorted(interaction_graph.vertices()), range(len(players)))
+            zip(sorted(interaction_graph.vertices), range(len(players)))
         )
 
     def set_players(self) -> None:

--- a/axelrod/tests/unit/test_graph.py
+++ b/axelrod/tests/unit/test_graph.py
@@ -1,67 +1,65 @@
-import unittest
 from collections import defaultdict
+import unittest
 
 from axelrod import graph
 
 
 class TestGraph(unittest.TestCase):
-    def test_init(self):
-        # Undirected graph with no vertices
+
+    def assert_out_mapping(self, g, expected_out_mapping):
+        self.assertDictEqual(g.out_mapping, expected_out_mapping)
+        for node, out_dict in expected_out_mapping.items():
+            self.assertListEqual(g.out_vertices(node), list(out_dict.keys()))
+            self.assertDictEqual(g.out_dict(node), out_dict)
+
+    def assert_in_mapping(self, g, expected_in_mapping):
+        self.assertDictEqual(g.in_mapping, expected_in_mapping)
+        for node, in_dict in expected_in_mapping.items():
+            self.assertListEqual(g.in_vertices(node), list(in_dict.keys()))
+            self.assertDictEqual(g.in_dict(node), in_dict)
+
+    def test_undirected_graph_with_no_vertices(self):
         g = graph.Graph()
         self.assertFalse(g.directed)
         self.assertIsInstance(g.out_mapping, defaultdict)
         self.assertIsInstance(g.in_mapping, defaultdict)
         self.assertEqual(g._edges, [])
+        self.assertEqual(str(g), "<Graph: None>")
 
-        # Directed graph with no vertices
+    def test_directed_graph_with_no_vertices(self):
         g = graph.Graph(directed=True)
         self.assertTrue(g.directed)
         self.assertIsInstance(g.out_mapping, defaultdict)
         self.assertIsInstance(g.in_mapping, defaultdict)
         self.assertEqual(g._edges, [])
+        self.assertEqual(str(g), "<Graph: None>")
 
-        # Undirected graph with vertices and unweighted edges
+    def test_undirected_graph_with_vertices_and_unweighted_edges(self):
         g = graph.Graph(edges=[[1, 2], [2, 3]])
-        expected_edges = [(1, 2), (2, 1), (2, 3), (3, 2)]
-        expected_out_mapping = {1: {2: None}, 2: {1: None, 3: None}, 3: {2: None}}
-        expected_in_mapping = {1: {2: None}, 2: {1: None, 3: None}, 3: {2: None}}
-
         self.assertFalse(g.directed)
-        self.assertEqual(len(g.out_mapping), len(expected_out_mapping))
-        for node in expected_out_mapping:
-            self.assertEqual(g.out_mapping[node], expected_out_mapping[node])
-        self.assertEqual(len(g.in_mapping), len(expected_in_mapping))
-        for node in expected_in_mapping:
-            self.assertEqual(g.in_mapping[node], expected_in_mapping[node])
-        self.assertEqual(g._edges, expected_edges)
+        self.assertEqual(str(g), "<Graph: [[1, 2], [2, 3]]>")
 
-        # Undirected graph with vertices and weighted edges
+        self.assertEqual(g._edges, [(1, 2), (2, 1), (2, 3), (3, 2)])
+        self.assert_out_mapping(g, {1: {2: None}, 2: {1: None, 3: None}, 3: {2: None}})
+        self.assert_in_mapping(g, {1: {2: None}, 2: {1: None, 3: None}, 3: {2: None}})
+
+    def test_undirected_graph_with_vertices_and_weighted_edges(self):
         g = graph.Graph(edges=[[1, 2, 10], [2, 3, 5]])
-        expected_edges = [(1, 2), (2, 1), (2, 3), (3, 2)]
-        expected_out_mapping = {1: {2: 10}, 2: {1: 10, 3: 5}, 3: {2: 5}}
-        expected_in_mapping = {1: {2: 10}, 2: {1: 10, 3: 5}, 3: {2: 5}}
         self.assertFalse(g.directed)
-        self.assertEqual(len(g.out_mapping), len(expected_out_mapping))
-        for node in expected_out_mapping:
-            self.assertEqual(g.out_mapping[node], expected_out_mapping[node])
-        self.assertEqual(len(g.in_mapping), len(expected_in_mapping))
-        for node in expected_in_mapping:
-            self.assertEqual(g.in_mapping[node], expected_in_mapping[node])
-        self.assertEqual(g._edges, expected_edges)
+        self.assertEqual(str(g), "<Graph: [[1, 2, 10], [2, 3, 5]]>")
 
-        # Directed graph with vertices and weighted edges
+        self.assertEqual(g._edges, [(1, 2), (2, 1), (2, 3), (3, 2)])
+        self.assert_out_mapping(g, {1: {2: 10}, 2: {1: 10, 3: 5}, 3: {2: 5}})
+        self.assert_in_mapping(g, {1: {2: 10}, 2: {1: 10, 3: 5}, 3: {2: 5}})
+
+    def test_directed_graph_vertices_and_weighted_edges(self):
         g = graph.Graph(edges=[[1, 2, 10], [2, 3, 5]], directed=True)
-        expected_edges = [(1, 2), (2, 3)]
-        expected_out_mapping = {1: {2: 10}, 2: {3: 5}}
-        expected_in_mapping = {2: {1: 10}, 3: {2: 5}}
         self.assertTrue(g.directed)
-        self.assertEqual(len(g.out_mapping), len(expected_out_mapping))
-        for node in expected_out_mapping:
-            self.assertEqual(g.out_mapping[node], expected_out_mapping[node])
-        self.assertEqual(len(g.in_mapping), len(expected_in_mapping))
-        for node in expected_in_mapping:
-            self.assertEqual(g.in_mapping[node], expected_in_mapping[node])
-        self.assertEqual(g._edges, expected_edges)
+        self.assertEqual(str(g), "<Graph: [[1, 2, 10], [2, 3, 5]]>")
+
+        self.assertEqual(g._edges, [(1, 2), (2, 3)])
+        self.assert_out_mapping(g, {1: {2: 10}, 2: {3: 5}})
+        self.assert_in_mapping(g, {2: {1: 10}, 3: {2: 5}})
 
     def test_add_loops(self):
         edges = [(0, 1), (0, 2), (1, 2)]
@@ -86,7 +84,7 @@ class TestGraph(unittest.TestCase):
             ),
         )
 
-    def test_add_loops2(self):
+    def test_add_loops_with_existing_loop_and_using_strings(self):
         """In this case there is already a loop present; also uses
         strings instead of integers as the hashable."""
         edges = [("a", "b"), ("b", "a"), ("c", "c")]
@@ -97,90 +95,46 @@ class TestGraph(unittest.TestCase):
             list(sorted([("a", "b"), ("b", "a"), ("c", "c"), ("a", "a"), ("b", "b")])),
         )
 
-    def test_out_dict(self):
-        # Undirected graph with vertices and unweighted edges
-        g = graph.Graph(edges=[[1, 2], [2, 3]])
-        expected_out_mapping = {1: {2: None}, 2: {1: None, 3: None}, 3: {2: None}}
-        for key in expected_out_mapping:
-            self.assertEqual(g.out_dict(key), expected_out_mapping[key])
 
-        # Undirected graph with vertices and weighted edges
-        g = graph.Graph(edges=[[1, 2, 10], [2, 3, 5]])
-        expected_out_mapping = {1: {2: 10}, 2: {1: 10, 3: 5}, 3: {2: 5}}
-        for key in expected_out_mapping:
-            self.assertEqual(g.out_dict(key), expected_out_mapping[key])
+class TestCycle(unittest.TestCase):
 
-        # Directed graph with vertices and weighted edges
-        g = graph.Graph(edges=[[1, 2, 10], [2, 3, 5]], directed=True)
-        expected_out_mapping = {1: {2: 10}, 2: {3: 5}}
-        for key in expected_out_mapping:
-            self.assertEqual(g.out_dict(key), expected_out_mapping[key])
-
-    def test_in_dict(self):
-        # Undirected graph with vertices and unweighted edges
-        g = graph.Graph(edges=[[1, 2], [2, 3]])
-        expected_in_mapping = {1: {2: None}, 2: {1: None, 3: None}, 3: {2: None}}
-        for key in expected_in_mapping:
-            self.assertEqual(g.in_dict(key), expected_in_mapping[key])
-
-        # Undirected graph with vertices and weighted edges
-        g = graph.Graph(edges=[[1, 2, 10], [2, 3, 5]])
-        expected_in_mapping = {1: {2: 10}, 2: {1: 10, 3: 5}, 3: {2: 5}}
-        for key in expected_in_mapping:
-            self.assertEqual(g.in_dict(key), expected_in_mapping[key])
-
-        # Directed graph with vertices and weighted edges
-        g = graph.Graph(edges=[[1, 2, 10], [2, 3, 5]], directed=True)
-        expected_in_mapping = {2: {1: 10}, 3: {2: 5}}
-        for key in expected_in_mapping:
-            self.assertEqual(g.in_dict(key), expected_in_mapping[key])
-
-    def test_repr(self):
-        # Undirected graph with no vertices
-        g = graph.Graph()
-        self.assertEqual(str(g), "<Graph: None>")
-
-        # Directed graph with no vertices
-        g = graph.Graph(directed=True)
-        self.assertEqual(str(g), "<Graph: None>")
-
-        # Undirected graph with vertices and unweighted edges
-        g = graph.Graph(edges=[[1, 2], [2, 3]])
-        self.assertEqual(str(g), "<Graph: [[1, 2], [2, 3]]>")
-
-        # Undirected graph with vertices and weighted edges
-        g = graph.Graph(edges=[[1, 2, 10], [2, 3, 5]])
-        self.assertEqual(str(g), "<Graph: [[1, 2, 10], [2, 3, 5]]>")
-
-        # Directed graph with vertices and weighted edges
-        g = graph.Graph(edges=[[1, 2, 10], [2, 3, 5]], directed=True)
-        self.assertEqual(str(g), "<Graph: [[1, 2, 10], [2, 3, 5]]>")
-
-    def test_cycle(self):
-        g = graph.cycle(1, directed=False)
-        self.assertEqual(g.vertices(), [0])
-        self.assertEqual(g.edges(), [(0, 0)])
-        self.assertEqual(g.directed, False)
+    def test_length_1_directed(self):
         g = graph.cycle(1, directed=True)
-        self.assertEqual(g.vertices(), [0])
-        self.assertEqual(g.edges(), [(0, 0)])
+        self.assertEqual(g.vertices, [0])
+        self.assertEqual(g.edges, [(0, 0)])
         self.assertEqual(g.directed, True)
+
+    def test_length_1_undirected(self):
+        g = graph.cycle(1, directed=False)
+        self.assertEqual(g.vertices, [0])
+        self.assertEqual(g.edges, [(0, 0)])
+        self.assertEqual(g.directed, False)
+
+    def test_length_2_directed(self):
         g = graph.cycle(2, directed=True)
-        self.assertEqual(g.vertices(), [0, 1])
-        self.assertEqual(g.edges(), [(0, 1), (1, 0)])
+        self.assertEqual(g.vertices, [0, 1])
+        self.assertEqual(g.edges, [(0, 1), (1, 0)])
+
+    def test_length_2_undirected(self):
         g = graph.cycle(2, directed=False)
-        self.assertEqual(g.vertices(), [0, 1])
-        self.assertEqual(g.edges(), [(0, 1), (1, 0)])
+        self.assertEqual(g.vertices, [0, 1])
+        self.assertEqual(g.edges, [(0, 1), (1, 0)])
+
+    def test_length_3_directed(self):
         g = graph.cycle(3, directed=True)
-        self.assertEqual(g.vertices(), [0, 1, 2])
-        self.assertEqual(g.edges(), [(0, 1), (1, 2), (2, 0)])
+        self.assertEqual(g.vertices, [0, 1, 2])
+        self.assertEqual(g.edges, [(0, 1), (1, 2), (2, 0)])
+        
+    def test_length_3_undirected(self):
         g = graph.cycle(3, directed=False)
         edges = [(0, 1), (1, 0), (1, 2), (2, 1), (2, 0), (0, 2)]
-        self.assertEqual(g.vertices(), [0, 1, 2])
-        self.assertEqual(g.edges(), edges)
+        self.assertEqual(g.vertices, [0, 1, 2])
+        self.assertEqual(g.edges, edges)
+
+    def test_length_4_directed(self):
         g = graph.cycle(4, directed=True)
-        self.assertEqual(g.vertices(), [0, 1, 2, 3])
-        self.assertEqual(g.edges(), [(0, 1), (1, 2), (2, 3), (3, 0)])
+        self.assertEqual(g.vertices, [0, 1, 2, 3])
+        self.assertEqual(g.edges, [(0, 1), (1, 2), (2, 3), (3, 0)])
         self.assertEqual(g.out_vertices(0), [1])
         self.assertEqual(g.out_vertices(1), [2])
         self.assertEqual(g.out_vertices(2), [3])
@@ -189,29 +143,36 @@ class TestGraph(unittest.TestCase):
         self.assertEqual(g.in_vertices(1), [0])
         self.assertEqual(g.in_vertices(2), [1])
         self.assertEqual(g.in_vertices(3), [2])
+
+    def test_length_4_undirected(self):
         g = graph.cycle(4, directed=False)
         edges = [(0, 1), (1, 0), (1, 2), (2, 1), (2, 3), (3, 2), (3, 0), (0, 3)]
-        self.assertEqual(g.vertices(), [0, 1, 2, 3])
-        self.assertEqual(g.edges(), edges)
+        self.assertEqual(g.vertices, [0, 1, 2, 3])
+        self.assertEqual(g.edges, edges)
         for vertex, neighbors in [(0, (1, 3)), (1, (0, 2)), (2, (1, 3)), (3, (0, 2))]:
             self.assertEqual(set(g.out_vertices(vertex)), set(neighbors))
         for vertex, neighbors in [(0, (1, 3)), (1, (0, 2)), (2, (1, 3)), (3, (0, 2))]:
             self.assertEqual(set(g.in_vertices(vertex)), set(neighbors))
 
-    def test_complete(self):
+
+class TestComplete(unittest.TestCase):
+
+    def test_size_2(self):
         g = graph.complete_graph(2, loops=False)
-        self.assertEqual(g.vertices(), [0, 1])
-        self.assertEqual(g.edges(), [(0, 1), (1, 0)])
+        self.assertEqual(g.vertices, [0, 1])
+        self.assertEqual(g.edges, [(0, 1), (1, 0)])
         self.assertEqual(g.directed, False)
 
+    def test_size_3(self):
         g = graph.complete_graph(3, loops=False)
-        self.assertEqual(g.vertices(), [0, 1, 2])
+        self.assertEqual(g.vertices, [0, 1, 2])
         edges = [(0, 1), (1, 0), (0, 2), (2, 0), (1, 2), (2, 1)]
-        self.assertEqual(g.edges(), edges)
+        self.assertEqual(g.edges, edges)
         self.assertEqual(g.directed, False)
 
+    def test_size_4(self):
         g = graph.complete_graph(4, loops=False)
-        self.assertEqual(g.vertices(), [0, 1, 2, 3])
+        self.assertEqual(g.vertices, [0, 1, 2, 3])
         edges = [
             (0, 1),
             (1, 0),
@@ -226,7 +187,7 @@ class TestGraph(unittest.TestCase):
             (2, 3),
             (3, 2),
         ]
-        self.assertEqual(g.edges(), edges)
+        self.assertEqual(g.edges, edges)
         self.assertEqual(g.directed, False)
         for vertex, neighbors in [
             (0, (1, 2, 3)),
@@ -243,18 +204,22 @@ class TestGraph(unittest.TestCase):
         ]:
             self.assertEqual(set(g.in_vertices(vertex)), set(neighbors))
 
-    def test_complete_with_loops(self):
+    def test_size_2_with_loops(self):
         g = graph.complete_graph(2, loops=True)
-        self.assertEqual(g.vertices(), [0, 1])
-        self.assertEqual(g.edges(), [(0, 1), (1, 0), (0, 0), (1, 1)])
+        self.assertEqual(g.vertices, [0, 1])
+        self.assertEqual(g.edges, [(0, 1), (1, 0), (0, 0), (1, 1)])
         self.assertEqual(g.directed, False)
+        
+    def test_size_3_with_loops(self):
         g = graph.complete_graph(3, loops=True)
-        self.assertEqual(g.vertices(), [0, 1, 2])
+        self.assertEqual(g.vertices, [0, 1, 2])
         edges = [(0, 1), (1, 0), (0, 2), (2, 0), (1, 2), (2, 1), (0, 0), (1, 1), (2, 2)]
-        self.assertEqual(g.edges(), edges)
+        self.assertEqual(g.edges, edges)
         self.assertEqual(g.directed, False)
+
+    def test_size_4_with_loops(self):
         g = graph.complete_graph(4, loops=True)
-        self.assertEqual(g.vertices(), [0, 1, 2, 3])
+        self.assertEqual(g.vertices, [0, 1, 2, 3])
         edges = [
             (0, 1),
             (1, 0),
@@ -273,7 +238,7 @@ class TestGraph(unittest.TestCase):
             (2, 2),
             (3, 3),
         ]
-        self.assertEqual(g.edges(), edges)
+        self.assertEqual(g.edges, edges)
         self.assertEqual(g.directed, False)
         neighbors = range(4)
         for vertex in range(4):


### PR DESCRIPTION
Continuation of #347.

Major changes:
- Change add_edge and add_edges to be internal since they're not used anywhere else
- Turned edges and vertices into properties
- Broke up unit tests into several classes
- Grouped and deduped unit test cases for Graph
- Added some coverage for untested methods (in_vertices, etc.)