### PR TITLE
Create function to handle relative paths

### DIFF
--- a/axelrod/load_data_.py
+++ b/axelrod/load_data_.py
@@ -1,6 +1,17 @@
-from typing import Dict, List, Tuple
+from typing import Dict, List, Text, Tuple
 
+import os
 import pkg_resources
+
+
+def axl_filename(axl_path: Text) -> Text:
+    """Get the path to Axelrod/<axl_path> from the working directory."""
+    # Working directory
+    dirname = os.path.dirname(__file__)
+
+    # We go up a dir because this code is located in Axelrod/axelrod and
+    # axl_path is from the top-level Axelrod dir.
+    return os.path.join(dirname, "..", axl_path)
 
 
 def load_file(filename: str, directory: str) -> List[List[str]]:

--- a/axelrod/load_data_.py
+++ b/axelrod/load_data_.py
@@ -4,25 +4,21 @@ from typing import Dict, List, Text, Tuple
 import pkg_resources
 
 
-def axl_filename(*axl_path: Text) -> Text:
+def axl_filename(path: pathlib.Path) -> pathlib.Path:
     """Given a path under Axelrod/, return absolute filepath.
 
     Parameters
     ----------
     axl_path
-        Path to file located under top-level Axelrod directory, with file names
-        separated at "/".  For example, to get the path to "Axelrod/xxx/yyy.py"
-        call this function with axl_filename("xxx", "yyy.py").
+        A pathlib.Path object with the relative directory under Axelrod/
 
     Returns
     -------
-        Absolute path to the given path.
+        A pathlib.Path object with the absolute directory.
     """
     # We go up a dir because this code is located in Axelrod/axelrod.
-    path = pathlib.Path(__file__).resolve().parent.parent
-    for p in axl_path:
-        path = path / p
-    return str(path)
+    axl_path = pathlib.Path(__file__).resolve().parent.parent
+    return axl_path / path
 
 
 def load_file(filename: str, directory: str) -> List[List[str]]:

--- a/axelrod/load_data_.py
+++ b/axelrod/load_data_.py
@@ -1,17 +1,28 @@
+import pathlib
 from typing import Dict, List, Text, Tuple
 
-import os
 import pkg_resources
 
 
-def axl_filename(axl_path: Text) -> Text:
-    """Get the path to Axelrod/<axl_path> from the working directory."""
-    # Working directory
-    dirname = os.path.dirname(__file__)
+def axl_filename(*axl_path: Text) -> Text:
+    """Given a path under Axelrod/, return absolute filepath.
 
-    # We go up a dir because this code is located in Axelrod/axelrod and
-    # axl_path is from the top-level Axelrod dir.
-    return os.path.join(dirname, "..", axl_path)
+    Parameters
+    ----------
+    axl_path
+        Path to file located under top-level Axelrod directory, with file names
+        separated at "/".  For example, to get the path to "Axelrod/xxx/yyy.py"
+        call this function with axl_filename("xxx", "yyy.py").
+
+    Returns
+    -------
+        Absolute path to the given path.
+    """
+    # We go up a dir because this code is located in Axelrod/axelrod.
+    path = pathlib.Path(__file__).resolve().parent.parent
+    for p in axl_path:
+        path = path / p
+    return str(path)
 
 
 def load_file(filename: str, directory: str) -> List[List[str]]:

--- a/axelrod/plot.py
+++ b/axelrod/plot.py
@@ -8,6 +8,7 @@ import tqdm
 from numpy import arange, median, nan_to_num
 
 from .result_set import ResultSet
+from .load_data_ import axl_filename
 
 titleType = List[str]
 namesType = List[str]
@@ -323,7 +324,7 @@ class Plot(object):
 
         for method, name in plots:
             f = getattr(self, method)(title="{} - {}".format(title_prefix, name))
-            f.savefig("{}_{}.{}".format(prefix, method, filetype))
+            f.savefig(axl_filename("{}_{}.{}".format(prefix, method, filetype)))
             plt.close(f)
 
             if progress_bar:

--- a/axelrod/plot.py
+++ b/axelrod/plot.py
@@ -4,6 +4,7 @@ from typing import List, Union
 import matplotlib
 import matplotlib.pyplot as plt
 import matplotlib.transforms as transforms
+import pathlib
 import tqdm
 from numpy import arange, median, nan_to_num
 
@@ -324,7 +325,8 @@ class Plot(object):
 
         for method, name in plots:
             f = getattr(self, method)(title="{} - {}".format(title_prefix, name))
