### PR TITLE
Remove redundant member functions of the Action class

### DIFF
--- a/axelrod/action.py
+++ b/axelrod/action.py
@@ -21,13 +21,13 @@ class UnknownActionError(ValueError):
 @total_ordering
 class Action(Enum):
     """Core actions in the Prisoner's Dilemma.
-    
+
     There are only two possible actions, namely Cooperate or Defect,
     which are called C and D for convenience.
     """
 
-    C = 1  # Cooperate
-    D = 0  # Defect
+    C = 0  # Cooperate
+    D = 1  # Defect
 
     def __lt__(self, other):
         return self.value < other.value
@@ -36,7 +36,7 @@ class Action(Enum):
         return self.name
 
     def __str__(self):
-        return repr(self)
+        return self.name
 
     def flip(self):
         """Returns the opposite Action."""
@@ -48,7 +48,7 @@ class Action(Enum):
     @classmethod
     def from_char(cls, character):
         """Converts a single character into an Action.
-        
+
         Parameters
         ----------
         character: a string of length one
@@ -91,7 +91,7 @@ def actions_to_str(actions: Iterable[Action]) -> str:
 
     Example: (D, D, C) would be converted to 'DDC'
 
-    Paramteters
+    Parameters
     -----------
     actions: iterable of Action
 
@@ -100,4 +100,4 @@ def actions_to_str(actions: Iterable[Action]) -> str:
     str
         A string of 'C's and 'D's.
     """
-    return "".join(map(repr, actions))
+    return "".join(map(str, actions))

--- a/axelrod/action.py
+++ b/axelrod/action.py
@@ -20,7 +20,7 @@ class UnknownActionError(ValueError):
 
 @total_ordering
 class Action(Enum):
-    """Core actions in the Prisoner's Dilemna.
+    """Core actions in the Prisoner's Dilemma.
     
     There are only two possible actions, namely Cooperate or Defect,
     which are called C and D for convenience.
@@ -29,23 +29,14 @@ class Action(Enum):
     C = 1  # Cooperate
     D = 0  # Defect
 
-    def __bool__(self):
-        return bool(self.value)
-
-    def __eq__(self, other):
-        return self.value == other.value
-
-    def __hash__(self):
-        return hash(self.value)
-
     def __lt__(self, other):
         return self.value < other.value
 
     def __repr__(self):
-        return "{}".format(self.name)
+        return self.name
 
     def __str__(self):
-        return "{}".format(self.name)
+        return repr(self)
 
     def flip(self):
         """Returns the opposite Action."""

--- a/axelrod/tests/unit/test_actions.py
+++ b/axelrod/tests/unit/test_actions.py
@@ -7,14 +7,6 @@ C, D = Action.C, Action.D
 
 
 class TestAction(unittest.TestCase):
-    def test_eq(self):
-        self.assertEqual(C, C)
-        self.assertEqual(D, D)
-
-    def test_hash(self):
-        self.assertEqual(hash(C), 1)
-        self.assertEqual(hash(D), 0)
-
     def test_lt(self):
         self.assertLess(D, C)
 
@@ -26,15 +18,16 @@ class TestAction(unittest.TestCase):
         self.assertEqual(str(C), "C")
         self.assertEqual(str(D), "D")
 
-    def test_bool(self):
-        self.assertTrue(C)
-        self.assertFalse(D)
-
     def test__eq__(self):
         self.assertTrue(C == C)
         self.assertTrue(D == D)
         self.assertFalse(C == D)
         self.assertFalse(D == C)
+
+    def test_total_order(self):
+        actions = [C, D, D, C, C, C, D]
+        actions.sort()
+        self.assertEqual(actions, [C, C, C, C, D, D, D])
 
     def test_flip(self):
         self.assertEqual(C.flip(), D)

--- a/axelrod/tests/unit/test_actions.py
+++ b/axelrod/tests/unit/test_actions.py
@@ -8,7 +8,7 @@ C, D = Action.C, Action.D
 
 class TestAction(unittest.TestCase):
     def test_lt(self):
-        self.assertLess(D, C)
+        self.assertLess(C, D)
 
     def test_repr(self):
         self.assertEqual(repr(C), "C")


### PR DESCRIPTION
On profiling a tournament I noticed that the removed functions were among the most often called. It turns out that they are unnecessary because Enums provide their own `__hash__` and `__eq__`. This PR speeds up actual tournaments by 20-25% in my (limited) testing.