### PR TITLE
Change classifier test to call Classifiers

### DIFF
--- a/axelrod/tests/strategies/test_gambler.py
+++ b/axelrod/tests/strategies/test_gambler.py
@@ -35,7 +35,6 @@ class TestGambler(TestPlayer):
     }
 
     expected_class_classifier = copy.copy(expected_classifier)
-    expected_class_classifier["memory_depth"] = float("inf")
 
     def test_strategy(self):
         tft_table = {((), (D,), ()): 0, ((), (C,), ()): 1}
@@ -71,7 +70,6 @@ class TestPSOGamblerMem1(TestPlayer):
         "manipulates_state": False,
     }
     expected_class_classifier = copy.copy(expected_classifier)
-    expected_class_classifier["memory_depth"] = float("inf")
 
     def test_new_data(self):
         original_data = {

--- a/axelrod/tests/strategies/test_lookerup.py
+++ b/axelrod/tests/strategies/test_lookerup.py
@@ -200,7 +200,6 @@ class TestLookerUp(TestPlayer):
     }
 
     expected_class_classifier = copy.copy(expected_classifier)
-    expected_class_classifier["memory_depth"] = float("inf")
 
     def test_default_init(self):
         player = self.player()
@@ -545,7 +544,6 @@ class TestWinner12(TestPlayer):
     }
 
     expected_class_classifier = copy.copy(expected_classifier)
-    expected_class_classifier["memory_depth"] = float("inf")
 
     def test_new_data(self):
         original_data = {
@@ -588,7 +586,6 @@ class TestWinner21(TestPlayer):
     }
 
     expected_class_classifier = copy.copy(expected_classifier)
-    expected_class_classifier["memory_depth"] = float("inf")
 
     def test_new_data(self):
         original_data = {

--- a/axelrod/tests/strategies/test_player.py
+++ b/axelrod/tests/strategies/test_player.py
@@ -93,10 +93,12 @@ class TestPlayerClass(unittest.TestCase):
         match = axl.Match((player1, player2), turns=5)
         _ = match.play()
         self.assertEqual(
-            player1.state_distribution, {(C, C): 1, (C, D): 2, (D, C): 1, (D, D): 1}
+            player1.state_distribution,
+            {(C, C): 1, (C, D): 2, (D, C): 1, (D, D): 1},
         )
         self.assertEqual(
-            player2.state_distribution, {(C, C): 1, (C, D): 1, (D, C): 2, (D, D): 1}
+            player2.state_distribution,
+            {(C, C): 1, (C, D): 1, (D, C): 2, (D, D): 1},
         )
 
     def test_noisy_play(self):
@@ -129,7 +131,9 @@ class TestPlayerClass(unittest.TestCase):
             player.history = []
 
     def test_strategy(self):
-        self.assertRaises(NotImplementedError, self.player().strategy, self.player())
+        self.assertRaises(
+            NotImplementedError, self.player().strategy, self.player()
+        )
 
     def test_clone(self):
         """Tests player cloning."""
@@ -345,7 +349,9 @@ class TestPlayerClass(unittest.TestCase):
         # Test that passing an unknown keyword argument or a spare one raises
         # an error.
         self.assertRaises(TypeError, ParameterisedTestPlayer, arg_test3="test")
-        self.assertRaises(TypeError, ParameterisedTestPlayer, "other", "other", "other")
+        self.assertRaises(
+            TypeError, ParameterisedTestPlayer, "other", "other", "other"
+        )
 
 
 class TestOpponent(axl.Player):
@@ -496,7 +502,9 @@ class TestPlayer(unittest.TestCase):
             self.assertEqual(player1.history, player2.history)
 
     @given(
-        strategies=strategy_lists(max_size=5, strategies=short_run_time_short_mem),
+        strategies=strategy_lists(
+            max_size=5, strategies=short_run_time_short_mem
+        ),
         seed=integers(min_value=1, max_value=200),
         turns=integers(min_value=1, max_value=200),
     )
@@ -544,10 +552,8 @@ class TestPlayer(unittest.TestCase):
     ):
         """
         Tests a sequence of outcomes for two given players.
-
         Parameters:
         -----------
-
         opponent: Player or list
             An instance of a player OR a sequence of actions. If a sequence of
             actions is passed, a Mock Player is created that cycles over that
@@ -605,20 +611,30 @@ class TestPlayer(unittest.TestCase):
         # specified
         if expected_class_classifier is None:
             expected_class_classifier = player.classifier
-        self.assertEqual(expected_class_classifier, self.player.classifier)
+        actual_class_classifier = {
+            c: axl.Classifiers[c](player)
+            for c in expected_class_classifier.keys()
+        }
+        self.assertEqual(expected_class_classifier, actual_class_classifier)
 
         self.assertTrue(
-            "memory_depth" in player.classifier, msg="memory_depth not in classifier"
+            "memory_depth" in player.classifier,
+            msg="memory_depth not in classifier",
         )
         self.assertTrue(
-            "stochastic" in player.classifier, msg="stochastic not in classifier"
+            "stochastic" in player.classifier,
+            msg="stochastic not in classifier",
         )
         for key in TestOpponent.classifier:
             self.assertEqual(
                 axl.Classifiers[key](player),
                 self.expected_classifier[key],
                 msg="%s - Behaviour: %s != Expected Behaviour: %s"
-                % (key, axl.Classifiers[key](player), self.expected_classifier[key]),
+                    % (
+                        key,
+                        axl.Classifiers[key](player),
+                        self.expected_classifier[key],
+                    ),
             )
 
 

--- a/axelrod/tests/strategies/test_titfortat.py
+++ b/axelrod/tests/strategies/test_titfortat.py
@@ -956,7 +956,6 @@ class TestNTitsForMTats(TestPlayer):
     }
 
     expected_class_classifier = copy.copy(expected_classifier)
-    expected_class_classifier["memory_depth"] = float("inf")
 
     def test_strategy(self):
         # TitForTat test_strategy


### PR DESCRIPTION
classifier_test in test_player was using dictionaries instead of the Classifiers class.  This error was masked because all classifiers currently match the dictionaries.  In the future, we will use formulas for some of the classifiers.

In addition to the changes on test_player, I removed some lines which altered expected classifiers to incorrect values.  These lines accounted for the fact that the memory_depth was sometimes set on initializing.  The new Classifiers paradigm can account for this.