### PR TITLE
Removes Fool Me Forever

### DIFF
--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -160,7 +160,7 @@ from .mindcontrol import MindBender, MindController, MindWarper
 from .mindreader import MindReader, MirrorMindReader, ProtectedMindReader
 from .mutual import Desperate, Hopeless, Willing
 from .negation import Negation
-from .oncebitten import FoolMeForever, FoolMeOnce, ForgetfulFoolMeOnce, OnceBitten
+from .oncebitten import FoolMeOnce, ForgetfulFoolMeOnce, OnceBitten
 from .prober import (
     CollectiveStrategy,
     Detective,
@@ -305,7 +305,6 @@ all_strategies = [
     EvolvedHMM5,
     Feld,
     FirmButFair,
-    FoolMeForever,
     FoolMeOnce,
     ForgetfulFoolMeOnce,
     ForgetfulGrudger,

--- a/axelrod/strategies/grudger.py
+++ b/axelrod/strategies/grudger.py
@@ -226,6 +226,7 @@ class EasyGo(Player):
 
     - Easy Go: [Prison1998]_
     - Reverse Grudger (RGRIM): [Li2011]_
+    - Fool Me Forever: [Harper2017]_
     """
 
     name = "EasyGo"

--- a/axelrod/strategies/oncebitten.py
+++ b/axelrod/strategies/oncebitten.py
@@ -128,31 +128,3 @@ class ForgetfulFoolMeOnce(Player):
         if self.D_count > 1:
             return D
         return C
-
-
-class FoolMeForever(Player):
-    """
-    Fool me once, shame on me. Teach a man to fool me and I'll be fooled for
-    the rest of my life.
-
-    Names:
-
-    - Fool Me Forever: Original name by Marc Harper
-    """
-
-    name = "Fool Me Forever"
-    classifier = {
-        "memory_depth": float("inf"),  # Long memory
-        "stochastic": False,
-        "makes_use_of": set(),
-        "long_run_time": False,
-        "inspects_source": False,
-        "manipulates_source": False,
-        "manipulates_state": False,
-    }
-
-    @staticmethod
-    def strategy(opponent: Player) -> Action:
-        if opponent.defections > 0:
-            return C
-        return D

--- a/axelrod/tests/strategies/test_meta.py
+++ b/axelrod/tests/strategies/test_meta.py
@@ -616,7 +616,9 @@ class TestNMWELongMemory(TestMetaPlayer):
 
     def test_strategy(self):
         actions = [(C, C), (C, D), (C, C), (D, D), (D, C)]
-        self.versus_test(opponent=axelrod.Alternator(), expected_actions=actions)
+        self.versus_test(opponent=axelrod.Alternator(),
+                         expected_actions=actions,
+                         seed=10)
 
 
 class TestNMWEMemoryOne(TestMetaPlayer):

--- a/axelrod/tests/strategies/test_oncebitten.py
+++ b/axelrod/tests/strategies/test_oncebitten.py
@@ -140,33 +140,3 @@ class TestForgetfulFoolMeOnce(TestPlayer):
             seed=2,
             attrs={"D_count": 0},
         )
-
-
-class TestFoolMeForever(TestPlayer):
-
-    name = "Fool Me Forever"
-    player = axelrod.FoolMeForever
-    expected_classifier = {
-        "memory_depth": float("inf"),  # Long memory
-        "stochastic": False,
-        "makes_use_of": set(),
-        "long_run_time": False,
-        "inspects_source": False,
-        "manipulates_source": False,
-        "manipulates_state": False,
-    }
-
-    def test_strategy(self):
-        # If opponent defects more than once, cooperate forever.
-        actions = [(D, C)] * 20
-        self.versus_test(opponent=axelrod.Cooperator(), expected_actions=actions)
-
-        actions = [(D, C), (D, D)] + [(C, C), (C, D)] * 20
-        self.versus_test(opponent=axelrod.Alternator(), expected_actions=actions)
-
-        opponent = axelrod.MockPlayer([D] + [C] * 19)
-        actions = [(D, D)] + [(C, C)] * 19
-        self.versus_test(opponent=opponent, expected_actions=actions)
-
-        actions = [(D, D)] + [(C, D)] * 19
-        self.versus_test(opponent=axelrod.Defector(), expected_actions=actions)


### PR DESCRIPTION
Hello everyone,

While working on one of my projects I realised that the strategy `Fool Me Forever`, which is an original strategy implemented within the library, is actually the same as the strategy `EasyGo` from
[Prison1998 and Li2011](https://axelrod.readthedocs.io/en/stable/reference/bibliography.html#li2011).

Source code for `Fool me Forever` (link to source code [here](https://axelrod.readthedocs.io/en/stable/_modules/axelrod/strategies/oncebitten.html#FoolMeForever)):
```python
    @staticmethod
    def strategy(opponent: Player) -> Action:
        if opponent.defections > 0:
            return C
        return D
```
Source code for `EasyGo` (link to source code [here](https://axelrod.readthedocs.io/en/stable/_modules/axelrod/strategies/grudger.html#EasyGo)):
```python
    @staticmethod
    def strategy(opponent: Player) -> Action:
        """Begins by playing D, then plays C for the remaining rounds if the
        opponent ever plays D."""
        if opponent.defections:
            return C
        return D
```

The code snippets, the Ashlock fingerprints for both strategies and their performance in the Axelrod-Python standard tournament (result csv: https://github.com/Axelrod-Python/tournament/blob/gh-pages/assets/std_summary.csv) are the same. 

![fool_me_forever](https://user-images.githubusercontent.com/19708408/68780085-9cab7a00-062d-11ea-981a-c1ee97b1e726.png)

![easygo](https://user-images.githubusercontent.com/19708408/68780346-117eb400-062e-11ea-8874-95309b59055f.png)

This `pr` removes Fool me Forever (because it's an original strategy), the imports and tests associated with it. Let me know if it's okay and if there is something I forgot to do 👍 