-            f.savefig(axl_filename("{}_{}.{}".format(prefix, method, filetype)))
+            path = pathlib.Path("{}_{}.{}".format(prefix, method, filetype))
+            f.savefig(axl_filename(path))
             plt.close(f)
 
             if progress_bar:

--- a/axelrod/tests/integration/test_tournament.py
+++ b/axelrod/tests/integration/test_tournament.py
@@ -33,20 +33,22 @@ class TestTournament(unittest.TestCase):
         ]
         cls.expected_outcome.sort()
 
-    @given(tournaments(
-        strategies=axelrod.short_run_time_strategies,
-        min_size=10,
-        max_size=30,
-        min_turns=2,
-        max_turns=210,
-        min_repetitions=1,
-        max_repetitions=4,
-    ))
+    @given(
+        tournaments(
+            strategies=axelrod.short_run_time_strategies,
+            min_size=10,
+            max_size=30,
+            min_turns=2,
+            max_turns=210,
+            min_repetitions=1,
+            max_repetitions=4,
+        )
+    )
     @settings(max_examples=1)
     def test_big_tournaments(self, tournament):
         """A test to check that tournament runs with a sample of non-cheating
         strategies."""
-        filename = axl_filename("test_outputs/test_tournament.csv")
+        filename = axl_filename("test_outputs", "test_tournament.csv")
         self.assertIsNone(
             tournament.play(progress_bar=False, filename=filename, build_results=False)
         )
@@ -91,7 +93,9 @@ class TestTournament(unittest.TestCase):
                 turns=2,
                 repetitions=2,
             )
-            files.append(axl_filename("test_outputs/stochastic_tournament_{}.csv".format(_)))
+            files.append(
+                axl_filename("test_outputs", "stochastic_tournament_{}.csv".format(_))
+            )
             tournament.play(progress_bar=False, filename=files[-1], build_results=False)
         self.assertTrue(filecmp.cmp(files[0], files[1]))
 
@@ -114,7 +118,9 @@ class TestTournament(unittest.TestCase):
                 turns=2,
                 repetitions=2,
             )
-            files.append(axl_filename("test_outputs/stochastic_tournament_{}.csv".format(_)))
+            files.append(
+                axl_filename("test_outputs", "stochastic_tournament_{}.csv".format(_))
+            )
             tournament.play(progress_bar=False, filename=files[-1], build_results=False)
         self.assertTrue(filecmp.cmp(files[0], files[1]))
 

--- a/axelrod/tests/integration/test_tournament.py
+++ b/axelrod/tests/integration/test_tournament.py
@@ -1,6 +1,7 @@
 import unittest
 
 import filecmp
+import pathlib
 
 import axelrod as axl
 from axelrod.load_data_ import axl_filename
@@ -49,7 +50,8 @@ class TestTournament(unittest.TestCase):
     def test_big_tournaments(self, tournament):
         """A test to check that tournament runs with a sample of non-cheating
         strategies."""
-        filename = axl_filename("test_outputs", "test_tournament.csv")
+        path = pathlib.Path("test_outputs/test_tournament.csv")
+        filename = axl_filename(path)
         self.assertIsNone(
             tournament.play(progress_bar=False, filename=filename, build_results=False)
         )
@@ -94,9 +96,8 @@ class TestTournament(unittest.TestCase):
                 turns=2,
                 repetitions=2,
             )
-            files.append(
-                axl_filename("test_outputs", "stochastic_tournament_{}.csv".format(_))
-            )
+            path = pathlib.Path("test_outputs/stochastic_tournament_{}.csv".format(_))
+            files.append(axl_filename(path))
             tournament.play(progress_bar=False, filename=files[-1], build_results=False)
         self.assertTrue(filecmp.cmp(files[0], files[1]))
 
@@ -119,9 +120,8 @@ class TestTournament(unittest.TestCase):
                 turns=2,
                 repetitions=2,
             )
-            files.append(
-                axl_filename("test_outputs", "stochastic_tournament_{}.csv".format(_))
-            )
+            path = pathlib.Path("test_outputs/stochastic_tournament_{}.csv".format(_))
+            files.append(axl_filename(path))
             tournament.play(progress_bar=False, filename=files[-1], build_results=False)
         self.assertTrue(filecmp.cmp(files[0], files[1]))
 

--- a/axelrod/tests/integration/test_tournament.py
+++ b/axelrod/tests/integration/test_tournament.py
@@ -4,6 +4,7 @@ import unittest
 from hypothesis import given, settings
 
 import axelrod
+from axelrod.load_data_ import axl_filename
 from axelrod.strategy_transformers import FinalTransformer
 from axelrod.tests.property import tournaments
 
