### PR TITLE
Cleanup ultimatum and expand coverage

### DIFF
--- a/axelrod/tests/ultimatum/tests.py
+++ b/axelrod/tests/ultimatum/tests.py
@@ -1,37 +1,96 @@
+import numpy as np
 import random
+from typing import List, Optional
 import unittest
 
-from axelrod.ultimatum import DoubleThresholdsPlayer, SimpleThresholdPlayer
+from scipy import stats
+
+from axelrod.ultimatum import (
+    AcceptanceThresholdPlayer,
+    DistributionPlayer,
+    DoubleThresholdsPlayer,
+    SimpleThresholdPlayer,
+    UltimatumPlayer,
+)
+
+
+class TestBaseUltimatumPlayer(unittest.TestCase):
+    def test_unimplemented_errors(self):
+        player = UltimatumPlayer()
+        with self.assertRaises(NotImplementedError):
+            player.offer()
+        with self.assertRaises(NotImplementedError):
+            player.consider(0.5)
+
+    def test_reset_player(self):
+        player1 = SimpleThresholdPlayer(0.6, 0.4)
+        player2 = SimpleThresholdPlayer(0.6, 0.4)
+        player1.play(player2)
+        self.assertEqual(len(player1.history), 1)
+        self.assertEqual(len(player2.history), 1)
+        player1.reset()
+        self.assertEqual(len(player1.history), 0)
+        self.assertEqual(len(player2.history), 1)
 
 
 class TestSimpleThresholdPlayer(unittest.TestCase):
     def test_consider(self):
         player = SimpleThresholdPlayer(0.6, 0.4)
-        self.assertEqual(player.consider(0.39), False)
-        self.assertEqual(player.consider(0.4), True)
-        self.assertEqual(player.consider(0.41), True)
+        self.assertFalse(player.consider(0.39))
+        self.assertTrue(player.consider(0.4))
+        self.assertTrue(player.consider(0.41))
 
     def test_offer(self):
         player = SimpleThresholdPlayer(0.4, 0.6)
-        self.assertEqual(player.offer(), 0.4)
+        self.assertAlmostEqual(player.offer(), 0.4)
+
+    def test_repr(self):
+        player = SimpleThresholdPlayer(0.6, 0.4)
+        self.assertEqual(str(player), "SimpleThresholdPlayer (0.6 | 0.4)")
+
+
+class TestAcceptanceThresholdPlayer(unittest.TestCase):
+    def test_consider(self):
+        player = AcceptanceThresholdPlayer(0.1, 0.4, 0.6)
+        self.assertFalse(player.consider(0.39))
+        self.assertTrue(player.consider(0.4))
+        self.assertTrue(player.consider(0.5))
+        self.assertTrue(player.consider(0.6))
+        self.assertFalse(player.consider(0.61))
+
+    def test_offer(self):
+        player = AcceptanceThresholdPlayer(0.1, 0.4, 0.6)
+        self.assertAlmostEqual(player.offer(), 0.1)
+
+    def test_repr(self):
+        player = AcceptanceThresholdPlayer(0.1, 0.4, 0.6)
+        self.assertEqual(
+            str(player), "AcceptanceThresholdPlayer (0.1 | [0.4, 0.6])"
+        )
 
 
 class TestDoubleThresholdsPlayer(unittest.TestCase):
     def test_consider(self):
         player = DoubleThresholdsPlayer(0.4, 0.6, 0.4, 0.6)
-        self.assertEqual(player.consider(0.39), False)
-        self.assertEqual(player.consider(0.4), True)
-        self.assertEqual(player.consider(0.41), True)
-        self.assertEqual(player.consider(0.6), True)
-        self.assertEqual(player.consider(0.61), False)
+        self.assertFalse(player.consider(0.39))
+        self.assertTrue(player.consider(0.4))
+        self.assertTrue(player.consider(0.41))
+        self.assertTrue(player.consider(0.6))
+        self.assertFalse(player.consider(0.61))
 
     def test_offer(self):
         a = random.random()
         b = random.uniform(a, 1)
