### PR TITLE
Create a scorer for ultimatum

### DIFF
--- a/axelrod/game.py
+++ b/axelrod/game.py
@@ -1,13 +1,14 @@
 from typing import Tuple, Union
 
 from axelrod import Action
+from .prototypes import BaseScorer
 
 C, D = Action.C, Action.D
 
 Score = Union[int, float]
 
 
-class Game(object):
+class Game(BaseScorer):
     """Container for the game matrix and scoring logic.
 
     Attributes
@@ -18,7 +19,7 @@ class Game(object):
 
     def __init__(self, r: Score = 3, s: Score = 0, t: Score = 5, p: Score = 1) -> None:
         """Create a new game object.
-        
+
         Parameters
         ----------
         r: int or float

--- a/axelrod/ipd_params.py
+++ b/axelrod/ipd_params.py
@@ -1,0 +1,21 @@
+"""Implements ipd_params."""
+
+from typing import Tuple
+
+from .action import Action
+from .game_params import GameParams, Outcome, Symm2pPosition, symm2p_generate_play_params, symm2p_play_round
+
+
+def ipd_result(outcome: Outcome) -> Tuple[Action, Action]:
+    return (
+        outcome.actions[Symm2pPosition.POS_1],
+        outcome.actions[Symm2pPosition.POS_2],
+    )
+
+
+ipd_params = GameParams(
+    game_type="IPD",
+    generate_play_params=symm2p_generate_play_params,
+    play_round=symm2p_play_round,
+    result=ipd_result,
+)

--- a/axelrod/match.py
+++ b/axelrod/match.py
@@ -6,7 +6,7 @@ from axelrod import Classifiers
 from axelrod import DEFAULT_TURNS
 from axelrod.action import Action
 from axelrod.game import Game
-from axelrod.game_params import ipd_params
+from axelrod.ipd_params import ipd_params
 from .deterministic_cache import DeterministicCache
 
 C, D = Action.C, Action.D

--- a/axelrod/prototypes.py
+++ b/axelrod/prototypes.py
@@ -11,9 +11,9 @@ Score = Union[float, int]
 
 class BasePlayer(object):
     def strategy(self, opponent: "BasePlayer") -> Action:
-        raise NotImplementedError()
+        raise NotImplementedError()  # pragma: no cover
 
 
 class BaseScorer(object):
     def score(self, actions: Tuple[Action, ...]) -> Tuple[Score, ...]:
-        raise NotImplementedError()
+        raise NotImplementedError()  # pragma: no cover

--- a/axelrod/prototypes.py
+++ b/axelrod/prototypes.py
@@ -1,0 +1,19 @@
+"""Prototypes for the various game components."""
+
+from enum import Enum
+from typing import Tuple, Union
+
+from .action import Action
+
+Position = Enum
+Score = Union[float, int]
+
+
+class BasePlayer(object):
+    def strategy(self, opponent: "BasePlayer") -> Action:
+        raise NotImplementedError()
+
+
+class BaseScorer(object):
+    def score(self, actions: Tuple[Action, ...]) -> Tuple[Score, ...]:
+        raise NotImplementedError()

--- a/axelrod/tests/ultimatum/test_game.py
+++ b/axelrod/tests/ultimatum/test_game.py
@@ -1,0 +1,18 @@
+import numpy as np
+import unittest
+
+from axelrod.ultimatum.game import UltimatumScorer
+
+class TestUltimatumScorer(unittest.TestCase):
+    def test_accept(self):
+        scorer = UltimatumScorer()
+        np.testing.assert_almost_equal(scorer.score((0.5, True)), (0.5, 0.5))
+        np.testing.assert_almost_equal(scorer.score((0.3, True)), (0.7, 0.3))
+        np.testing.assert_almost_equal(scorer.score((0.0, True)), (1.0, 0.0))
+        np.testing.assert_almost_equal(scorer.score((1.0, True)), (0.0, 1.0))
+
+    def test_reject(self):
+        scorer = UltimatumScorer()
+        np.testing.assert_almost_equal(scorer.score((0.5, False)), (0.0, 0.0))
+        np.testing.assert_almost_equal(scorer.score((0.0, False)), (0.0, 0.0))
+        np.testing.assert_almost_equal(scorer.score((1.0, False)), (0.0, 0.0))

--- a/axelrod/ultimatum/game.py
+++ b/axelrod/ultimatum/game.py
@@ -1,0 +1,16 @@
+from typing import Tuple
+
+from axelrod.prototypes import BaseScorer, Score
+
+
+class UltimatumScorer(BaseScorer):
+    def __init__(self):
+        super().__init__()
+
+    def score(self, offer_decision: Tuple) -> Tuple[Score, Score]:
+        """Given offer and decision, returns the score to the offerer and
+        decider, resp."""
+        offer, decision = offer_decision
+        if decision:
+            return 1.0 - offer, offer
+        return 0.0, 0.0


### PR DESCRIPTION
Creates a scorer (or "Game") for ultimatum.  This is one of the inputs to Matches and Tournaments, so it's needed to run an ultimatum tournament.

I would have liked to have done a couple of things differently:

1. Move scorer to belong to game_params.  Remove scorer as an input to Matches and Tournaments and Moran processes and Match Generators, preferring instead to pass around game_params.  (game_params would need to be more carefully initialized so that scorer objects aren't shared.)  The advantage of this approach is 1) it makes it impossible to mix-and-match scorers and game types (an issue I've ignored for now), and 2) it centralizes all the _settings_ for a game type.

2. Have the scorer's score function take in a dictionary of Actions keyed by position and return a dictionary of Scores keyed by position.  This more naturally extends to multi-player game, and is consistent with a pattern I've started to use on things like Outcome.  (It's also perhaps more natural for an asymmetric game like Ultimatum vs using order alone to specify position.)

I have restrained from making these changes here, because they are API-breaking.  Aside from causing problems with an eventual merge onto master, it means I have to change A LOT of code to keep the library working (tests passing) on this branch.  At this early stage, where we're still experimenting with API, I want to avoid that. 