### PR TITLE
Update the nbr of strategies in first page of docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,8 +8,8 @@ Welcome to the documentation for the Axelrod Python library
 
 Here is quick overview of the current capabilities of the library:
 
-* Over 230 strategies including from the literature and some exciting original
-  contributions
+* Over 230 strategies including many from the literature and exciting
+  original contributions
 
     * Classic strategies like TiT-For-Tat, WSLS, and variants
     * Zero-Determinant and other Memory-One strategies

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ Welcome to the documentation for the Axelrod Python library
 
 Here is quick overview of the current capabilities of the library:
 
-* Over 100 strategies from the literature and some exciting original
+* Over 230 strategies including from the literature and some exciting original
   contributions
 
     * Classic strategies like TiT-For-Tat, WSLS, and variants


### PR DESCRIPTION
Running `len(axelrod.strategies)` gives 235 :)

Genuinely not sure if I've got my grammar right in this sentence so please do suggest something else. I just wanted to bump the number :)