@@ -45,7 +46,7 @@ class TestTournament(unittest.TestCase):
     def test_big_tournaments(self, tournament):
         """A test to check that tournament runs with a sample of non-cheating
         strategies."""
-        filename = "test_outputs/test_tournament.csv"
+        filename = axl_filename("test_outputs/test_tournament.csv")
         self.assertIsNone(
             tournament.play(progress_bar=False, filename=filename, build_results=False)
         )
@@ -90,7 +91,7 @@ class TestTournament(unittest.TestCase):
                 turns=2,
                 repetitions=2,
             )
-            files.append("test_outputs/stochastic_tournament_{}.csv".format(_))
+            files.append(axl_filename("test_outputs/stochastic_tournament_{}.csv".format(_)))
             tournament.play(progress_bar=False, filename=files[-1], build_results=False)
         self.assertTrue(filecmp.cmp(files[0], files[1]))
 
@@ -113,7 +114,7 @@ class TestTournament(unittest.TestCase):
                 turns=2,
                 repetitions=2,
             )
-            files.append("test_outputs/stochastic_tournament_{}.csv".format(_))
+            files.append(axl_filename("test_outputs/stochastic_tournament_{}.csv".format(_)))
             tournament.play(progress_bar=False, filename=files[-1], build_results=False)
         self.assertTrue(filecmp.cmp(files[0], files[1]))
 

--- a/axelrod/tests/unit/test_deterministic_cache.py
+++ b/axelrod/tests/unit/test_deterministic_cache.py
@@ -3,6 +3,7 @@ import pickle
 import unittest
 
 from axelrod import Action, Defector, DeterministicCache, Random, TitForTat
+from axelrod.load_data_ import axl_filename
 
 C, D = Action.C, Action.D
 
@@ -12,8 +13,8 @@ class TestDeterministicCache(unittest.TestCase):
     def setUpClass(cls):
         cls.test_key = (TitForTat(), Defector())
         cls.test_value = [(C, D), (D, D), (D, D)]
-        cls.test_save_file = "test_cache_save.txt"
-        cls.test_load_file = "test_cache_load.txt"
+        cls.test_save_file = axl_filename("test_outputs/test_cache_save.txt")
+        cls.test_load_file = axl_filename("test_outputs/test_cache_load.txt")
         test_data_to_pickle = {("Tit For Tat", "Defector"): [(C, D), (D, D), (D, D)]}
         cls.test_pickle = pickle.dumps(test_data_to_pickle)
 
@@ -92,7 +93,7 @@ class TestDeterministicCache(unittest.TestCase):
         self.assertEqual(self.cache[self.test_key], self.test_value)
 
     def test_load_error_for_inccorect_format(self):
-        filename = "test_outputs/test.cache"
+        filename = axl_filename("test_outputs/test.cache")
         with open(filename, "wb") as io:
             pickle.dump(range(5), io)
 

--- a/axelrod/tests/unit/test_deterministic_cache.py
+++ b/axelrod/tests/unit/test_deterministic_cache.py
@@ -13,8 +13,8 @@ class TestDeterministicCache(unittest.TestCase):
     def setUpClass(cls):
         cls.test_key = (TitForTat(), Defector())
         cls.test_value = [(C, D), (D, D), (D, D)]
-        cls.test_save_file = axl_filename("test_outputs/test_cache_save.txt")
-        cls.test_load_file = axl_filename("test_outputs/test_cache_load.txt")
+        cls.test_save_file = axl_filename("test_outputs", "test_cache_save.txt")
+        cls.test_load_file = axl_filename("test_outputs", "test_cache_load.txt")
         test_data_to_pickle = {("Tit For Tat", "Defector"): [(C, D), (D, D), (D, D)]}
         cls.test_pickle = pickle.dumps(test_data_to_pickle)
 
@@ -93,7 +93,7 @@ class TestDeterministicCache(unittest.TestCase):
         self.assertEqual(self.cache[self.test_key], self.test_value)
 
     def test_load_error_for_inccorect_format(self):
-        filename = axl_filename("test_outputs/test.cache")
+        filename = axl_filename("test_outputs", "test.cache")
         with open(filename, "wb") as io:
             pickle.dump(range(5), io)
 

--- a/axelrod/tests/unit/test_deterministic_cache.py
+++ b/axelrod/tests/unit/test_deterministic_cache.py
@@ -1,5 +1,6 @@
 import unittest
 import os
+import pathlib
 import pickle
 
 import axelrod as axl
@@ -13,8 +14,10 @@ class TestDeterministicCache(unittest.TestCase):
     def setUpClass(cls):
         cls.test_key = (axl.TitForTat(), axl.Defector())
         cls.test_value = [(C, D), (D, D), (D, D)]