-        player = DoubleThresholdsPlayer(a, b, 0., 1.)
+        player = DoubleThresholdsPlayer(a, b, 0.0, 1.0)
         for _ in range(10):
             offer = player.offer()
             self.assertTrue(a <= offer <= b)
+
+    def test_repr(self):
+        player = DoubleThresholdsPlayer(0.4, 0.6, 0.4, 0.6)
+        self.assertEqual(
+            str(player), "DoubleThresholdsPlayer (0.4, 0.6 | [0.4, 0.6])"
+        )
 
 
 class TestPlay(unittest.TestCase):
@@ -39,15 +98,50 @@ class TestPlay(unittest.TestCase):
         player = SimpleThresholdPlayer(0.6, 0.4)
         coplayer = SimpleThresholdPlayer(0.5, 0.5)
         result = player.play(coplayer)
-        self.assertEqual(result[0].scores, (0.4, 0.6))
+        np.testing.assert_almost_equal(result[0].scores, (0.4, 0.6))
         result = coplayer.play(player)
-        self.assertEqual(result[0].scores, (0.5, 0.5))
+        np.testing.assert_almost_equal(result[0].scores, (0.5, 0.5))
         player = SimpleThresholdPlayer(0.4, 0.6)
         result = player.play(coplayer)
-        self.assertEqual(result[0].scores, (0.0, 0.0))
+        np.testing.assert_almost_equal(result[0].scores, (0.0, 0.0))
         result = coplayer.play(player)
-        self.assertEqual(result[0].scores, (0.0, 0.0))
+        np.testing.assert_almost_equal(result[0].scores, (0.0, 0.0))
 
 
-if __name__ == '__main__':
-    unittest.main()
+class MockRVContinuous(stats.distributions.rv_continuous):
+    """Creates a mock distribution which returns values from the list provided
+    at initialization."""
+
+    def __init__(self, values: Optional[List[float]] = None):
+        if not values:
+            values = []
+        self.values = values
+
+    def rvs(self) -> float:
+        if not self.values:  # pragma: no cover
+            return 0.0
+        result = self.values[0]
+        self.values = self.values[1:]
+        return result
+
+
+class TestDistributionPlayer(unittest.TestCase):
+    def test_consider(self):
+        player = DistributionPlayer(
+            MockRVContinuous(), MockRVContinuous([0.1, 0.2, 0.3, 0.4])
+        )
+        self.assertTrue(player.consider(0.15))
+        self.assertFalse(player.consider(0.15))
+        self.assertFalse(player.consider(0.25))
+        self.assertTrue(player.consider(0.5))
+
+    def test_offer(self):
+        player = DistributionPlayer(
+            MockRVContinuous([0.1, 0.2]), MockRVContinuous()
+        )
+        self.assertAlmostEqual(player.offer(), 0.1)
+        self.assertAlmostEqual(player.offer(), 0.2)
+
+    def test_repr(self):
+        player = DistributionPlayer(MockRVContinuous(), MockRVContinuous())
+        self.assertEqual(str(player), "DistributionThresholdPlayer")

--- a/axelrod/ultimatum/player.py
+++ b/axelrod/ultimatum/player.py
@@ -1,9 +1,11 @@
 """
-Ultimatum Game .
+Ultimatum Game.
 """
 
-from collections import namedtuple
 from enum import Enum
+from typing import Optional, Tuple
+
+import attr
 from scipy import stats
 
 
@@ -12,8 +14,12 @@ class PlayerPosition(Enum):
     DECIDER = 2
 
 
-# Python 3.7 dataclass would be nice here
-Outcome = namedtuple('Outcome', ['position', 'offer', 'decision', 'scores'])
+@attr.s
+class Outcome(object):
+    position: "UltimatumPlayer" = attr.ib()
+    offer: float = attr.ib()
+    decision: bool = attr.ib()
+    scores: Tuple[float, float] = attr.ib()
 
 
 class UltimatumPlayer(object):
