### PR TITLE
Speed up caching logic

### DIFF
--- a/axelrod/deterministic_cache.py
+++ b/axelrod/deterministic_cache.py
@@ -19,8 +19,8 @@ from typing import List, Tuple
 from .action import Action
 from .player import Player
 
-CachePlayerKey = Tuple[Player, Player, int]
-CacheKey = Tuple[str, str, int]
+CachePlayerKey = Tuple[Player, Player]
+CacheKey = Tuple[str, str]
 
 
 def _key_transform(key: CachePlayerKey) -> CacheKey:
@@ -29,15 +29,15 @@ def _key_transform(key: CachePlayerKey) -> CacheKey:
     Parameters
     ----------
     key: tuple
-        A 3-tuple: (player instance, player instance, match length)
+        A 3-tuple: (player instance, player instance)
     """
-    return key[0].name, key[1].name, key[2]
+    return key[0].name, key[1].name
 
 
 def _is_valid_key(key: CachePlayerKey) -> bool:
     """Validate a deterministic cache player key.
 
-    The key should always be a 3-tuple, with a pair of axelrod.Player
+    The key should always be a 2-tuple, with a pair of axelrod.Player
     instances and one integer. Both players should be deterministic.
 
     Parameters
@@ -48,13 +48,12 @@ def _is_valid_key(key: CachePlayerKey) -> bool:
     -------
     Boolean indicating if the key is valid
     """
-    if not isinstance(key, tuple) or len(key) != 3:
+    if not isinstance(key, tuple) or len(key) != 2:
         return False
 
     if not (
         isinstance(key[0], Player)
         and isinstance(key[1], Player)
-        and isinstance(key[2], int)
     ):
         return False
 
@@ -83,10 +82,11 @@ def _is_valid_value(value: List) -> bool:
 class DeterministicCache(UserDict):
     """A class to cache the results of deterministic matches.
 
-    For fixed length matches with no noise between pairs of deterministic
-    players, the results will always be the same. We can hold those results
-    in this class so as to avoid repeatedly generating them in tournaments
-    of multiple repetitions.
+    For matches with no noise between pairs of deterministic players, the
+    results will always be the same.  We can hold the results for the longest
+    run in this class, so as to avoid repeatedly generating them in tournaments
+    of multiple repetitions.  If a shorter or equal-length match is run, we can
+    use the stored results.
 
     By also storing those cached results in a file, we can re-use the cache
     between multiple tournaments if necessary.
@@ -134,8 +134,7 @@ class DeterministicCache(UserDict):
 
         if not _is_valid_key(key):
             raise ValueError(
-                "Key must be a tuple of 2 deterministic axelrod Player classes "
-                "and an integer"
+                "Key must be a tuple of 2 deterministic axelrod Player classes"
             )
 
         if not _is_valid_value(value):

--- a/axelrod/match.py
+++ b/axelrod/match.py
@@ -116,6 +116,15 @@ class Match(object):
             and not (any(p.classifier["stochastic"] for p in self.players))
         )
 
+    def _cached_enough_turns(self, cache_key, turns):
+      """
+      Returns true iff there are is a entry in self._cache for the given key and
+      it's at least turns long.
+      """
+      if cache_key not in self._cache:
+        return False
+      return len(self._cache[cache_key]) >= turns
+
     def play(self):
         """
         The resulting list of actions from a match between two players.
@@ -135,9 +144,9 @@ class Match(object):
         i.e. One entry per turn containing a pair of actions.
         """
         turns = min(sample_length(self.prob_end), self.turns)
-        cache_key = (self.players[0], self.players[1], turns)
+        cache_key = (self.players[0], self.players[1])
 
-        if self._stochastic or (cache_key not in self._cache):
+        if self._stochastic or not self._cached_enough_turns(cache_key, turns):
             for p in self.players:
                 p.reset()
                 p.set_match_attributes(**self.match_attributes)
@@ -148,7 +157,7 @@ class Match(object):
             if self._cache_update_required:
                 self._cache[cache_key] = result
         else:
-            result = self._cache[cache_key]
+          result = self._cache[cache_key][:turns]
 
         self.result = result
         return result

