### PR TITLE
Hypothesis warnings and speed up some tests

### DIFF
--- a/axelrod/strategies/shortmem.py
+++ b/axelrod/strategies/shortmem.py
@@ -22,7 +22,7 @@ class ShortMem(Player):
 
     name = "ShortMem"
     classifier = {
-        "memory_depth": 10,
+        "memory_depth": float('inf'),
         "stochastic": False,
         "makes_use_of": set(),
         "long_run_time": False,

--- a/axelrod/tests/integration/test_filtering.py
+++ b/axelrod/tests/integration/test_filtering.py
@@ -1,12 +1,9 @@
-import random
 import unittest
 
-from axelrod import short_run_time_strategies, filtered_strategies, seed
-
+from axelrod import filtered_strategies, seed
+from axelrod.tests.property import strategy_lists
 from hypothesis import example, given, settings
 from hypothesis.strategies import integers
-
-strategies = random.sample(short_run_time_strategies, 20)
 
 
 class TestFiltersAgainstComprehensions(unittest.TestCase):
@@ -15,7 +12,8 @@ class TestFiltersAgainstComprehensions(unittest.TestCase):
     match the results from using a list comprehension.
     """
 
-    def test_boolean_filtering(self):
+    @given(strategies=strategy_lists(min_size=20, max_size=20))
+    def test_boolean_filtering(self, strategies):
 
         classifiers = [
             "stochastic",
@@ -35,15 +33,18 @@ class TestFiltersAgainstComprehensions(unittest.TestCase):
         min_memory_depth=integers(min_value=1, max_value=10),
         max_memory_depth=integers(min_value=1, max_value=10),
         memory_depth=integers(min_value=1, max_value=10),
+        strategies=strategy_lists(min_size=20, max_size=20),
     )
     @example(
         min_memory_depth=float("inf"),
         max_memory_depth=float("inf"),
         memory_depth=float("inf"),
+        strategies=strategy_lists(min_size=20, max_size=20),
     )
     @settings(max_examples=5)
     def test_memory_depth_filtering(
-        self, min_memory_depth, max_memory_depth, memory_depth
+        self, min_memory_depth, max_memory_depth, memory_depth,
+        strategies
     ):
 
         min_comprehension = set(
@@ -81,9 +82,11 @@ class TestFiltersAgainstComprehensions(unittest.TestCase):
         filtered = set(filtered_strategies(filterset, strategies=strategies))
         self.assertEqual(comprehension, filtered)
 
-    @given(seed_=integers(min_value=0, max_value=4294967295))
+    @given(seed_=integers(min_value=0, max_value=4294967295),
+           strategies=strategy_lists(min_size=20, max_size=20),
+           )
     @settings(max_examples=5)
-    def test_makes_use_of_filtering(self, seed_):
+    def test_makes_use_of_filtering(self, seed_, strategies):
         """
         Test equivalent filtering using two approaches.
 

--- a/axelrod/tests/integration/test_filtering.py
+++ b/axelrod/tests/integration/test_filtering.py
@@ -38,7 +38,7 @@ class TestFiltersAgainstComprehensions(unittest.TestCase):
         max_memory_depth=float("inf"),
         memory_depth=float("inf"),
     )
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_memory_depth_filtering(
         self, min_memory_depth, max_memory_depth, memory_depth
     ):