-        cls.test_save_file = axl_filename("test_outputs", "test_cache_save.txt")
-        cls.test_load_file = axl_filename("test_outputs", "test_cache_load.txt")
+        save_path = pathlib.Path("test_outputs/test_cache_save.txt")
+        cls.test_save_file = axl_filename(save_path)
+        load_path = pathlib.Path("test_outputs/test_cache_load.txt")
+        cls.test_load_file = axl_filename(load_path)
         test_data_to_pickle = {("Tit For Tat", "Defector"): [(C, D), (D, D), (D, D)]}
         cls.test_pickle = pickle.dumps(test_data_to_pickle)
 
@@ -93,7 +96,8 @@ class TestDeterministicCache(unittest.TestCase):
         self.assertEqual(self.cache[self.test_key], self.test_value)
 
     def test_load_error_for_inccorect_format(self):
-        filename = axl_filename("test_outputs", "test.cache")
+        path = pathlib.Path("test_outputs/test.cache")
+        filename = axl_filename(path)
         with open(filename, "wb") as io:
             pickle.dump(range(5), io)
 

--- a/axelrod/tests/unit/test_fingerprint.py
+++ b/axelrod/tests/unit/test_fingerprint.py
@@ -2,12 +2,10 @@ import unittest
 from unittest.mock import patch
 
 import os
-
 from tempfile import mkstemp
-
 import matplotlib.pyplot
-
 import numpy as np
+import pathlib
 
 import axelrod as axl
 from axelrod.fingerprint import AshlockFingerprint, Point, TransitiveFingerprint
@@ -201,7 +199,8 @@ class TestFingerprint(unittest.TestCase):
 
         RecordedMksTemp.reset_record()
         af = AshlockFingerprint(axl.TitForTat)
-        filename = axl_filename("test_outputs/test_fingerprint.csv")
+        path = pathlib.Path("test_outputs/test_fingerprint.csv")
+        filename = axl_filename(path)
 
         self.assertEqual(RecordedMksTemp.record, [])
 
@@ -217,7 +216,8 @@ class TestFingerprint(unittest.TestCase):
         self.assertFalse(os.path.isfile(filename))
 
     def test_fingerprint_with_filename(self):
-        filename = axl_filename("test_outputs", "test_fingerprint.csv")
+        path = pathlib.Path("test_outputs/test_fingerprint.csv")
+        filename = axl_filename(path)
         af = AshlockFingerprint(axl.TitForTat)
         af.fingerprint(
             turns=1, repetitions=1, step=0.5, progress_bar=False, filename=filename
@@ -431,7 +431,8 @@ class TestTransitiveFingerprint(unittest.TestCase):
         )
 
     def test_fingerprint_with_filename(self):
-        filename = axl_filename("test_outputs", "test_fingerprint.csv")
+        path = pathlib.Path("test_outputs/test_fingerprint.csv")
+        filename = axl_filename(path)
         strategy = axl.TitForTat()
         tf = TransitiveFingerprint(strategy)
         tf.fingerprint(turns=1, repetitions=1, progress_bar=False, filename=filename)
@@ -442,10 +443,11 @@ class TestTransitiveFingerprint(unittest.TestCase):
     def test_serial_fingerprint(self):
         strategy = axl.TitForTat()
         tf = TransitiveFingerprint(strategy)
+        path = pathlib.Path("test_outputs/test_fingerprint.csv")
         tf.fingerprint(
             repetitions=1,
             progress_bar=False,
-            filename=axl_filename("test_outputs", "tran_fin.csv"),
+            filename=axl_filename(path),
         )
         self.assertEqual(tf.data.shape, (50, 50))
 
@@ -458,7 +460,8 @@ class TestTransitiveFingerprint(unittest.TestCase):
 
     def test_analyse_cooperation_ratio(self):
         tf = TransitiveFingerprint(axl.TitForTat)
