### PR TITLE
Make Human work w/ both prompt_toolkit v1 and v2

### DIFF
--- a/axelrod/strategies/human.py
+++ b/axelrod/strategies/human.py
@@ -5,7 +5,7 @@ from axelrod.player import Player
 from prompt_toolkit import prompt
 from prompt_toolkit.validation import ValidationError, Validator
 
-try:  # prompt_toolkit v1
+try:  # pragma: no cover
     from prompt_toolkit.styles import style_from_dict
     from prompt_toolkit.token import Token
 

--- a/axelrod/tests/strategies/test_human.py
+++ b/axelrod/tests/strategies/test_human.py
@@ -52,13 +52,13 @@ class TestHumanClass(TestPlayer):
     def test_history_toolbar(self):
         human = Human()
         expected_content = ""
-        actual_content = human._history_toolbar(None)[0][1]
+        actual_content = human._history_toolbar()
         self.assertEqual(actual_content, expected_content)
 
         human.history = [C]
         human.opponent_history = [C]
         expected_content = "History (human, opponent): [('C', 'C')]"
-        actual_content = human._history_toolbar(None)[0][1]
+        actual_content = human._history_toolbar()
         self.assertIn(actual_content, expected_content)
 
     def test_status_messages(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ hypothesis==3.2
 matplotlib>=2.0.0,<3.0.0
 numpy>=1.9.2
 pandas>=0.18.1
-prompt-toolkit>=1.0.7,<2.0.0
+prompt-toolkit>=1.0.7
 scipy>=0.19.0
 toolz>=0.8.0
 tqdm>=3.4.0


### PR DESCRIPTION
As of today, some systems work with prompt_toolkit v1 by default, but
Arch Linux has migrated to v2, and it's the last version on PyPI

To maintain the Arch Linux package of this library, it was required to
revert the 8dba4c0 commit, yet that didn't suffice to make the Human
class work in that system

This commit changes the Human strategy to work on environments with
either prompt_toolkit versions, the main differences are:

- Human._history_toolbar no longer return a list with a tuple, but
  just the raw content (making its tests more straightforward)
- self.status_messages["toolbar"] is a function as expected by the
  prompt_toolkit version available

Although the "pygments.toolbar" string is there when using the
prompt_toolkit v2, the "pygments" library isn't a dependency, since
using the Human strategy works fine in a virtual environment without
pygments