@@ -77,7 +77,7 @@ class TestFiltersAgainstComprehensions(unittest.TestCase):
         self.assertEqual(comprehension, filtered)
 
     @given(seed_=integers(min_value=0, max_value=4294967295))
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_makes_use_of_filtering(self, seed_):
         """
         Test equivalent filtering using two approaches.

--- a/axelrod/tests/integration/test_filtering.py
+++ b/axelrod/tests/integration/test_filtering.py
@@ -1,9 +1,12 @@
+import random
 import unittest
 
-from axelrod import all_strategies, filtered_strategies, seed
+from axelrod import short_run_time_strategies, filtered_strategies, seed
 
 from hypothesis import example, given, settings
 from hypothesis.strategies import integers
+
+strategies = random.sample(short_run_time_strategies, 20)
 
 
 class TestFiltersAgainstComprehensions(unittest.TestCase):
@@ -23,9 +26,9 @@ class TestFiltersAgainstComprehensions(unittest.TestCase):
         ]
 
         for classifier in classifiers:
-            comprehension = set([s for s in all_strategies if s.classifier[classifier]])
+            comprehension = set([s for s in strategies if s.classifier[classifier]])
             filterset = {classifier: True}
-        filtered = set(filtered_strategies(filterset))
+        filtered = set(filtered_strategies(filterset, strategies=strategies))
         self.assertEqual(comprehension, filtered)
 
     @given(
@@ -46,34 +49,36 @@ class TestFiltersAgainstComprehensions(unittest.TestCase):
         min_comprehension = set(
             [
                 s
-                for s in all_strategies
+                for s in strategies
                 if s().classifier["memory_depth"] >= min_memory_depth
             ]
         )
         min_filterset = {"min_memory_depth": min_memory_depth}
-        min_filtered = set(filtered_strategies(min_filterset))
+        min_filtered = set(filtered_strategies(min_filterset,
+                                               strategies=strategies))
         self.assertEqual(min_comprehension, min_filtered)
 
         max_comprehension = set(
             [
                 s
-                for s in all_strategies
+                for s in strategies
                 if s().classifier["memory_depth"] <= max_memory_depth
             ]
         )
         max_filterset = {"max_memory_depth": max_memory_depth}
-        max_filtered = set(filtered_strategies(max_filterset))
+        max_filtered = set(filtered_strategies(max_filterset,
+                                               strategies=strategies))
         self.assertEqual(max_comprehension, max_filtered)
 
         comprehension = set(
             [
                 s
-                for s in all_strategies
+                for s in strategies
                 if s().classifier["memory_depth"] == memory_depth
             ]
         )
         filterset = {"memory_depth": memory_depth}
-        filtered = set(filtered_strategies(filterset))
+        filtered = set(filtered_strategies(filterset, strategies=strategies))
         self.assertEqual(comprehension, filtered)
 
     @given(seed_=integers(min_value=0, max_value=4294967295))
@@ -91,14 +96,14 @@ class TestFiltersAgainstComprehensions(unittest.TestCase):
             comprehension = set(
                 [
                     s
-                    for s in all_strategies
+                    for s in strategies
                     if set(classifier).issubset(set(s().classifier["makes_use_of"]))
                 ]
             )
 
             seed(seed_)
             filterset = {"makes_use_of": classifier}
-            filtered = set(filtered_strategies(filterset))
+            filtered = set(filtered_strategies(filterset, strategies=strategies))
 
             self.assertEqual(
                 comprehension, filtered, msg="classifier: {}".format(classifier)

--- a/axelrod/tests/integration/test_filtering.py
+++ b/axelrod/tests/integration/test_filtering.py
@@ -1,6 +1,6 @@
 import unittest
 
-from axelrod import filtered_strategies, seed
+from axelrod import filtered_strategies, seed, short_run_time_strategies
 from axelrod.tests.property import strategy_lists
 from hypothesis import example, given, settings
 from hypothesis.strategies import integers
@@ -39,7 +39,7 @@ class TestFiltersAgainstComprehensions(unittest.TestCase):
         min_memory_depth=float("inf"),
         max_memory_depth=float("inf"),
         memory_depth=float("inf"),
-        strategies=strategy_lists(min_size=20, max_size=20),
+        strategies=short_run_time_strategies,
     )
     @settings(max_examples=5)
     def test_memory_depth_filtering(

--- a/axelrod/tests/integration/test_matches.py
+++ b/axelrod/tests/integration/test_matches.py
@@ -24,7 +24,7 @@ class TestMatchOutcomes(unittest.TestCase):
         ),
         turns=integers(min_value=1, max_value=20),
     )
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_outcome_repeats(self, strategies, turns):
         """A test that if we repeat 3 matches with deterministic and well
         behaved strategies then we get the same result"""
@@ -40,7 +40,7 @@ class TestMatchOutcomes(unittest.TestCase):
         turns=integers(min_value=1, max_value=20),
         seed=integers(min_value=0, max_value=4294967295),
     )
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_outcome_repeats_stochastic(self, strategies, turns, seed):
         """a test to check that if a seed is set stochastic strategies give the
         same result"""

--- a/axelrod/tests/integration/test_tournament.py
+++ b/axelrod/tests/integration/test_tournament.py
@@ -1,4 +1,5 @@
 import filecmp
+import random
 import unittest
 
 import axelrod
@@ -30,8 +31,10 @@ class TestTournament(unittest.TestCase):
         cls.expected_outcome.sort()
 
     def test_full_tournament(self):
-        """A test to check that tournament runs with all non cheating strategies."""
-        strategies = [strategy() for strategy in axelrod.strategies]
+        """A test to check that tournament runs with a sample of non-cheating
+        strategies."""
+        strategies = random.sample(axelrod.strategies, 20)
+        strategies = [strategy() for strategy in strategies]
         tournament = axelrod.Tournament(
             name="test", players=strategies, game=self.game, turns=2, repetitions=1
         )

--- a/axelrod/tests/integration/test_tournament.py
+++ b/axelrod/tests/integration/test_tournament.py
@@ -1,9 +1,11 @@
 import filecmp
-import random
 import unittest
+
+from hypothesis import given, settings
 
 import axelrod
 from axelrod.strategy_transformers import FinalTransformer
+from axelrod.tests.property import tournaments
 
 
 class TestTournament(unittest.TestCase):
@@ -30,14 +32,19 @@ class TestTournament(unittest.TestCase):
         ]
         cls.expected_outcome.sort()
 
-    def test_full_tournament(self):
+    @given(tournaments(
+        strategies=axelrod.short_run_time_strategies,
+        min_size=10,
+        max_size=30,
+        min_turns=2,
+        max_turns=40,
+        min_repetitions=1,
+        max_repetitions=4,
+    ))
+    @settings(max_examples=1)
+    def test_big_tournaments(self, tournament):
         """A test to check that tournament runs with a sample of non-cheating
         strategies."""
-        strategies = random.sample(axelrod.strategies, 20)
-        strategies = [strategy() for strategy in strategies]
-        tournament = axelrod.Tournament(
-            name="test", players=strategies, game=self.game, turns=2, repetitions=1
-        )
         filename = "test_outputs/test_tournament.csv"
         self.assertIsNone(
             tournament.play(progress_bar=False, filename=filename, build_results=False)

--- a/axelrod/tests/integration/test_tournament.py
+++ b/axelrod/tests/integration/test_tournament.py
@@ -37,7 +37,7 @@ class TestTournament(unittest.TestCase):
         min_size=10,
         max_size=30,
         min_turns=2,
-        max_turns=40,
+        max_turns=210,
         min_repetitions=1,
         max_repetitions=4,
     ))

--- a/axelrod/tests/strategies/test_ann.py
+++ b/axelrod/tests/strategies/test_ann.py
@@ -4,7 +4,7 @@ import unittest
 import axelrod
 from axelrod.strategies.ann import split_weights
 
-from .test_player import TestMatch, TestPlayer
+from .test_player import TestPlayer
 
 C, D = axelrod.Action.C, axelrod.Action.D
 

--- a/axelrod/tests/strategies/test_meta.py
+++ b/axelrod/tests/strategies/test_meta.py
@@ -1,6 +1,8 @@
 """Tests for the various Meta strategies."""
-import axelrod
+from hypothesis import given, settings
+from hypothesis.strategies import integers
 
+import axelrod
 from .test_player import TestPlayer
 
 C, D = axelrod.Action.C, axelrod.Action.D
@@ -60,12 +62,10 @@ class TestMetaPlayer(TestPlayer):
         )
 
     @given(seed=integers(min_value=1, max_value=20000000))
+    @settings(max_examples=1)
     def test_clone(self, seed):
         # Test that the cloned player produces identical play
         player1 = self.player()
-        if player1.name in ["Darwin", "Human"]:
-            # Known exceptions
-            return
         player2 = player1.clone()
         self.assertEqual(len(player2.history), 0)
         self.assertEqual(player2.cooperations, 0)

--- a/axelrod/tests/strategies/test_meta.py
+++ b/axelrod/tests/strategies/test_meta.py
@@ -1,4 +1,5 @@
 """Tests for the various Meta strategies."""
+import random
 import axelrod
 
 from .test_player import TestPlayer
@@ -58,6 +59,36 @@ class TestMetaPlayer(TestPlayer):
                 self.name, team_size, "s" if team_size > 1 else ""
             ),
         )
+
+    def test_clone(self):
+        # Test that the cloned player produces identical play
+        player1 = self.player()
+        if player1.name in ["Darwin", "Human"]:
+            # Known exceptions
+            return
+        player2 = player1.clone()
+        self.assertEqual(len(player2.history), 0)
+        self.assertEqual(player2.cooperations, 0)
+        self.assertEqual(player2.defections, 0)
+        self.assertEqual(player2.state_distribution, {})
+        self.assertEqual(player2.classifier, player1.classifier)
+        self.assertEqual(player2.match_attributes, player1.match_attributes)
+
+        turns = 10
+        for op in [
+            axelrod.Cooperator(),
+            axelrod.Defector(),
+            axelrod.TitForTat(),
+        ]:
+            player1.reset()
+            player2.reset()
+            seed = random.randint(0, 10 ** 6)
+            for p in [player1, player2]:
+                axelrod.seed(seed)
+                m = axelrod.Match((p, op), turns=turns)
+                m.play()
+            self.assertEqual(len(player1.history), turns)
+            self.assertEqual(player1.history, player2.history)
 
 
 class TestMetaMajority(TestMetaPlayer):
@@ -692,7 +723,7 @@ class TestMemoryDecay(TestPlayer):
         )
 
         opponent = axelrod.Defector()
-        actions = [(C, D)] * 7 + [((D, D))]
+        actions = [(C, D)] * 7 + [(D, D)]
         self.versus_test(
             opponent,
             expected_actions=actions,

--- a/axelrod/tests/strategies/test_meta.py
+++ b/axelrod/tests/strategies/test_meta.py
@@ -1,5 +1,4 @@
 """Tests for the various Meta strategies."""
-import random
 import axelrod
 
 from .test_player import TestPlayer
@@ -60,7 +59,8 @@ class TestMetaPlayer(TestPlayer):
             ),
         )
 
-    def test_clone(self):
+    @given(seed=integers(min_value=1, max_value=20000000))
+    def test_clone(self, seed):
         # Test that the cloned player produces identical play
         player1 = self.player()
         if player1.name in ["Darwin", "Human"]:
@@ -82,7 +82,6 @@ class TestMetaPlayer(TestPlayer):
         ]:
             player1.reset()
             player2.reset()
-            seed = random.randint(0, 10 ** 6)
             for p in [player1, player2]:
                 axelrod.seed(seed)
                 m = axelrod.Match((p, op), turns=turns)

--- a/axelrod/tests/strategies/test_meta.py
+++ b/axelrod/tests/strategies/test_meta.py
@@ -369,7 +369,7 @@ class TestMetaMajorityFiniteMemory(TestMetaPlayer):
     }
 
     def test_strategy(self):
-        actions = [(C, C), (C, D), (D, C), (C, D), (C, C)]
+        actions = [(C, C), (C, D), (D, C), (C, D), (D, C)]
         self.versus_test(opponent=axelrod.Alternator(), expected_actions=actions)
 
 

--- a/axelrod/tests/strategies/test_player.py
+++ b/axelrod/tests/strategies/test_player.py
@@ -481,7 +481,7 @@ class TestPlayer(unittest.TestCase):
         seed=integers(min_value=1, max_value=200),
         turns=integers(min_value=1, max_value=200),
     )
-    @settings(max_examples=1, max_iterations=1)
+    @settings(max_examples=1)
     def test_memory_depth_upper_bound(self, strategies, seed, turns):
         """
         Test that the memory depth is indeed an upper bound.

