### PR TITLE
Added Appold (k88r) strategy from Axelrod's second.

### DIFF
--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -20,6 +20,7 @@ from .axelrod_first import (
     UnnamedStrategy,
 )
 from .axelrod_second import (
+    Appold,
     Black,
     Borufsen,
     Cave,
@@ -248,6 +249,7 @@ all_strategies = [
     APavlov2006,
     APavlov2011,
     Appeaser,
+    Appold,
     ArrogantQLearner,
     AverageCopier,
     BackStabber,

--- a/axelrod/strategies/axelrod_second.py
+++ b/axelrod/strategies/axelrod_second.py
@@ -536,11 +536,11 @@ class Kluepfel(Player):
                     self.dd_counts += 1
             else:
                 if opponent.history[-1] == C:
-                    self.dc_counts += 1
-                else:
                     self.cc_counts += 1
+                else:
+                    self.dc_counts += 1
 
-        # Check for randomness
+        # Check for "randomness"
         if len(self.history) > 26:
             if self.cd_counts >= (self.cd_counts + self.dd_counts) / 2 - 0.75 * np.sqrt(
                 self.cd_counts + self.dd_counts

--- a/axelrod/strategies/axelrod_second.py
+++ b/axelrod/strategies/axelrod_second.py
@@ -540,11 +540,11 @@ class Kluepfel(Player):
                 else:
                     self.dc_counts += 1
 
-        # Check for "randomness"
+        # Check for randomness
         if len(self.history) > 26:
             if self.cd_counts >= (self.cd_counts + self.dd_counts) / 2 - 0.75 * np.sqrt(
                 self.cd_counts + self.dd_counts
-            ) and self.cc_counts >= (
+            ) and self.dc_counts >= (
                 self.dc_counts + self.cc_counts
             ) / 2 - 0.75 * np.sqrt(
                 self.dc_counts + self.cc_counts

--- a/axelrod/tests/strategies/test_axelrod_second.py
+++ b/axelrod/tests/strategies/test_axelrod_second.py
@@ -546,7 +546,12 @@ class TestKluepfel(TestPlayer):
     }
 
     def test_strategy(self):
-        actions = [(C, C)] * 100  # Cooperate forever
+        actions = [(C, C)] * 27  # Cooperate at first
+        # After this point, the strategy will always detect false, becasue the
+        # two checks become:
+        # 0 >= 0, and
+        # cc_counts >= (cc_counts)/2 - 0.75*sqrt(cc_counts)
+        actions += [(D, C)] * 100
         self.versus_test(axelrod.Cooperator(), expected_actions=actions)
 
         # Since never two in a row, will respond in kind with 70% if
@@ -598,16 +603,12 @@ class TestKluepfel(TestPlayer):
             (D, C),
             (C, C),
             (C, D),
-            # Success detect random opponent for remaining turns.
-            (D, D),
-            (D, D),
-            (D, D),
+            (C, D),
             (D, C),
-            (D, D),
-            (D, C),
-            (D, D),
-            (D, C),
-            (D, D),
+            (C, C),
+            (C, C),
+            (D, D),  # At this point cc_counts=10, cd_counts=10, dc_counts=10,
+                     # and dd_counts=5.  Detect random and defect hereafter.
             (D, C),
             (D, C),
             (D, D),
@@ -617,11 +618,7 @@ class TestKluepfel(TestPlayer):
             (D, C),
             (D, C),
             (D, D),
-            (D, C),
-            (D, C),
-            (D, C),
-            (D, C),
-            (D, D),
+            (D, C)
         ]
         self.versus_test(axelrod.Random(0.5), expected_actions=actions, seed=10)
 

--- a/axelrod/tests/strategies/test_axelrod_second.py
+++ b/axelrod/tests/strategies/test_axelrod_second.py
@@ -546,12 +546,7 @@ class TestKluepfel(TestPlayer):
     }
 
     def test_strategy(self):
-        actions = [(C, C)] * 27  # Cooperate at first
-        # After this point, the strategy will always detect false, becasue the
-        # two checks become:
-        # 0 >= 0, and
-        # cc_counts >= (cc_counts)/2 - 0.75*sqrt(cc_counts)
-        actions += [(D, C)] * 100
+        actions = [(C, C)] * 100  # Cooperate forever
         self.versus_test(axelrod.Cooperator(), expected_actions=actions)
 
         # Since never two in a row, will respond in kind with 70% if
@@ -603,12 +598,16 @@ class TestKluepfel(TestPlayer):
             (D, C),
             (C, C),
             (C, D),
-            (C, D),
+            # Success detect random opponent for remaining turns.
+            (D, D),
+            (D, D),
+            (D, D),
             (D, C),
-            (C, C),
-            (C, C),
-            (D, D),  # At this point cc_counts=10, cd_counts=10, dc_counts=10,
-                     # and dd_counts=5.  Detect random and defect hereafter.
+            (D, D),
+            (D, C),
+            (D, D),
+            (D, C),
+            (D, D),
             (D, C),
             (D, C),
             (D, D),
@@ -618,7 +617,11 @@ class TestKluepfel(TestPlayer):
             (D, C),
             (D, C),
             (D, D),
-            (D, C)
+            (D, C),
+            (D, C),
+            (D, C),
+            (D, C),
+            (D, D),
         ]
         self.versus_test(axelrod.Random(0.5), expected_actions=actions, seed=10)
 

--- a/docs/reference/overview_of_strategies.rst
+++ b/docs/reference/overview_of_strategies.rst
@@ -115,7 +115,7 @@ repository.
    "K85R_", "Robert B Falk and James M Langsted", "Not Implemented"
    "K86R_", "Bernard Grofman", "Not Implemented"
    "K87R_", "E E H Schurmann",  "Not Implemented"
-   "K88R_", "Scott Appold", "Not Implemented"
+   "K88R_", "Scott Appold", ":class:`Appold <axelrod.strategies.axelrod_second.Appold>`"
    "K89R_", "Gene Snodgrass", "Not Implemented"
    "K90R_", "John Maynard Smith", "Not Implemented"
    "K91R_", "Jonathan Pinkley", "Not Implemented"

--- a/docs/tutorials/advanced/classification_of_strategies.rst
+++ b/docs/tutorials/advanced/classification_of_strategies.rst
@@ -47,7 +47,7 @@ strategies::
     ... }
     >>> strategies = axl.filtered_strategies(filterset)
     >>> len(strategies)
-    86
+    87
 
 Or, to find out how many strategies only use 1 turn worth of memory to
 make a decision::


### PR DESCRIPTION
Adapted from https://github.com/Axelrod-Python/TourExec/blob/v0.3.0/src/strategies/k58r.f

Here are some fingerprints for this new strategy and for the existing Fortran strategy:

![appold_basic_axl](https://user-images.githubusercontent.com/5215426/66036856-27437a00-e4c3-11e9-938a-e812aaa0bf22.png)
![appold_basic_fortran](https://user-images.githubusercontent.com/5215426/66036858-27dc1080-e4c3-11e9-86fb-2b3efdfc2532.png)
![appold_prob_axl](https://user-images.githubusercontent.com/5215426/66036859-27dc1080-e4c3-11e9-8642-e4511c0b942d.png)
![appold_prob_fortran](https://user-images.githubusercontent.com/5215426/66036863-27dc1080-e4c3-11e9-8086-cc1231beb7c1.png)