@@ -27,10 +33,7 @@ class UltimatumPlayer(object):
     def __init__(self):
         self.history = []
 
-    def set_match_attributes(self, *args, **kwargs):
-        pass
-
-    def reset(self):
+    def reset(self) -> None:
         self.history = []
 
     def offer(self) -> float:
@@ -42,26 +45,31 @@ class UltimatumPlayer(object):
         """Decision rule for whether to accept the offer."""
         raise NotImplementedError
 
-    def play(self, coplayer, noise=None):
+    def play(
+        self, coplayer: "UltimatumPlayer", noise: Optional[float] = None
+    ) -> Tuple[Outcome, Outcome]:
+        """Play a game with this player as the offerer and the passed coplayer
+        as the decider.  Appends Outcomes with offer decision and scores to the
+        player's and coplayer's history, and returns."""
         offer = self.offer()
         decision = coplayer.consider(offer)
         # If the offer is accepted, return the split. Otherwise both players
         # receive nothing.
         if decision:
-            scores = 1. - offer, offer
+            scores = 1.0 - offer, offer
         else:
-            scores = 0., 0.
+            scores = 0.0, 0.0
         outcome = Outcome(
             position=PlayerPosition.OFFERER,
             offer=offer,
             decision=decision,
-            scores=scores
+            scores=scores,
         )
         coplayer_outcome = Outcome(
             position=PlayerPosition.DECIDER,
             offer=offer,
             decision=decision,
-            scores=list(reversed(scores))
+            scores=list(reversed(scores)),
         )
         self.history.append(outcome)
         coplayer.history.append(coplayer_outcome)
@@ -74,14 +82,17 @@ class SimpleThresholdPlayer(UltimatumPlayer):
 
     name = "Simple Threshold Player"
 
-    def __init__(self, offer_proportion=0.5, lower_threshold=0.5):
+    def __init__(
+        self, offer_proportion: float = 0.5, lower_threshold: float = 0.5
+    ):
         super().__init__()
         self.offer_proportion = offer_proportion
         self.lower_threshold = lower_threshold
 
     def __repr__(self) -> str:
         return "SimpleThresholdPlayer ({} | {})".format(
-            self.offer_proportion, self.lower_threshold)
+            self.offer_proportion, self.lower_threshold
+        )
 
     def offer(self) -> float:
         return self.offer_proportion
@@ -94,25 +105,30 @@ class AcceptanceThresholdPlayer(UltimatumPlayer):
     """A simple Ultimatum game player with fixed acceptance thresholds (upper
     and lower) and a fixed offer proportion."""
 
-    name = "Double Threshold Player"
+    name = "Acceptance Threshold Player"
 
-    def __init__(self, offer_proportion, lower_threshold, upper_threshold):
+    def __init__(
+        self,
+        offer_proportion: float = 0.5,
+        lower_threshold: float = 0.5,
+        upper_threshold: float = 0.5,
+    ):
         self.offer_proportion = offer_proportion
         self.lower_threshold = lower_threshold
         self.upper_threshold = upper_threshold
 
     def __repr__(self) -> str:
-        return "DoubleThresholdPlayer ({} | [{}, {}])".format(
-            self.offer_proportion,
-            self.lower_threshold,
-            self.upper_threshold)
+        return "AcceptanceThresholdPlayer ({} | [{}, {}])".format(
+            self.offer_proportion, self.lower_threshold, self.upper_threshold
+        )
 
     def offer(self) -> float:
         return self.offer_proportion
 
     def consider(self, offer: float) -> bool:
         return (offer >= self.lower_threshold) and (
-            offer <= self.upper_threshold)
+            offer <= self.upper_threshold
+        )
 
 
 class DoubleThresholdsPlayer(UltimatumPlayer):
@@ -123,26 +139,33 @@ class DoubleThresholdsPlayer(UltimatumPlayer):
 
     classifier = dict(stochastic=True)
 
