### PR TITLE
Fix RevisedDowning

### DIFF
--- a/axelrod/strategies/revised_downing.py
+++ b/axelrod/strategies/revised_downing.py
@@ -52,7 +52,7 @@ class RevisedDowning(Player):
 
         # Update various counts
         if round_number > 2:
-            if self.history[-1] == D:
+            if self.history[-2] == D:
                 if opponent.history[-1] == C:
                     self.nice2 += 1
                 self.total_D += 1

--- a/axelrod/tests/strategies/test_revised_downing.py
+++ b/axelrod/tests/strategies/test_revised_downing.py
@@ -30,11 +30,11 @@ class TestRevisedDowning(TestPlayer):
         self.versus_test(opponent, expected_actions=actions)
 
         opponent = axl.MockPlayer(actions=[D, D, C])
-        actions = [(C, D), (C, D), (D, C), (D, D)]
+        actions = [(C, D), (C, D), (D, C), (C, D)]
         self.versus_test(opponent, expected_actions=actions)
 
         opponent = axl.MockPlayer(actions=[C, C, D, D, C, C])
-        actions = [(C, C), (C, C), (C, D), (C, D), (D, C), (D, C), (D, C)]
+        actions = [(C, C), (C, C), (C, D), (C, D), (D, C), (C, C), (D, C)]
         self.versus_test(opponent, expected_actions=actions)
 
         opponent = axl.MockPlayer(actions=[C, C, C, C, D, D])


### PR DESCRIPTION
Fixes https://github.com/Axelrod-Python/Axelrod/issues/1279

It looks like when the fortran was translated to python, PAST was changed to self.history[-1]. Because of where it's set in the fortran, it should actually be self.history[-2].

https://github.com/Axelrod-Python/TourExec/blob/master/src/strategies/K59R.f#L35
https://github.com/Axelrod-Python/Axelrod/blob/master/axelrod/strategies/revised_downing.py#L55

This was tested with axelrod_fortran.