### PR TITLE
Change EvolvablePlayer serialization to write strings instead of bytes

### DIFF
--- a/axelrod/evolvable_player.py
+++ b/axelrod/evolvable_player.py
@@ -1,3 +1,4 @@
+import base64
 from pickle import dumps, loads
 from random import randrange
 from typing import Dict, List
@@ -36,12 +37,14 @@ class EvolvablePlayer(Player):
 
     def serialize_parameters(self):
         """Serialize parameters."""
-        return dumps(self.init_kwargs)
+        pickled = dumps(self.init_kwargs)  # bytes
+        s = base64.b64encode(pickled).decode('utf8')  # string
+        return s
 
     @classmethod
     def deserialize_parameters(cls, serialized):
         """Deserialize parameters to a Player instance."""
-        init_kwargs = loads(serialized)
+        init_kwargs = loads(base64.b64decode(serialized))
         return cls(**init_kwargs)
 
     # Optional methods for evolutionary algorithms and Moran processes.

--- a/axelrod/tests/strategies/test_evolvable_player.py
+++ b/axelrod/tests/strategies/test_evolvable_player.py
@@ -140,6 +140,17 @@ class TestEvolvablePlayer(TestPlayer):
         self.assertEqual(player, deserialized_player)
         self.assertEqual(deserialized_player, deserialized_player.clone())
 
+    def test_serialization_csv(self):
+        """Serializing and deserializing should return the original player."""
+        seed(0)
+        player = self.player()
+        serialized = player.serialize_parameters()
+        s = "0, 1, {}, 3".format(serialized)
+        s2 = s.split(',')[2]
+        deserialized_player = player.__class__.deserialize_parameters(s2)
+        self.assertEqual(player, deserialized_player)
+        self.assertEqual(deserialized_player, deserialized_player.clone())
+
     def behavior_test(self, player1, player2):
         """Test that the evolvable player plays the same as its (nonevolvable) parent class."""
         for opponent_class in [axl.Random, axl.TitForTat, axl.Alternator]:


### PR DESCRIPTION
for easier inclusion in CSV files (as used in axelrod-dojo).