-    def __init__(self, lower_offer=0.4, upper_offer=0.6, lower_accept=0.4,
-                 upper_accept=0.6):
+    def __init__(
+        self,
+        lower_offer: float = 0.4,
+        upper_offer: float = 0.6,
+        lower_accept: float = 0.4,
+        upper_accept: float = 0.6,
+    ):
         self.lower_offer = lower_offer
         self.upper_offer = upper_offer
         self.lower_accept = lower_accept
         self.upper_accept = upper_accept
         self.offer_distribution = stats.uniform(
-            loc=lower_offer, scale=upper_offer - lower_offer)
+            loc=lower_offer, scale=upper_offer - lower_offer
+        )
         self.init_kwargs = dict(
             lower_offer=lower_offer,
             upper_offer=upper_offer,
             lower_accept=lower_accept,
-            upper_accept=upper_accept)
+            upper_accept=upper_accept,
+        )
 
     def __repr__(self) -> str:
         return "DoubleThresholdsPlayer ({}, {} | [{}, {}])".format(
             self.lower_offer,
             self.upper_offer,
             self.lower_accept,
-            self.upper_accept
+            self.upper_accept,
         )
 
     def offer(self) -> float:
@@ -150,30 +173,33 @@ class DoubleThresholdsPlayer(UltimatumPlayer):
         return self.offer_distribution.rvs()
 
     def consider(self, offer: float) -> bool:
-        return (offer >= self.lower_accept) and (
-            offer <= self.upper_accept)
+        return (offer >= self.lower_accept) and (offer <= self.upper_accept)
 
 
-# class DistributionPlayer(UltimatumPlayer):
-#     """A stochastic player of the ultimatum game."""
-#
-#     name = "Distribution Player"
-#
-#     def __init__(self, offer_distribution: None, acceptance_distribution=None):
-#         if not offer_distribution:
-#             offer_distribution = stats.norm(0.5, 0.1)
-#         if not acceptance_distribution:
-#             acceptance_distribution = stats.norm(0.5, 0.1)
-#         self.offer_distribution = offer_distribution
-#         self.acceptance_distribution = acceptance_distribution
-#
-#     def __repr__(self) -> str:
-#         return "DistributionThresholdPlayer"
-#
-#     def offer(self) -> float:
-#         return self.offer_distribution.rvs()
-#
-#     def consider(self, offer: float) -> bool:
-#         return self.acceptance_distribution.rvs() <= offer
+class DistributionPlayer(UltimatumPlayer):
+    """A stochastic player of the ultimatum game."""
 
+    name = "Distribution Player"
 
+    def __init__(
+        self,
+        offer_distribution: Optional[stats.distributions.rv_continuous] = None,
+        acceptance_distribution: Optional[
+            stats.distributions.rv_continuous
+        ] = None,
+    ):
+        if not offer_distribution:
+            offer_distribution = stats.norm(0.5, 0.1)  # pragma: no cover
+        if not acceptance_distribution:
+            acceptance_distribution = stats.norm(0.5, 0.1)  # pragma: no cover
+        self.offer_distribution = offer_distribution
+        self.acceptance_distribution = acceptance_distribution
+
+    def __repr__(self) -> str:
+        return "DistributionThresholdPlayer"
+
+    def offer(self) -> float:
+        return self.offer_distribution.rvs()
+
+    def consider(self, offer: float) -> bool:
+        return self.acceptance_distribution.rvs() <= offer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+attrs>=19.3.0
 cloudpickle>=0.2.1
 fsspec>=0.4.3
 dask>=2.3.0


### PR DESCRIPTION
Did a few cleanup tasks and expanded to 100% coverage.

Specially I:
- Added tests
- Deleted set_match_attributes for now.
- Changed name/repr on AcceptanceThresholdPlayer.  It looks like this was a copy-paste error.
- Typed remaining inputs/outputs
- Added default values to strategies, to be consistent with IPD where every strategy is trivially initializable.
- Uncommented distribution strategy
- Changed tests to assertTrue/assertFalse (for boolean tests) and assertAlmostEqual for testing equality of floats.  I think these are best practices.
- Use attrs library instead of namedtuple, to address the commen there - I really love this library.