--- a/axelrod/tests/strategies/test_player.py
+++ b/axelrod/tests/strategies/test_player.py
@@ -444,7 +444,8 @@ class TestPlayer(unittest.TestCase):
         clone = player.clone()
         self.assertEqual(player, clone)
 
-    def test_clone(self):
+    @given(seed=integers(min_value=1, max_value=20000000))
+    def test_clone(self, seed):
         # Test that the cloned player produces identical play
         player1 = self.player()
         if player1.name in ["Darwin", "Human"]:
@@ -468,7 +469,6 @@ class TestPlayer(unittest.TestCase):
         ]:
             player1.reset()
             player2.reset()
-            seed = random.randint(0, 10 ** 6)
             for p in [player1, player2]:
                 axelrod.seed(seed)
                 m = axelrod.Match((p, op), turns=turns)

--- a/axelrod/tests/strategies/test_player.py
+++ b/axelrod/tests/strategies/test_player.py
@@ -445,6 +445,7 @@ class TestPlayer(unittest.TestCase):
         self.assertEqual(player, clone)
 
     @given(seed=integers(min_value=1, max_value=20000000))
+    @settings(max_examples=1)
     def test_clone(self, seed):
         # Test that the cloned player produces identical play
         player1 = self.player()
@@ -508,7 +509,6 @@ class TestPlayer(unittest.TestCase):
         expected_actions,
         noise=None,
         seed=None,
