### PR TITLE
Mock yaml in documentation for rtd

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,6 +43,7 @@ MOCK_MODULES = [
     "toolz.curried",
     "toolz.functoolz",
     "tqdm",
+    "yaml",
 ]
 
 for mod_name in MOCK_MODULES:


### PR DESCRIPTION
Closes #1311 

You can see the build on https://axelrod.readthedocs.io/en/fix-documentation/reference/overview_of_strategies.html#beaufils-et-al-s-tournament-1997

This is a bug fix, I'll do a new release once it's in.