### PR TITLE
Add documentation about hypothesis

### DIFF
--- a/docs/tutorials/contributing/running_tests.rst
+++ b/docs/tutorials/contributing/running_tests.rst
@@ -4,6 +4,10 @@ Running tests
 Basic test runners
 ------------------
 
+Before running tests, you should have hypothesis 3.2 installed::
+
+    $ pip install hypothesis==3.2
+
 The project has an extensive test suite which is run each time a new
 contribution is made to the repository.  If you want to check that all the tests
 pass before you submit a pull request you can run the tests yourself::


### PR DESCRIPTION
After removing from requirements, hypothesis isn't automatically installed.  This may cause confusion, especially since we require a very specific version of hypothesis.  Here I add a note in the Running Tests documentation.