### PR TITLE
Fix rendering of code snippet in docs.

### DIFF
--- a/docs/tutorials/further_topics/evolvable_players.rst
+++ b/docs/tutorials/further_topics/evolvable_players.rst
@@ -21,7 +21,7 @@ Additionally, the Moran process implementation supports a second style of mutati
 evolving new strategies utilizing the :code:`EvolvablePlayer` class via its :code:`mutate` method.
 This is in contrast to the transitional mutation that selects one of the other player types rather than (possibly)
 generating a new player variant. To use this mutation style set `mutation_method=atomic` in the initialisation
-of the Moran process:
+of the Moran process::
 
     >>> import axelrod as axl
     >>> C = axl.Action.C


### PR DESCRIPTION
This ensures the `doctest: +SKIP` does not appear.