--- a/axelrod/tests/unit/test_deterministic_cache.py
+++ b/axelrod/tests/unit/test_deterministic_cache.py
@@ -10,11 +10,11 @@ C, D = Action.C, Action.D
 class TestDeterministicCache(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.test_key = (TitForTat(), Defector(), 3)
+        cls.test_key = (TitForTat(), Defector())
         cls.test_value = [(C, D), (D, D), (D, D)]
         cls.test_save_file = "test_cache_save.txt"
         cls.test_load_file = "test_cache_load.txt"
-        test_data_to_pickle = {("Tit For Tat", "Defector", 3): [(C, D), (D, D), (D, D)]}
+        test_data_to_pickle = {("Tit For Tat", "Defector"): [(C, D), (D, D), (D, D)]}
         cls.test_pickle = pickle.dumps(test_data_to_pickle)
 
         with open(cls.test_load_file, "wb") as f:
@@ -44,40 +44,30 @@ class TestDeterministicCache(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.cache[invalid_key] = self.test_value
 
-    def test_setitem_invalid_key_too_short(self):
-        invalid_key = self.test_key + (4,)
-        with self.assertRaises(ValueError):
-            self.cache[invalid_key] = self.test_value
-
-    def test_setitem_invalid_key_too_long(self):
-        invalid_key = self.test_key[:2]
-        with self.assertRaises(ValueError):
-            self.cache[invalid_key] = self.test_value
-
     def test_setitem_invalid_key_first_two_elements_not_player(self):
-        invalid_key = ("test", "test", 2)
+        invalid_key = ("test", "test")
         with self.assertRaises(ValueError):
             self.cache[invalid_key] = self.test_value
 
-        invalid_key = (TitForTat(), "test", 2)
+        invalid_key = (TitForTat(), "test")
         with self.assertRaises(ValueError):
             self.cache[invalid_key] = self.test_value
 
-        invalid_key = ("test", TitForTat(), 2)
+        invalid_key = ("test", TitForTat())
         with self.assertRaises(ValueError):
             self.cache[invalid_key] = self.test_value
 
-    def test_setitem_invalid_key_last_element_not_integer(self):
+    def test_setitem_invalid_key_too_many_players(self):
         invalid_key = (TitForTat(), TitForTat(), TitForTat())
         with self.assertRaises(ValueError):
             self.cache[invalid_key] = self.test_value
 
     def test_setitem_invalid_key_stochastic_player(self):
-        invalid_key = (Random(), TitForTat(), 2)
+        invalid_key = (Random(), TitForTat())
         with self.assertRaises(ValueError):
             self.cache[invalid_key] = self.test_value
 
-        invalid_key = (TitForTat(), Random(), 2)
+        invalid_key = (TitForTat(), Random())
         with self.assertRaises(ValueError):
             self.cache[invalid_key] = self.test_value
 

--- a/axelrod/tests/unit/test_match.py
+++ b/axelrod/tests/unit/test_match.py
@@ -89,12 +89,8 @@ class TestMatch(unittest.TestCase):
             self.assertEqual(len(match.play()), expected_length)
             self.assertEqual(match.noise, 0)
             self.assertEqual(match.game.RPST(), (3, 1, 0, 5))
-        self.assertEqual(len(match._cache), 3)
-
-        for expected_length in expected_lengths:
-            self.assertEqual(
-                match._cache[(p1, p2, expected_length)], [(C, C)] * expected_length
-            )
+        self.assertEqual(len(match._cache), 1)
+        self.assertEqual(match._cache[(p1, p2)], [(C, C)] * 5)
 
     @given(turns=integers(min_value=1, max_value=200), game=games())
     @example(turns=5, game=axelrod.DefaultGame)
@@ -167,14 +163,29 @@ class TestMatch(unittest.TestCase):
         expected_result = [(C, D), (C, D), (C, D)]
         self.assertEqual(match.play(), expected_result)
         self.assertEqual(
-            cache[(axelrod.Cooperator(), axelrod.Defector(), 3)], expected_result
+            cache[(axelrod.Cooperator(), axelrod.Defector())], expected_result
         )
 
         # a deliberately incorrect result so we can tell it came from the cache
-        expected_result = [(C, C), (D, D), (D, C)]
-        cache[(axelrod.Cooperator(), axelrod.Defector(), 3)] = expected_result
+        expected_result = [(C, C), (D, D), (D, C), (C, C), (C, D)]
+        cache[(axelrod.Cooperator(), axelrod.Defector())] = expected_result
         match = axelrod.Match(players, 3, deterministic_cache=cache)
-        self.assertEqual(match.play(), expected_result)
+        self.assertEqual(match.play(), expected_result[:3])
+
+    def test_long_cache(self):
+        cache = DeterministicCache()
+        players = (axelrod.Cooperator(), axelrod.Defector())
+        match = axelrod.Match(players, 5, deterministic_cache=cache)
+        expected_result_5_turn = [(C, D), (C, D), (C, D), (C, D), (C, D)]
+        expected_result_3_turn = [(C, D), (C, D), (C, D)]
+        self.assertEqual(match.play(), expected_result_5_turn)
+        match.turns = 3
+        self.assertEqual(match.play(), expected_result_3_turn)
+        # The cache should still hold the 5.
+        self.assertEqual(
+            cache[(axelrod.Cooperator(), axelrod.Defector())],
+            expected_result_5_turn
+        )
 
     def test_scores(self):
         player1 = axelrod.TitForTat()

--- a/axelrod/tests/unit/test_match.py
+++ b/axelrod/tests/unit/test_match.py
@@ -172,7 +172,32 @@ class TestMatch(unittest.TestCase):
         match = axelrod.Match(players, 3, deterministic_cache=cache)
         self.assertEqual(match.play(), expected_result[:3])
 
-    def test_long_cache(self):
+    def test_cache_grows(self):
+        """
+        We want to make sure that if we try to use the cache for more turns than
+        what is stored, then it will instead regenerate the result and overwrite
+        the cache.
+        """
+        cache = DeterministicCache()
+        players = (axelrod.Cooperator(), axelrod.Defector())
+        match = axelrod.Match(players, 3, deterministic_cache=cache)
+        expected_result_5_turn = [(C, D), (C, D), (C, D), (C, D), (C, D)]
+        expected_result_3_turn = [(C, D), (C, D), (C, D)]
+        self.assertEqual(match.play(), expected_result_3_turn)
+        match.turns = 5
+        self.assertEqual(match.play(), expected_result_5_turn)
+        # The cache should now hold the 5-turn result..
+        self.assertEqual(
+            cache[(axelrod.Cooperator(), axelrod.Defector())],
+            expected_result_5_turn
+        )
+
+    def test_cache_doesnt_shrink(self):
+        """
+        We want to make sure that when we access the cache looking for fewer
+        turns than what is stored, then it will not overwrite the cache with the
+        shorter result.
+        """
         cache = DeterministicCache()
         players = (axelrod.Cooperator(), axelrod.Defector())
         match = axelrod.Match(players, 5, deterministic_cache=cache)

--- a/docs/tutorials/advanced/using_the_cache.rst
+++ b/docs/tutorials/advanced/using_the_cache.rst
@@ -40,9 +40,11 @@ Let us rerun the above match but using the cache::
 We can take a look at the cache::
 
     >>> cache  # doctest: +ELLIPSIS
-    {('Soft Go By Majority', 'Alternator', 200): [(C, C), ..., (C, D)]}
+    {('Soft Go By Majority', 'Alternator'): [(C, C), ..., (C, D)]}
     >>> len(cache)
     1
+    >>> len(cache[(axl.GoByMajority(), axl.Alternator())])
+    200
 
 This maps a triplet of 2 player names and the match length to the resulting
 interactions.  We can rerun the code and compare the timing::


### PR DESCRIPTION
The caching is inefficient when prob_end is used.  The current paradigm caches by players and number of turns in match, for non-stochastic.  But this ignores the fact that you can read a shorter match from the result of a longer match.  For example if we have a 20-turn match cached, and we wish to run a 19-turn match, we COULD just read the first 19 moves from the 20-turn match, but the current paradigm would completely re-run because no 19-turn match has been run yet.

I changed the code to
1. Cache on player-pairs only.
2. Only re-run a match if the cache is shorter than the desired match.  In that case overwrite the cached value.
3. Sliced the cached value after reading, so as to get the first n moves, as desired.

I ran the code below and found an 80% speed-up.  I don't think this adds complexity, and keying on player-pairs only is simpler and more natural.


Experimental code:
```
import axelrod as axl
import time

MATCH_SIMS = 100

player1, player2 = axl.Cooperator(), axl.DBS()
players = (player1, player2)
match = axl.Match(players, prob_end=0.01)

start_time = time.time()
prev_time = time.time()
for _ in range(MATCH_SIMS):
  match.play()
  print("Running simulation {} of {}.  Played {} rounds.  It took {} secs.".format(
      _, MATCH_SIMS, len(match.result), time.time() - prev_time))
  prev_time = time.time()
end_time = time.time()
print("================")
print("Total time for {} simulations: {} secs.".format(MATCH_SIMS, end_time - start_time))
```