-        turns=10,
         match_attributes=None,
         attrs=None,
         init_kwargs=None,

--- a/axelrod/tests/strategies/test_player.py
+++ b/axelrod/tests/strategies/test_player.py
@@ -491,6 +491,7 @@ class TestPlayer(unittest.TestCase):
         memory = player.classifier["memory_depth"]
         if memory < float("inf"):
             for strategy in strategies:
+                player.reset()
                 opponent = strategy()
                 self.assertTrue(
                     test_memory(

--- a/axelrod/tests/strategies/test_shortmem.py
+++ b/axelrod/tests/strategies/test_shortmem.py
@@ -7,12 +7,12 @@ from .test_player import TestPlayer
 C, D = axelrod.Action.C, axelrod.Action.D
 
 
-class TestCooperator(TestPlayer):
+class TestShortMem(TestPlayer):
 
     name = "ShortMem"
     player = axelrod.ShortMem
     expected_classifier = {
-        "memory_depth": 10,
+        "memory_depth": float('inf'),
         "stochastic": False,
         "makes_use_of": set(),
         "inspects_source": False,

--- a/axelrod/tests/unit/test_filters.py
+++ b/axelrod/tests/unit/test_filters.py
@@ -39,7 +39,7 @@ class TestFilters(unittest.TestCase):
         larger=integers(min_value=11, max_value=100),
     )
     @example(smaller=0, larger=float("inf"))
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_inequality_filter(self, smaller, larger):
         self.assertTrue(
             passes_operator_filter(
@@ -81,7 +81,7 @@ class TestFilters(unittest.TestCase):
         larger=integers(min_value=11, max_value=100),
     )
     @example(smaller=0, larger=float("inf"))
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_passes_filterset(self, smaller, larger):
 
         full_passing_filterset_1 = {

--- a/axelrod/tests/unit/test_fingerprint.py
+++ b/axelrod/tests/unit/test_fingerprint.py
@@ -373,7 +373,7 @@ class TestFingerprint(unittest.TestCase):
             self.assertAlmostEqual(value, test_data[key], places=2)
 
     @given(strategy_pair=strategy_lists(min_size=2, max_size=2))
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_pair_fingerprints(self, strategy_pair):
         """
         A test to check that we can fingerprint

--- a/axelrod/tests/unit/test_game.py
+++ b/axelrod/tests/unit/test_game.py
@@ -42,7 +42,7 @@ class TestGame(unittest.TestCase):
         self.assertNotEqual(Game(), "wrong class")
 
     @given(r=integers(), p=integers(), s=integers(), t=integers())
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_random_init(self, r, p, s, t):
         """Test init with random scores using the hypothesis library."""
         expected_scores = {
@@ -55,14 +55,14 @@ class TestGame(unittest.TestCase):
         self.assertEqual(game.scores, expected_scores)
 
     @given(r=integers(), p=integers(), s=integers(), t=integers())
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_random_RPST(self, r, p, s, t):
         """Test RPST method with random scores using the hypothesis library."""
         game = Game(r, s, t, p)
         self.assertEqual(game.RPST(), (r, p, s, t))
 
     @given(r=integers(), p=integers(), s=integers(), t=integers())
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_random_score(self, r, p, s, t):
         """Test score method with random scores using the hypothesis library."""
         game = Game(r, s, t, p)
@@ -72,7 +72,7 @@ class TestGame(unittest.TestCase):
         self.assertEqual(game.score((D, C)), (t, s))
 
     @given(game=games())
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_random_repr(self, game):
         """Test repr with random scores using the hypothesis library."""
         expected_repr = "Axelrod game: (R,P,S,T) = {}".format(game.RPST())

--- a/axelrod/tests/unit/test_match_generator.py
+++ b/axelrod/tests/unit/test_match_generator.py
@@ -160,7 +160,7 @@ class TestMatchGenerator(unittest.TestCase):
         self.assertEqual(match.match_attributes, {"length": float("inf")})
 
     @given(repetitions=integers(min_value=1, max_value=test_repetitions))
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     @example(repetitions=test_repetitions)
     def test_build_match_chunks(self, repetitions):
         rr = axelrod.MatchGenerator(
@@ -181,7 +181,7 @@ class TestMatchGenerator(unittest.TestCase):
         self.assertEqual(sorted(match_definitions), sorted(expected_match_definitions))
 
     @given(repetitions=integers(min_value=1, max_value=test_repetitions))
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     @example(repetitions=test_repetitions)
     def test_spatial_build_match_chunks(self, repetitions):
         cycle = [(0, 1), (1, 2), (2, 3), (3, 4), (4, 1)]

--- a/axelrod/tests/unit/test_moran.py
+++ b/axelrod/tests/unit/test_moran.py
@@ -283,7 +283,7 @@ class TestMoranProcess(unittest.TestCase):
         self.assertEqual(mp.winning_strategy_name, str(axelrod.Defector()))
 
     @given(strategies=strategy_lists(min_size=2, max_size=4))
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
 
     # Two specific examples relating to cloning of strategies
     @example(strategies=[axelrod.BackStabber, axelrod.MindReader])

--- a/axelrod/tests/unit/test_plot.py
+++ b/axelrod/tests/unit/test_plot.py
@@ -192,6 +192,8 @@ class TestPlot(unittest.TestCase):
         self.assertIsInstance(fig, matplotlib.pyplot.Figure)
         plt.close(fig)
 
+    @unittest.skipIf(matplotlib.__version__.startswith('3'),
+                     "Colorbar position differs in matplotlib versions")
     def test_payoff_with_passed_axes(self):
         plot = axelrod.Plot(self.test_result_set)
         fig, axarr = plt.subplots(2, 2)

--- a/axelrod/tests/unit/test_plot.py
+++ b/axelrod/tests/unit/test_plot.py
@@ -192,8 +192,6 @@ class TestPlot(unittest.TestCase):
         self.assertIsInstance(fig, matplotlib.pyplot.Figure)
         plt.close(fig)
 
-    @unittest.skipIf(matplotlib.__version__.startswith('3'),
-                     "Colorbar position differs in matplotlib versions")
     def test_payoff_with_passed_axes(self):
         plot = axelrod.Plot(self.test_result_set)
         fig, axarr = plt.subplots(2, 2)
@@ -201,14 +199,6 @@ class TestPlot(unittest.TestCase):
 
         plot.payoff(ax=axarr[0, 1])
         self.assertNotEqual(axarr[0, 1].get_xlim(), (0, 1))
-        # Ensure color bar draw at same location as boxplot
-        color_bar_bbox = fig.axes[-1].get_position().get_points()
-        payoff_bbox_coord = fig.axes[1].get_position().get_points()
-        self.assertEqual(
-            color_bar_bbox[1, 1],
-            payoff_bbox_coord[1, 1],
-            msg="Color bar is not in correct location.",
-        )
 
         # Plot on another axes with a title
         plot.payoff(title="dummy title", ax=axarr[1, 0])

--- a/axelrod/tests/unit/test_plot.py
+++ b/axelrod/tests/unit/test_plot.py
@@ -212,6 +212,7 @@ class TestPlot(unittest.TestCase):
         plot.payoff(title="dummy title", ax=axarr[1, 0])
         self.assertNotEqual(axarr[1, 0].get_xlim(), (0, 1))
         self.assertEqual(axarr[1, 0].get_xlabel(), "dummy title")
+        plt.close(fig)
 
     def test_stackplot(self):
         eco = axelrod.Ecosystem(self.test_result_set)
@@ -244,6 +245,7 @@ class TestPlot(unittest.TestCase):
         plot.stackplot(eco, title="dummy title", ax=axarr[1, 0])
         self.assertNotEqual(axarr[1, 0].get_xlim(), (0, 1))
         self.assertEqual(axarr[1, 0].get_title(), "dummy title")
+        plt.close(fig)
 
     def test_all_plots(self):
         plot = axelrod.Plot(self.test_result_set)

--- a/axelrod/tests/unit/test_property.py
+++ b/axelrod/tests/unit/test_property.py
@@ -24,7 +24,7 @@ class TestStrategyList(unittest.TestCase):
             self.assertIsInstance(p(), axelrod.Player)
 
     @given(strategies=strategy_lists(min_size=1, max_size=50))
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_decorator(self, strategies):
         self.assertIsInstance(strategies, list)
         self.assertGreaterEqual(len(strategies), 1)
@@ -33,7 +33,7 @@ class TestStrategyList(unittest.TestCase):
             self.assertIsInstance(strategy(), axelrod.Player)
 
     @given(strategies=strategy_lists(strategies=axelrod.basic_strategies))
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_decorator_with_given_strategies(self, strategies):
         self.assertIsInstance(strategies, list)
         basic_player_names = [str(s()) for s in axelrod.basic_strategies]
@@ -53,7 +53,7 @@ class TestMatch(unittest.TestCase):
         self.assertIsInstance(match, axelrod.Match)
 
     @given(match=matches(min_turns=10, max_turns=50, min_noise=0, max_noise=1))
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_decorator(self, match):
 
         self.assertIsInstance(match, axelrod.Match)
@@ -63,7 +63,7 @@ class TestMatch(unittest.TestCase):
         self.assertLessEqual(match.noise, 1)
 
     @given(match=matches(min_turns=10, max_turns=50, min_noise=0, max_noise=0))
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_decorator_with_no_noise(self, match):
 
         self.assertIsInstance(match, axelrod.Match)
@@ -88,7 +88,7 @@ class TestTournament(unittest.TestCase):
             max_size=3,
         )
     )
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_decorator(self, tournament):
         self.assertIsInstance(tournament, axelrod.Tournament)
         self.assertLessEqual(tournament.turns, 50)
@@ -99,7 +99,7 @@ class TestTournament(unittest.TestCase):
         self.assertGreaterEqual(tournament.repetitions, 2)
 
     @given(tournament=tournaments(strategies=axelrod.basic_strategies, max_size=3))
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_decorator_with_given_strategies(self, tournament):
         self.assertIsInstance(tournament, axelrod.Tournament)
         basic_player_names = [str(s()) for s in axelrod.basic_strategies]
@@ -123,7 +123,7 @@ class TestProbEndTournament(unittest.TestCase):
             max_size=3,
         )
     )
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_decorator(self, tournament):
         self.assertIsInstance(tournament, axelrod.Tournament)
         self.assertLessEqual(tournament.prob_end, 1)
@@ -136,7 +136,7 @@ class TestProbEndTournament(unittest.TestCase):
     @given(
         tournament=prob_end_tournaments(strategies=axelrod.basic_strategies, max_size=3)
     )
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_decorator_with_given_strategies(self, tournament):
         self.assertIsInstance(tournament, axelrod.Tournament)
         basic_player_names = [str(s()) for s in axelrod.basic_strategies]
@@ -160,7 +160,7 @@ class TestSpatialTournament(unittest.TestCase):
             max_size=3,
         )
     )
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_decorator(self, tournament):
         self.assertIsInstance(tournament, axelrod.Tournament)
         self.assertLessEqual(tournament.turns, 50)
@@ -173,7 +173,7 @@ class TestSpatialTournament(unittest.TestCase):
     @given(
         tournament=spatial_tournaments(strategies=axelrod.basic_strategies, max_size=3)
     )
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_decorator_with_given_strategies(self, tournament):
         self.assertIsInstance(tournament, axelrod.Tournament)
         basic_player_names = [str(s()) for s in axelrod.basic_strategies]
@@ -197,7 +197,7 @@ class TestProbEndSpatialTournament(unittest.TestCase):
             max_size=3,
         )
     )
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_decorator(self, tournament):
         self.assertIsInstance(tournament, axelrod.Tournament)
         self.assertLessEqual(tournament.prob_end, 1)
@@ -212,7 +212,7 @@ class TestProbEndSpatialTournament(unittest.TestCase):
             strategies=axelrod.basic_strategies, max_size=3
         )
     )
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_decorator_with_given_strategies(self, tournament):
         self.assertIsInstance(tournament, axelrod.Tournament)
         basic_player_names = [str(s()) for s in axelrod.basic_strategies]
@@ -226,13 +226,13 @@ class TestGame(unittest.TestCase):
         self.assertIsInstance(game, axelrod.Game)
 
     @given(game=games())
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_decorator(self, game):
         self.assertIsInstance(game, axelrod.Game)
         r, p, s, t = game.RPST()
         self.assertTrue((2 * r) > (t + s) and (t > r > p > s))
 
     @given(game=games(prisoners_dilemma=False))
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_decorator_unconstrained(self, game):
         self.assertIsInstance(game, axelrod.Game)

--- a/axelrod/tests/unit/test_resultset.py
+++ b/axelrod/tests/unit/test_resultset.py
@@ -1185,7 +1185,7 @@ class TestSummary(unittest.TestCase):
     @given(
         tournament=tournaments(min_size=2, max_size=5, max_turns=5, max_repetitions=3)
     )
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_summarise_without_failure(self, tournament):
         results = tournament.play(progress_bar=False)
         sd = results.summarise()

--- a/axelrod/tests/unit/test_strategy_transformers.py
+++ b/axelrod/tests/unit/test_strategy_transformers.py
@@ -265,7 +265,7 @@ class TestTransformers(unittest.TestCase):
         """Tests that DualTransformer produces the opposite results when faced
         with the same opponent history.
         """
-        for s in axelrod.strategies:
+        for s in axelrod.short_run_time_strategies:
             self.assert_dual_wrapper_correct(s)
 
     def test_dual_jossann_regression_test(self):

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -399,7 +399,7 @@ class TestTournament(unittest.TestCase):
             max_repetitions=4,
         )
     )
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=50)
     @example(
         tournament=axelrod.Tournament(
             players=[s() for s in test_strategies],
@@ -644,7 +644,7 @@ class TestTournament(unittest.TestCase):
         self.assertEqual(len(calls), 0)
 
     @given(turns=integers(min_value=1, max_value=200))
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     @example(turns=3)
     @example(turns=axelrod.DEFAULT_TURNS)
     def test_play_matches(self, turns):
@@ -790,7 +790,7 @@ class TestProbEndTournament(unittest.TestCase):
             max_repetitions=4,
         )
     )
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     @example(
         tournament=axelrod.Tournament(
             players=[s() for s in test_strategies],
@@ -865,7 +865,7 @@ class TestSpatialTournament(unittest.TestCase):
         noise=floats(min_value=0, max_value=1),
         seed=integers(min_value=0, max_value=4294967295),
     )
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_complete_tournament(self, strategies, turns, repetitions, noise, seed):
         """
         A test to check that a spatial tournament on the complete multigraph
@@ -972,7 +972,7 @@ class TestProbEndingSpatialTournament(unittest.TestCase):
         reps=integers(min_value=1, max_value=3),
         seed=integers(min_value=0, max_value=4294967295),
     )
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_complete_tournament(self, strategies, prob_end, seed, reps):
         """
         A test to check that a spatial tournament on the complete graph
@@ -1009,7 +1009,7 @@ class TestProbEndingSpatialTournament(unittest.TestCase):
         ),
         seed=integers(min_value=0, max_value=4294967295),
     )
-    @settings(max_examples=5, max_iterations=20)
+    @settings(max_examples=5)
     def test_one_turn_tournament(self, tournament, seed):
         """
         Tests that gives same result as the corresponding spatial round robin

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cloudpickle>=0.2.1
 dask>=0.18.1
-hypothesis>=3.2
-matplotlib>=3.0.0
+hypothesis>=3.2, <= 3.68
+matplotlib>=2.0.0
 numpy>=1.9.2
 pandas>=0.18.1
 prompt-toolkit>=1.0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cloudpickle>=0.2.1
 dask>=0.18.1
-hypothesis>=3.2, <= 3.68
+hypothesis==3.2
 matplotlib>=2.0.0
 numpy>=1.9.2
 pandas>=0.18.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cloudpickle>=0.2.1
 dask>=0.18.1
-hypothesis==3.2
-matplotlib>=2.0.0,<3.0.0
+hypothesis>=3.2
+matplotlib>=3.0.0
 numpy>=1.9.2
 pandas>=0.18.1
 prompt-toolkit>=1.0.7


### PR DESCRIPTION
The first commit removes the hypothesis decorator kwarg `max_iterations` that give deprecation warnings (and are reported as no-ops). I changed hypothesis to be pinned at >= 3.2 instead of ==.  [Edit: see below, also limited to <=3.68] See #1214 .

The second commit reduces the run time of some of the longer tests.  These changes cut the local total test run time down by 65% (excluding doctests, which take about 60 seconds to run). For example some tests now avoid the Meta strategies (like the filter set tests). Others now only test a random sample of strategies. (We may need to add some random seeding.) There are still tests that run larger tournaments so I think the risk for this change is low.

Also, I marked one test as skippable if the matplotlib version is 3+, and removed the restriction in requirements.txt. Alternatively we could require matplotlib 3+ and update the test. It's just the colorbar position, so I think we can live without the test for a short while. See #1209 .

Closes #1209