-        filename = axl_filename("test_outputs", "test_fingerprint.csv")
+        path = pathlib.Path("test_outputs/test_fingerprint.csv")
+        filename = axl_filename(path)
         with open(filename, "w") as f:
             f.write(
                 """Interaction index,Player index,Opponent index,Repetition,Player name,Opponent name,Actions

--- a/axelrod/tests/unit/test_fingerprint.py
+++ b/axelrod/tests/unit/test_fingerprint.py
@@ -212,7 +212,7 @@ class TestFingerprint(unittest.TestCase):
         self.assertFalse(os.path.isfile(filename))
 
     def test_fingerprint_with_filename(self):
-        filename = axl_filename("test_outputs/test_fingerprint.csv")
+        filename = axl_filename("test_outputs", "test_fingerprint.csv")
         af = AshlockFingerprint(axl.TitForTat)
         af.fingerprint(
             turns=1, repetitions=1, step=0.5, progress_bar=False, filename=filename
@@ -426,7 +426,7 @@ class TestTransitiveFingerprint(unittest.TestCase):
         )
 
     def test_fingerprint_with_filename(self):
-        filename = axl_filename("test_outputs/test_fingerprint.csv")
+        filename = axl_filename("test_outputs", "test_fingerprint.csv")
         strategy = axl.TitForTat()
         tf = TransitiveFingerprint(strategy)
         tf.fingerprint(turns=1, repetitions=1, progress_bar=False, filename=filename)
@@ -440,7 +440,7 @@ class TestTransitiveFingerprint(unittest.TestCase):
         tf.fingerprint(
             repetitions=1,
             progress_bar=False,
-            filename=axl_filename("test_outputs/tran_fin.csv"),
+            filename=axl_filename("test_outputs", "tran_fin.csv"),
         )
         self.assertEqual(tf.data.shape, (50, 50))
 
@@ -453,7 +453,7 @@ class TestTransitiveFingerprint(unittest.TestCase):
 
     def test_analyse_cooperation_ratio(self):
         tf = TransitiveFingerprint(axl.TitForTat)
-        filename = axl_filename("test_outputs/test_fingerprint.csv")
+        filename = axl_filename("test_outputs", "test_fingerprint.csv")
         with open(filename, "w") as f:
             f.write(
                 """Interaction index,Player index,Opponent index,Repetition,Player name,Opponent name,Actions

--- a/axelrod/tests/unit/test_fingerprint.py
+++ b/axelrod/tests/unit/test_fingerprint.py
@@ -9,6 +9,7 @@ from hypothesis import given, settings
 
 import axelrod as axl
 from axelrod.fingerprint import AshlockFingerprint, Point, TransitiveFingerprint
+from axelrod.load_data_ import axl_filename
 from axelrod.strategy_transformers import DualTransformer, JossAnnTransformer
 from axelrod.tests.property import strategy_lists
 
@@ -195,7 +196,7 @@ class TestFingerprint(unittest.TestCase):
 
         RecordedMksTemp.reset_record()
         af = AshlockFingerprint(axl.TitForTat)
-        filename = "test_outputs/test_fingerprint.csv"
+        filename = axl_filename("test_outputs/test_fingerprint.csv")
 
         self.assertEqual(RecordedMksTemp.record, [])
 
@@ -211,7 +212,7 @@ class TestFingerprint(unittest.TestCase):
         self.assertFalse(os.path.isfile(filename))
 
     def test_fingerprint_with_filename(self):
-        filename = "test_outputs/test_fingerprint.csv"
+        filename = axl_filename("test_outputs/test_fingerprint.csv")
         af = AshlockFingerprint(axl.TitForTat)
         af.fingerprint(
             turns=1, repetitions=1, step=0.5, progress_bar=False, filename=filename
@@ -425,7 +426,7 @@ class TestTransitiveFingerprint(unittest.TestCase):
         )
 
     def test_fingerprint_with_filename(self):
-        filename = "test_outputs/test_fingerprint.csv"
+        filename = axl_filename("test_outputs/test_fingerprint.csv")
         strategy = axl.TitForTat()
         tf = TransitiveFingerprint(strategy)
         tf.fingerprint(turns=1, repetitions=1, progress_bar=False, filename=filename)
@@ -437,7 +438,9 @@ class TestTransitiveFingerprint(unittest.TestCase):
         strategy = axl.TitForTat()
         tf = TransitiveFingerprint(strategy)
         tf.fingerprint(
-            repetitions=1, progress_bar=False, filename="test_outputs/tran_fin.csv"
+            repetitions=1,
+            progress_bar=False,
+            filename=axl_filename("test_outputs/tran_fin.csv"),
         )
         self.assertEqual(tf.data.shape, (50, 50))
 
@@ -450,7 +453,7 @@ class TestTransitiveFingerprint(unittest.TestCase):
 
     def test_analyse_cooperation_ratio(self):
         tf = TransitiveFingerprint(axl.TitForTat)
-        filename = "test_outputs/test_fingerprint.csv"
+        filename = axl_filename("test_outputs/test_fingerprint.csv")
         with open(filename, "w") as f:
             f.write(
                 """Interaction index,Player index,Opponent index,Repetition,Player name,Opponent name,Actions

--- a/axelrod/tests/unit/test_load_data.py
+++ b/axelrod/tests/unit/test_load_data.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import unittest
 
 from axelrod.load_data_ import axl_filename
@@ -6,7 +7,8 @@ from axelrod.load_data_ import axl_filename
 
 class TestLoadData(unittest.TestCase):
     def test_axl_filename(self):
-        actual_fn = axl_filename("axelrod/strategies/titfortat.py")
+        path = pathlib.Path("axelrod/strategies/titfortat.py")
+        actual_fn = axl_filename(path)
 
         # First go from "unit" up to "tests", then up to "axelrod"
         dirname = os.path.dirname(__file__)

--- a/axelrod/tests/unit/test_load_data.py
+++ b/axelrod/tests/unit/test_load_data.py
@@ -1,0 +1,15 @@
+import os
+import unittest
+
+from axelrod.load_data_ import axl_filename
+
+
+class TestLoadData(unittest.TestCase):
+    def test_axl_filename(self):
+        actual_fn = axl_filename("axelrod/strategies/titfortat.py")
+
+        # First go from "unit" up to "tests", then up to "axelrod"
+        dirname = os.path.dirname(__file__)
+        expected_fn = os.path.join(dirname, "../../strategies/titfortat.py")
+
+        self.assertTrue(os.path.samefile(actual_fn, expected_fn))

--- a/axelrod/tests/unit/test_plot.py
+++ b/axelrod/tests/unit/test_plot.py
@@ -3,6 +3,7 @@ import unittest
 import tempfile
 import matplotlib
 import matplotlib.pyplot as plt
+import pathlib
 
 from numpy import mean
 
@@ -13,7 +14,8 @@ from axelrod.load_data_ import axl_filename
 class TestPlot(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.filename = axl_filename("test_outputs", "test_results.csv")
+        path = pathlib.Path("test_outputs/test_results.csv")
+        cls.filename = axl_filename(path)
 
         cls.players = [axl.Alternator(), axl.TitForTat(), axl.Defector()]
         cls.repetitions = 3

--- a/axelrod/tests/unit/test_plot.py
+++ b/axelrod/tests/unit/test_plot.py
@@ -2,6 +2,7 @@ import tempfile
 import unittest
 
 import axelrod
+from axelrod.load_data_ import axl_filename
 import matplotlib
 import matplotlib.pyplot as plt
 from numpy import mean
@@ -10,7 +11,7 @@ from numpy import mean
 class TestPlot(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.filename = "test_outputs/test_results.csv"
+        cls.filename = axl_filename("test_outputs/test_results.csv")
 
         cls.players = [axelrod.Alternator(), axelrod.TitForTat(), axelrod.Defector()]
         cls.repetitions = 3

--- a/axelrod/tests/unit/test_plot.py
+++ b/axelrod/tests/unit/test_plot.py
@@ -11,7 +11,7 @@ from numpy import mean
 class TestPlot(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.filename = axl_filename("test_outputs/test_results.csv")
+        cls.filename = axl_filename("test_outputs", "test_results.csv")
 
         cls.players = [axelrod.Alternator(), axelrod.TitForTat(), axelrod.Defector()]
         cls.repetitions = 3

--- a/axelrod/tests/unit/test_resultset.py
+++ b/axelrod/tests/unit/test_resultset.py
@@ -5,6 +5,7 @@ from collections import Counter
 import axelrod
 import axelrod.interaction_utils as iu
 import pandas as pd
+from axelrod.load_data_ import axl_filename
 from axelrod.result_set import create_counter_dict
 from axelrod.tests.property import prob_end_tournaments, tournaments
 from numpy import mean, nanmedian, std
@@ -19,7 +20,7 @@ class TestResultSet(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
 
-        cls.filename = "test_outputs/test_results.csv"
+        cls.filename = axl_filename("test_outputs/test_results.csv")
 
         cls.players = [axelrod.Alternator(), axelrod.TitForTat(), axelrod.Defector()]
         cls.repetitions = 3
@@ -647,7 +648,7 @@ class TestResultSetSpatialStructure(TestResultSet):
     @classmethod
     def setUpClass(cls):
 
-        cls.filename = "test_outputs/test_results_spatial.csv"
+        cls.filename = axl_filename("test_outputs/test_results_spatial.csv")
         cls.players = [axelrod.Alternator(), axelrod.TitForTat(), axelrod.Defector()]
         cls.turns = 5
         cls.edges = [(0, 1), (0, 2)]

--- a/axelrod/tests/unit/test_resultset.py
+++ b/axelrod/tests/unit/test_resultset.py
@@ -648,7 +648,7 @@ class TestResultSetSpatialStructure(TestResultSet):
     @classmethod
     def setUpClass(cls):
 
-        cls.filename = axl_filename("test_outputs/test_results_spatial.csv")
+        cls.filename = axl_filename("test_outputs", "test_results_spatial.csv")
         cls.players = [axelrod.Alternator(), axelrod.TitForTat(), axelrod.Defector()]
         cls.turns = 5
         cls.edges = [(0, 1), (0, 2)]

--- a/axelrod/tests/unit/test_resultset.py
+++ b/axelrod/tests/unit/test_resultset.py
@@ -4,6 +4,7 @@ from collections import Counter
 import pandas as pd
 from dask.dataframe.core import DataFrame
 from numpy import mean, nanmedian, std
+import pathlib
 
 import axelrod as axl
 from axelrod.load_data_ import axl_filename
@@ -19,7 +20,8 @@ class TestResultSet(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
 
-        cls.filename = axl_filename("test_outputs", "test_results.csv")
+        path = pathlib.Path("test_outputs/test_results.csv")
+        cls.filename = str(axl_filename(path))
 
         cls.players = [axl.Alternator(), axl.TitForTat(), axl.Defector()]
         cls.repetitions = 3
@@ -677,7 +679,8 @@ class TestResultSetSpatialStructure(TestResultSet):
     @classmethod
     def setUpClass(cls):
 
-        cls.filename = axl_filename("test_outputs", "test_results_spatial.csv")
+        path = pathlib.Path("test_outputs/test_results_spatial.csv")
+        cls.filename = str(axl_filename(path))
         cls.players = [axl.Alternator(), axl.TitForTat(), axl.Defector()]
         cls.turns = 5
         cls.edges = [(0, 1), (0, 2)]
@@ -857,7 +860,8 @@ class TestResultSetSpatialStructureTwo(TestResultSetSpatialStructure):
     @classmethod
     def setUpClass(cls):
 
-        cls.filename = axl_filename("test_outputs", "test_results_spatial_two.csv")
+        path = pathlib.Path("test_outputs/test_results_spatial_two.csv")
+        cls.filename = str(axl_filename(path))
         cls.players = [
             axl.Alternator(),
             axl.TitForTat(),
@@ -1058,7 +1062,8 @@ class TestResultSetSpatialStructureThree(TestResultSetSpatialStructure):
     @classmethod
     def setUpClass(cls):
 
-        cls.filename = axl_filename("test_outputs", "test_results_spatial_three.csv")
+        path = pathlib.Path("test_outputs/test_results_spatial_three.csv")
+        cls.filename = str(axl_filename(path))
         cls.players = [
             axl.Alternator(),
             axl.TitForTat(),

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -12,6 +12,7 @@ from multiprocessing import Queue, cpu_count
 from unittest.mock import MagicMock, patch
 
 import axelrod
+from axelrod.load_data_ import axl_filename
 import numpy as np
 import pandas as pd
 from axelrod.tests.property import (
@@ -88,7 +89,7 @@ class TestTournament(unittest.TestCase):
             [200, 200, 1, 200, 200],
         ]
 
-        cls.filename = "test_outputs/test_tournament.csv"
+        cls.filename = axl_filename("test_outputs/test_tournament.csv")
 
     def setUp(self):
         self.test_tournament = axelrod.Tournament(
@@ -733,7 +734,9 @@ class TestTournament(unittest.TestCase):
         )
         tournament.play(filename=self.filename, progress_bar=False)
         df = pd.read_csv(self.filename)
-        expected_df = pd.read_csv("test_outputs/expected_test_tournament.csv")
+        expected_df = pd.read_csv(
+            axl_filename("test_outputs/expected_test_tournament.csv")
+        )
         self.assertTrue(df.equals(expected_df))
 
     def test_write_to_csv_without_results(self):
@@ -747,7 +750,7 @@ class TestTournament(unittest.TestCase):
         tournament.play(filename=self.filename, progress_bar=False, build_results=False)
         df = pd.read_csv(self.filename)
         expected_df = pd.read_csv(
-            "test_outputs/expected_test_tournament_no_results.csv"
+            axl_filename("test_outputs/expected_test_tournament_no_results.csv")
         )
         self.assertTrue(df.equals(expected_df))
 

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -89,7 +89,7 @@ class TestTournament(unittest.TestCase):
             [200, 200, 1, 200, 200],
         ]
 
-        cls.filename = axl_filename("test_outputs/test_tournament.csv")
+        cls.filename = axl_filename("test_outputs", "test_tournament.csv")
 
     def setUp(self):
         self.test_tournament = axelrod.Tournament(
@@ -735,7 +735,7 @@ class TestTournament(unittest.TestCase):
         tournament.play(filename=self.filename, progress_bar=False)
         df = pd.read_csv(self.filename)
         expected_df = pd.read_csv(
-            axl_filename("test_outputs/expected_test_tournament.csv")
+            axl_filename("test_outputs", "expected_test_tournament.csv")
         )
         self.assertTrue(df.equals(expected_df))
 
@@ -750,7 +750,7 @@ class TestTournament(unittest.TestCase):
         tournament.play(filename=self.filename, progress_bar=False, build_results=False)
         df = pd.read_csv(self.filename)
         expected_df = pd.read_csv(
-            axl_filename("test_outputs/expected_test_tournament_no_results.csv")
+            axl_filename("test_outputs", "expected_test_tournament_no_results.csv")
         )
         self.assertTrue(df.equals(expected_df))
 

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -7,6 +7,7 @@ import filecmp
 import io
 import logging
 import os
+import pathlib
 import pickle
 import warnings
 from multiprocessing import Queue, cpu_count
@@ -90,7 +91,8 @@ class TestTournament(unittest.TestCase):
             [200, 200, 1, 200, 200],
         ]
 
-        cls.filename = axl_filename("test_outputs", "test_tournament.csv")
+        path = pathlib.Path("test_outputs/test_tournament.csv")
+        cls.filename = axl_filename(path)
 
     def setUp(self):
         self.test_tournament = axl.Tournament(
@@ -110,9 +112,7 @@ class TestTournament(unittest.TestCase):
             noise=0.2,
         )
         self.assertEqual(len(tournament.players), len(test_strategies))
-        self.assertIsInstance(
-            tournament.players[0].match_attributes["game"], axl.Game
-        )
+        self.assertIsInstance(tournament.players[0].match_attributes["game"], axl.Game)
         self.assertEqual(tournament.game.score((C, C)), (3, 3))
         self.assertEqual(tournament.turns, self.test_turns)
         self.assertEqual(tournament.repetitions, 10)
@@ -415,9 +415,7 @@ class TestTournament(unittest.TestCase):
     # these two examples were identified by hypothesis.
     @example(
         tournament=axl.Tournament(
-            players=[axl.BackStabber(), axl.MindReader()],
-            turns=2,
-            repetitions=1,
+            players=[axl.BackStabber(), axl.MindReader()], turns=2, repetitions=1,
         )
     )
     @example(
@@ -735,9 +733,8 @@ class TestTournament(unittest.TestCase):
         )
         tournament.play(filename=self.filename, progress_bar=False)
         df = pd.read_csv(self.filename)
-        expected_df = pd.read_csv(
-            axl_filename("test_outputs", "expected_test_tournament.csv")
-        )
+        path = pathlib.Path("test_outputs/expected_test_tournament.csv")
+        expected_df = pd.read_csv(axl_filename(path))
         self.assertTrue(df.equals(expected_df))
 
     def test_write_to_csv_without_results(self):
@@ -750,9 +747,8 @@ class TestTournament(unittest.TestCase):
         )
         tournament.play(filename=self.filename, progress_bar=False, build_results=False)
         df = pd.read_csv(self.filename)
-        expected_df = pd.read_csv(
-            axl_filename("test_outputs", "expected_test_tournament_no_results.csv")
-        )
+        path = pathlib.Path("test_outputs/expected_test_tournament_no_results.csv")
+        expected_df = pd.read_csv(axl_filename(path))
         self.assertTrue(df.equals(expected_df))
 
 
@@ -808,16 +804,12 @@ class TestProbEndTournament(unittest.TestCase):
     # these two examples were identified by hypothesis.
     @example(
         tournament=axl.Tournament(
-            players=[axl.BackStabber(), axl.MindReader()],
-            prob_end=0.2,
-            repetitions=1,
+            players=[axl.BackStabber(), axl.MindReader()], prob_end=0.2, repetitions=1,
         )
     )
     @example(
         tournament=axl.Tournament(
-            players=[axl.ThueMorse(), axl.MindReader()],
-            prob_end=0.2,
-            repetitions=1,
+            players=[axl.ThueMorse(), axl.MindReader()], prob_end=0.2, repetitions=1,
         )
     )
     def test_property_serial_play(self, tournament):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ hypothesis==3.2
 matplotlib>=2.0.0
 numpy>=1.9.2
 pandas>=0.18.1
+pathlib>=1.0.1
 prompt-toolkit>=1.0.7
 scipy>=0.19.0
 toolz>=0.8.0


### PR DESCRIPTION
A lot of the file reads and writes are causing me problems because my IDE tries to run logic from the location where the file is located, and the code is written to only be run from the top-level directory.  I could see a new user being thrown by this too.

This change makes paths a little more robust, by accounting for the path the user is actually in.