### PR TITLE
Add GameParams to make Match generalizable

### DIFF
--- a/axelrod/game_params.py
+++ b/axelrod/game_params.py
@@ -102,7 +102,7 @@ def symm2p_play_round(
         params.player_positions[Symm2pPosition.POS_1],
         params.player_positions[Symm2pPosition.POS_2],
     )
-    action_1, action_2 = player_1.play(player_2)
+    action_1, action_2 = player_1.play(player_2, noise=noise)
     actions = {
         Symm2pPosition.POS_1: action_1,
         Symm2pPosition.POS_2: action_2,

--- a/axelrod/game_params.py
+++ b/axelrod/game_params.py
@@ -1,0 +1,131 @@
+"""Implements GameParams and other classes.
+
+The GameParams class defines all everything a program should need to understand
+a game (e.g. IPD or ultimatum).
+"""
+
+from enum import Enum
+from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
+
+import attr
+
+from axelrod.action import Action
+from axelrod.game import Game
+from axelrod.player import Player, PlayerName
+
+Position = Enum
+Score = Union[float, int]
+
+
+@attr.s
+class PlayParams(object):
+    """Parameters controlling a single round of play.
+
+    Attributes
+    ----------
+    player_positions : Dict[Position, Player]
+        Specifies the player that's going to play each of the positions.
+    """
+    player_positions: Dict[Position, Player] = attr.ib()
+
+
+@attr.s
+class Outcome(object):
+    """Describes the outcome of a single round of play.
+
+    Attributes
+    ----------
+    position : Position
+        ...
+    actions : Dict[Position, Any]
+        The chosen action for each player, keyed by the player's position.
+    scores : Dict[Position, Score]
+        The resulting score for the player, keyed by the player's position.
+    """
+    position: Position = attr.ib()
+    # TODO: Change Any to Action, creating an ultimatum action.
+    actions: Dict[Position, Any] = attr.ib()
+    scores: Dict[Position, Score] = attr.ib()
+
+
+@attr.s
+class GameParams(object):
+    """Parameters describing a game type (like IPD or ultimatum).
+
+    Attributes
+    ----------
+    generate_play_params : Callable[
+        [List[Player], int], Generator[PlayParams, None, None]
+    ]
+        A function that takes a list of players and an integer representing the
+        number of turns, yields PlayParams for rounds of play for as long as a
+        match should last.
+    play_round : Callable[[PlayParams, Game], Outcome]
+        A function that given a PlayParams and a Game object will play a single
+        round of the game, and returns the Outcome object.
+    result : Callable[[Outcome], Any]
+        Translates an Outcome object to a result that the match's play method
+        returns.  By default, this is a pass-through.
+    """
+    generate_play_params: Callable[
+        [List[Player], int], Generator[PlayParams, None, None]
+    ] = attr.ib()
+    play_round: Callable[[PlayParams, Game], Outcome] = attr.ib()
+    result: Callable[[Outcome], Any] = attr.ib(default=lambda x: x)
+
+
+class Symm2pPosition(Position):
+    """A position enum for symmetric 2-player games.
+
+    "Symmetric" means that the positions are interchangeable.
+    """
+    POS_1 = 1
+    POS_2 = 2
+
+
+def symm2p_generate_play_params(
+    players: List[Player], rounds: int
+) -> Generator[PlayParams, None, None]:
+    assert len(players) == 2
+    player_positions = {
+        Symm2pPosition.POS_1: players[0],
+        Symm2pPosition.POS_2: players[1],
+    }
+    for _ in range(rounds):
+        yield PlayParams(player_positions=player_positions)
+
+
+def symm2p_play_round(
+    params: PlayParams, game: Game, noise: Optional[float] = None
+) -> Outcome:
+    player_1, player_2 = (
+        params.player_positions[Symm2pPosition.POS_1],
+        params.player_positions[Symm2pPosition.POS_2],
+    )
+    action_1, action_2 = player_1.play(player_2)
+    actions = {
+        Symm2pPosition.POS_1: action_1,
+        Symm2pPosition.POS_2: action_2,
+    }
+    score_1, score_2 = game.score((action_1, action_2))
+    scores = {
+        Symm2pPosition.POS_1: score_1,
+        Symm2pPosition.POS_2: score_2,
+    }
+    return Outcome(
+        position=Symm2pPosition.POS_1, actions=actions, scores=scores
+    )
+
+
+def ipd_result(outcome: Outcome) -> Tuple[Action, Action]:
+    return (
+        outcome.actions[Symm2pPosition.POS_1],
+        outcome.actions[Symm2pPosition.POS_2],
+    )
+
+
+ipd_params = GameParams(
+    generate_play_params=symm2p_generate_play_params,
+    play_round=symm2p_play_round,
+    result=ipd_result,
+)

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -2,7 +2,7 @@ import copy
 import inspect
 import itertools
 import types
-from typing import Any, Dict
+from typing import Any, Dict, Text
 
 import numpy as np
 
@@ -12,6 +12,8 @@ from axelrod.history import History
 from axelrod.random_ import random_flip
 
 C, D = Action.C, Action.D
+
+PlayerName = Text
 
 
 def simultaneous_play(player, coplayer, noise=0):
@@ -31,7 +33,7 @@ class Player(object):
     This is an abstract base class, not intended to be used directly.
     """
 
-    name = "Player"
+    name: PlayerName = "Player"
     classifier = {}  # type: Dict[str, Any]
 
     def __new__(cls, *args, **kwargs):

--- a/axelrod/tests/ultimatum/tests.py
+++ b/axelrod/tests/ultimatum/tests.py
@@ -12,6 +12,7 @@ from axelrod.ultimatum import (
     DoubleThresholdsPlayer,
     SimpleThresholdPlayer,
     UltimatumPlayer,
+    UltimatumPosition,
 )
 
 
@@ -39,29 +40,51 @@ class TestPlay(unittest.TestCase):
         player = SimpleThresholdPlayer(0.6, 0.4)
         coplayer = SimpleThresholdPlayer(0.5, 0.5)
         result = player.play(coplayer)
-        np.testing.assert_almost_equal(result[0].scores, (0.4, 0.6))
+        np.testing.assert_almost_equal(result[0].scores[UltimatumPosition.OFFERER], 0.4)
+        np.testing.assert_almost_equal(result[0].scores[UltimatumPosition.DECIDER], 0.6)
         result = coplayer.play(player)
-        np.testing.assert_almost_equal(result[0].scores, (0.5, 0.5))
+        np.testing.assert_almost_equal(result[0].scores[UltimatumPosition.OFFERER], 0.5)
+        np.testing.assert_almost_equal(result[0].scores[UltimatumPosition.DECIDER], 0.5)
         player = SimpleThresholdPlayer(0.4, 0.6)
         result = player.play(coplayer)
-        np.testing.assert_almost_equal(result[0].scores, (0.0, 0.0))
+        np.testing.assert_almost_equal(result[0].scores[UltimatumPosition.OFFERER], 0.0)
+        np.testing.assert_almost_equal(result[0].scores[UltimatumPosition.DECIDER], 0.0)
         result = coplayer.play(player)
-        np.testing.assert_almost_equal(result[0].scores, (0.0, 0.0))
+        np.testing.assert_almost_equal(result[0].scores[UltimatumPosition.OFFERER], 0.0)
+        np.testing.assert_almost_equal(result[0].scores[UltimatumPosition.DECIDER], 0.0)
 
         # Check history
         self.assertEqual(len(coplayer.history), 4)
-        self.assertEqual(coplayer.history[0].decision, True)
-        self.assertEqual(coplayer.history[1].decision, True)
-        self.assertEqual(coplayer.history[2].decision, False)
-        self.assertEqual(coplayer.history[3].decision, False)
+        self.assertEqual(
+            coplayer.history[0].actions[UltimatumPosition.DECIDER], True
+        )
+        self.assertEqual(
+            coplayer.history[1].actions[UltimatumPosition.DECIDER], True
+        )
+        self.assertEqual(
+            coplayer.history[2].actions[UltimatumPosition.DECIDER], False
+        )
+        self.assertEqual(
+            coplayer.history[3].actions[UltimatumPosition.DECIDER], False
+        )
 
         self.assertEqual(len(coplayer.history.offers), 2)
-        self.assertEqual(coplayer.history.offers[0].decision, True)
-        self.assertEqual(coplayer.history.offers[1].decision, False)
+        self.assertEqual(
+            coplayer.history.offers[0].actions[UltimatumPosition.DECIDER], True
+        )
+        self.assertEqual(
+            coplayer.history.offers[1].actions[UltimatumPosition.DECIDER], False
+        )
 
         self.assertEqual(len(coplayer.history.decisions), 2)
-        self.assertEqual(coplayer.history.decisions[0].decision, True)
-        self.assertEqual(coplayer.history.decisions[1].decision, False)
+        self.assertEqual(
+            coplayer.history.decisions[0].actions[UltimatumPosition.DECIDER],
+            True,
+        )
+        self.assertEqual(
+            coplayer.history.decisions[1].actions[UltimatumPosition.DECIDER],
+            False,
+        )
 
 
 class TestSimpleThresholdPlayer(unittest.TestCase):


### PR DESCRIPTION
I modify Match to take a "GameParams" object.  A GameParams class is intended to eventually include everything that a Match or Tournament needs to know about a new game type (IPD, ultimatum, etc.).  For now it includes only a few functions used in Match play, described below.  This change is non-API breaking, because Match takes ipd_game_params by default.

GameParams is a class with three elements, all functions passed at initialization:
- generate_play_params: Generates a "PlayParams" object, which tells Match how to play a single round.  (For now, this is players with their positions.)  This is an iterator which should produce all the PlayParams needed for the entire Match run.  It takes in a list of players and the number of desired rounds.
- play_round:  From PlayParams and a Game object (for scoring), play a round of the game.
- result:  This is a translator which for IPD translates Outcome classes to a pair of Actions, which keeps the Match API unchanged.  For new games, we will probably make this a pass-through, an let Match's play function return a list of Outcome classes.

generate_play_params and play_round could be combined, because they get called back-to-back in Match play.  I chose not to do this because: 1) The functionality naturally separates, and 2) For an asymmetric game, like Ultimatum, some research would prefer Matches to alternate roles between the players, while other research would prefer each player to keep a role; between these cases, generate_play_params would change, but not play_round.

In addition to GameParams and it's helper functions, this change generalizes the Outcome class.

In a future change, we can make GameParams class for Ultimatum, and run Match on that game.