### PR TITLE
Standardize tests for memoryone and memorytwo files.

### DIFF
--- a/axelrod/data/all_classifiers.yml
+++ b/axelrod/data/all_classifiers.yml
@@ -1220,6 +1220,14 @@ Opposite Grudger:
   manipulates_state: false
   memory_depth: .inf
   stochastic: false
+Original Gradual:
+  inspects_source: false
+  long_run_time: false
+  makes_use_of: !!set {}
+  manipulates_source: false
+  manipulates_state: false
+  memory_depth: .inf
+  stochastic: false
 PSO Gambler 1_1_1:
   inspects_source: false
   long_run_time: false

--- a/axelrod/strategies/memoryone.py
+++ b/axelrod/strategies/memoryone.py
@@ -73,8 +73,6 @@ class MemoryOnePlayer(Player):
             warnings.warn("Memory one player is set to default (1, 0, 0, 1).")
 
         self.set_four_vector(four_vector)
-        if self.name == "Generic Memory One Player":
-            self.name = "%s: %s" % (self.name, four_vector)
 
     def set_four_vector(self, four_vector: Tuple[float, float, float, float]):
         if not all(0 <= p <= 1 for p in four_vector):
@@ -340,4 +338,3 @@ class ReactivePlayer(MemoryOnePlayer):
     def __init__(self, probabilities: Tuple[float, float]) -> None:
         four_vector = (*probabilities, *probabilities)
         super().__init__(four_vector)
-        self.name = "%s: %s" % (self.name, probabilities)

--- a/axelrod/strategies/memorytwo.py
+++ b/axelrod/strategies/memorytwo.py
@@ -2,7 +2,7 @@
 
 import itertools
 import warnings
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
 
 from axelrod.action import Action
 from axelrod.player import Player
@@ -55,7 +55,7 @@ class MemoryTwoPlayer(Player):
     }
 
     def __init__(
-        self, sixteen_vector: Tuple[float, ...] = None, initial: Action = C
+        self, sixteen_vector: Tuple[float, ...] = None, initial: Optional[Action] = None
     ) -> None:
         """
         Parameters
@@ -67,6 +67,8 @@ class MemoryTwoPlayer(Player):
             The initial 2 moves
         """
         super().__init__()
+        if initial is None:
+            initial = C
         self._initial = initial
         self.set_initial_sixteen_vector(sixteen_vector)
 
@@ -76,8 +78,6 @@ class MemoryTwoPlayer(Player):
             warnings.warn("Memory two player is set to default, Cooperator.")
 
         self.set_sixteen_vector(sixteen_vector)
-        if self.name == "Generic Memory Two Player":
-            self.name = "%s: %s" % (self.name, sixteen_vector)
 
     def set_sixteen_vector(self, sixteen_vector: Tuple):
         if not all(0 <= p <= 1 for p in sixteen_vector):
@@ -127,7 +127,7 @@ class AON2(MemoryTwoPlayer):
 
     In [Hilbe2017]_ the following vectors are reported as "equivalent" to AON2
     with their respective self-cooperation rate (note that these are not the same):
-    
+
     1. [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1], self-cooperation
     rate: 0.952
     2. [1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1], self-cooperation

--- a/axelrod/tests/strategies/test_memoryone.py
+++ b/axelrod/tests/strategies/test_memoryone.py
@@ -10,25 +10,6 @@ from .test_player import TestPlayer, test_four_vector
 C, D = axl.Action.C, axl.Action.D
 
 
-class TestGenericPlayerOne(unittest.TestCase):
-    """A class to test the naming and classification of generic memory one
-    players."""
-
-    p1 = axl.MemoryOnePlayer(four_vector=(0, 0, 0, 0))
-    p2 = axl.MemoryOnePlayer(four_vector=(1, 0, 1, 0))
-    p3 = axl.MemoryOnePlayer(four_vector=(1, 0.5, 1, 0.5))
-
-    def test_name(self):
-        self.assertEqual(self.p1.name, "Generic Memory One Player: (0, 0, 0, 0)")
-        self.assertEqual(self.p2.name, "Generic Memory One Player: (1, 0, 1, 0)")
-        self.assertEqual(self.p3.name, "Generic Memory One Player: (1, 0.5, 1, 0.5)")
-
-    def test_stochastic_classification(self):
-        self.assertFalse(axl.Classifiers["stochastic"](self.p1))
-        self.assertFalse(axl.Classifiers["stochastic"](self.p2))
-        self.assertTrue(axl.Classifiers["stochastic"](self.p3))
-
-
 class TestWinStayLoseShift(TestPlayer):
 
     name = "Win-Stay Lose-Shift: C"
@@ -292,11 +273,6 @@ class TestGenericReactiveStrategy(unittest.TestCase):
     p2 = axl.ReactivePlayer(probabilities=(1, 0))
     p3 = axl.ReactivePlayer(probabilities=(1, 0.5))
 
-    def test_name(self):
-        self.assertEqual(self.p1.name, "Reactive Player: (0, 0)")
-        self.assertEqual(self.p2.name, "Reactive Player: (1, 0)")
-        self.assertEqual(self.p3.name, "Reactive Player: (1, 0.5)")
-
     def test_four_vector(self):
         self.assertEqual(
             self.p1._four_vector, {(C, D): 0.0, (D, C): 0.0, (C, C): 0.0, (D, D): 0.0}
@@ -307,11 +283,6 @@ class TestGenericReactiveStrategy(unittest.TestCase):
         self.assertEqual(
             self.p3._four_vector, {(C, D): 0.5, (D, C): 1.0, (C, C): 1.0, (D, D): 0.5}
         )
-
-    def test_stochastic_classification(self):
-        self.assertFalse(axl.Classifiers["stochastic"](self.p1))
-        self.assertFalse(axl.Classifiers["stochastic"](self.p2))
-        self.assertTrue(axl.Classifiers["stochastic"](self.p3))
 
     def test_subclass(self):
         self.assertIsInstance(self.p1, MemoryOnePlayer)

--- a/axelrod/tests/strategies/test_memorytwo.py
+++ b/axelrod/tests/strategies/test_memorytwo.py
@@ -14,67 +14,6 @@ from .test_player import TestPlayer
 C, D = axl.Action.C, axl.Action.D
 
 
-class TestGenericPlayerTwo(unittest.TestCase):
-    """A class to test the naming and classification of generic memory two
-    players."""
-
-    p1 = MemoryTwoPlayer(
-        sixteen_vector=(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-    )
-    p2 = MemoryTwoPlayer(
-        sixteen_vector=(1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0)
-    )
-    p3 = MemoryTwoPlayer(
-        sixteen_vector=(
-            0.5,
-            0.5,
-            0.5,
-            0.5,
-            0.5,
-            0.5,
-            0.5,
-            0.5,
-            0.5,
-            0.5,
-            0.5,
-            0.5,
-            0.5,
-            0.5,
-            0.5,
-            0.5,
-        )
-    )
-    p4 = MemoryTwoPlayer(
-        sixteen_vector=(0.1, 0, 0.2, 0, 0.3, 0, 0.4, 0, 0.5, 0, 0.6, 0, 0.7, 0, 0.8, 0)
-    )
-
-    def test_name(self):
-        self.assertEqual(
-            self.p1.name,
-            "Generic Memory Two Player: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)",
-        )
-        self.assertEqual(
-            self.p2.name,
-            "Generic Memory Two Player: (1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0)",
-        )
-        self.assertEqual(
-            self.p3.name,
-            "Generic Memory Two Player: (0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5)",
-        )
-        self.assertEqual(
-            self.p4.name,
-            "Generic Memory Two Player: (0.1, 0, 0.2, 0, 0.3, 0, 0.4, 0, 0.5, 0, 0.6, 0, 0.7, 0, 0.8, 0)",
-        )
-
-    def test_deterministic_classification(self):
-        self.assertFalse(axl.Classifiers["stochastic"](self.p1))
-        self.assertFalse(axl.Classifiers["stochastic"](self.p2))
-
-    def test_stochastic_classification(self):
-        self.assertTrue(axl.Classifiers["stochastic"](self.p3))
-        self.assertTrue(axl.Classifiers["stochastic"](self.p4))
-
-
 class TestMemoryTwoPlayer(unittest.TestCase):
     def test_default_if_four_vector_not_set(self):
         player = MemoryTwoPlayer()
@@ -142,7 +81,7 @@ class TestMemoryTwoPlayer(unittest.TestCase):
 
 class TestMemoryStochastic(TestPlayer):
     name = (
-        "Generic Memory Two Player: (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1): C"
+        "Generic Memory Two Player"
     )
     player = axl.MemoryTwoPlayer
     expected_classifier = {


### PR DESCRIPTION
The memoryone and memorytwo strategy files were doing some unusual things in the test files.  It seems like they were trying to duplicate some functionality in Player's repr and in TestPlayers tests.  This was causing problems with Classifiers logic.  Details:

Code was changing name on initialization to include the parameter that the strategy was used with.  name is only used in two places:  for __repr__ and for Classifiers.  __repr__ already attaches the initialization parameters, and Classifiers was getting messed up because instances had a different name than the class.  By making this change we make the strategy behave consistently with other strategies.

I removed test_name from these unittests because this is covered by test_repr in TestPlayer.  It's true that test_play in these tests covers __repr__ for strategies initialized with specific parameters, but we can rely on the unittests that cover a general Player's __repr__ logic.

I removed classifier tests in these files.  We see in https://github.com/Axelrod-Python/Axelrod/pull/1330 that we had to update classifier tests.  We can update here too, but it'd be redundant and hard to maintain to continue to have these tests listed special.