### PR TITLE
Add ultimatum game_params, and extend documentation.

### DIFF
--- a/axelrod/classifier.py
+++ b/axelrod/classifier.py
@@ -15,6 +15,7 @@ import warnings
 import yaml
 
 from axelrod.player import Player
+from axelrod.prototypes import BasePlayer
 
 ALL_CLASSIFIERS_PATH = "data/all_classifiers.yml"
 
@@ -187,7 +188,7 @@ class _Classifiers(object):
 
             # If the passed player is not an instance, then try to initialize an
             # instance without arguments.
-            if not isinstance(player, Player):
+            if not isinstance(player, BasePlayer):
                 try:
                     player = player()
                     warnings.warn(

--- a/axelrod/game.py
+++ b/axelrod/game.py
@@ -8,6 +8,7 @@ C, D = Action.C, Action.D
 Score = Union[int, float]
 
 
+# TODO(5.0): Consider making Game a part of the GameParams
 class Game(BaseScorer):
     """Container for the game matrix and scoring logic.
 

--- a/axelrod/game_params.py
+++ b/axelrod/game_params.py
@@ -1,7 +1,26 @@
 """Implements GameParams and other classes.
 
 The GameParams class defines all everything a program should need to understand
-a game (e.g. IPD or ultimatum).
+how to play a game.  This class includes:
+
+ -  game_type: A name specifying the game type (e.g. IPD or Ultimatum)
+ -  generate_play_params: A function that takes a list of players and an integer
+    representing the number of turns, yields PlayParams for rounds of play for
+    as long as a match should last.
+ -  play_round: A function that given a PlayParams and a Game object will play a
+    single round of the game, and returns the Outcome object.
+ -  result : A function that translates an Outcome object to a result that the
+    match's play method returns.  By default, this is a pass-through.
+
+GameParams gets passed into Match, Tournament, and Moran processes, so a
+canonical instance of this class should get defined for each new game type.
+However some game types may have more than one GameParams.  For example,
+Ultimatum may generate rounds by keeping roles the same or by alternating roles;
+so Ultimatum has two distinct GameParams.
+
+Additionally includes some generic functionality for generate_play_params and
+for play_round, that can be shared among any "symmetric" 2-player game.
+("Symmetric" means that the roles are all the same, as with IPD.)
 """
 
 from typing import (
@@ -56,6 +75,8 @@ class GameParams(object):
     """
 
     game_type: Text = attr.ib()
+    # TODO(5.0): This should be called generate_round, since the user won't know
+    #  what PlayParams are.
     generate_play_params: Callable[
         [List[BasePlayer], int], Generator[PlayParams, None, None]
     ] = attr.ib()
@@ -63,6 +84,8 @@ class GameParams(object):
     result: Callable[[Outcome], Any] = attr.ib(default=lambda x: x)
 
 
+# TODO(5.0): Consider moving these Symm2p functions to a new file, and update
+#  file-level docstrings.
 class Symm2pPosition(Position):
     """A position enum for symmetric 2-player games.
 

--- a/axelrod/game_params.py
+++ b/axelrod/game_params.py
@@ -17,7 +17,7 @@ from typing import (
 
 import attr
 
-from .prototypes import BasePlayer, BaseScorer, Position, Score
+from .prototypes import BasePlayer, BaseScorer, Outcome, Position
 
 
 @attr.s
@@ -31,29 +31,6 @@ class PlayParams(object):
     """
 
     player_positions: Dict[Position, BasePlayer] = attr.ib()
-
-
-@attr.s
-class Outcome(object):
-    """Describes the outcome of a single round of play.
-
-    Attributes
-    ----------
-    actions : Dict[Position, Any]
-        The chosen action for each player, keyed by the player's position.
-    scores : Dict[Position, Score]
-        The resulting score for the player, keyed by the player's position.
-    position : Position
-        An Outcome object will contain info about each position's action and
-        score, but may also have a perspective indicating a single position.
-        For example, when Outcome is stored to a player's history, position
-        indicates which position that player played as on that turn.
-    """
-
-    # TODO(5.0): Change Any to Action, creating an ultimatum action.
-    actions: Dict[Position, Any] = attr.ib()
-    scores: Dict[Position, Score] = attr.ib()
-    position: Optional[Position] = attr.ib(default=None)
 
 
 @attr.s

--- a/axelrod/game_params.py
+++ b/axelrod/game_params.py
@@ -50,7 +50,7 @@ class Outcome(object):
         indicates which position that player played as on that turn.
     """
 
-    # TODO: Change Any to Action, creating an ultimatum action.
+    # TODO(5.0): Change Any to Action, creating an ultimatum action.
     actions: Dict[Position, Any] = attr.ib()
     scores: Dict[Position, Score] = attr.ib()
     position: Optional[Position] = attr.ib(default=None)

--- a/axelrod/game_params.py
+++ b/axelrod/game_params.py
@@ -12,6 +12,7 @@ from typing import (
     List,
     Optional,
     Text,
+    Tuple
 )
 
 import attr
@@ -112,18 +113,26 @@ def x_plays_y_round(
     y: Position,
     params: PlayParams,
     scorer: BaseScorer,
+    outcomes_to_actions: Optional[
+        Callable[[Outcome, Outcome], Tuple[Any, Any]]
+    ] = None,
     noise: Optional[float] = None,
 ) -> Outcome:
     """Calls play on player in position x, with the player in position y
     passed in."""
+    if not outcomes_to_actions:
+        def outcomes_to_actions(x, y):
+            return x, y
+
     player_1, player_2 = (
         params.player_positions[x],
         params.player_positions[y],
     )
-    action_1, action_2 = player_1.play(player_2, noise=noise)
-    score_1, score_2 = scorer.score((action_1, action_2))
+    outcome_1, outcome_2 = player_1.play(player_2, noise=noise)
+    actions = outcomes_to_actions(outcome_1, outcome_2)
+    score_1, score_2 = scorer.score(actions)
     scores = {x: score_1, y: score_2}
-    return Outcome(actions={x: action_1, y: action_2}, scores=scores)
+    return Outcome(actions={x: actions[0], y: actions[1]}, scores=scores)
 
 
 def symm2p_play_round(

--- a/axelrod/ipd_params.py
+++ b/axelrod/ipd_params.py
@@ -1,9 +1,20 @@
-"""Implements ipd_params."""
+"""Implements ipd_params, a single IPD instance of GameParams.
+
+Because IPD is a symmetric 2-player game, we can use the round generator and
+round player defined for general Symm2p games.  Additionally we define a
+"result" function that translates Outcome into a pair of Actions to make this
+backwards compatible with Match, which saves Match results as a pair of Actions.
+"""
 
 from typing import Tuple
 
 from .action import Action
-from .game_params import GameParams, Symm2pPosition, symm2p_generate_play_params, symm2p_play_round
+from .game_params import (
+    GameParams,
+    Symm2pPosition,
+    symm2p_generate_play_params,
+    symm2p_play_round
+)
 from .prototypes import Outcome
 
 

--- a/axelrod/ipd_params.py
+++ b/axelrod/ipd_params.py
@@ -3,7 +3,8 @@
 from typing import Tuple
 
 from .action import Action
-from .game_params import GameParams, Outcome, Symm2pPosition, symm2p_generate_play_params, symm2p_play_round
+from .game_params import GameParams, Symm2pPosition, symm2p_generate_play_params, symm2p_play_round
+from .prototypes import Outcome
 
 
 def ipd_result(outcome: Outcome) -> Tuple[Action, Action]:

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -9,6 +9,7 @@ import numpy as np
 from axelrod.action import Action
 from axelrod.game import DefaultGame
 from axelrod.history import History
+from axelrod.prototypes import BasePlayer
 from axelrod.random_ import random_flip
 
 C, D = Action.C, Action.D
@@ -27,7 +28,7 @@ def simultaneous_play(player, coplayer, noise=0):
     return s1, s2
 
 
-class Player(object):
+class Player(BasePlayer):
     """A class for a player in the tournament.
 
     This is an abstract base class, not intended to be used directly.

--- a/axelrod/prototypes.py
+++ b/axelrod/prototypes.py
@@ -1,4 +1,7 @@
-"""Prototypes for the various game components."""
+"""Prototypes for the various game components.
+
+This is used for type annotations and deriving functions.
+"""
 
 from enum import Enum
 from typing import Tuple, Union
@@ -9,13 +12,19 @@ Position = Enum
 Score = Union[float, int]
 
 
+# TODO(5.0): Explore what functions should be shared for all players / all
+#  scorers.
 class BasePlayer(object):
-    def strategy(self, opponent: "BasePlayer") -> Action:
-        raise NotImplementedError()  # pragma: no cover
+    """A player for any game.  No gauranteed functionality."""
+    pass
 
 
 class BaseScorer(object):
+    """Scorer function for any game.  Should at least include a score
+    function."""
     def score(self, actions: Tuple[Action, ...]) -> Tuple[Score, ...]:
+        """Taking player actions in some understood order, returns the scores
+        in this round for the player taking that action (in the same order)."""
         raise NotImplementedError()  # pragma: no cover
 
 

--- a/axelrod/prototypes.py
+++ b/axelrod/prototypes.py
@@ -4,7 +4,7 @@ This is used for type annotations and deriving functions.
 """
 
 from enum import Enum
-from typing import Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 import attr
 

--- a/axelrod/prototypes.py
+++ b/axelrod/prototypes.py
@@ -6,6 +6,8 @@ This is used for type annotations and deriving functions.
 from enum import Enum
 from typing import Tuple, Union
 
+import attr
+
 from .action import Action
 
 Position = Enum

--- a/axelrod/prototypes.py
+++ b/axelrod/prototypes.py
@@ -17,3 +17,26 @@ class BasePlayer(object):
 class BaseScorer(object):
     def score(self, actions: Tuple[Action, ...]) -> Tuple[Score, ...]:
         raise NotImplementedError()  # pragma: no cover
+
+
+@attr.s
+class Outcome(object):
+    """Describes the outcome of a single round of play.
+
+    Attributes
+    ----------
+    actions : Dict[Position, Any]
+        The chosen action for each player, keyed by the player's position.
+    scores : Dict[Position, Score]
+        The resulting score for the player, keyed by the player's position.
+    position : Position
+        An Outcome object will contain info about each position's action and
+        score, but may also have a perspective indicating a single position.
+        For example, when Outcome is stored to a player's history, position
+        indicates which position that player played as on that turn.
+    """
+
+    # TODO(5.0): Change Any to Action, creating an ultimatum action.
+    actions: Dict[Position, Any] = attr.ib()
+    scores: Dict[Position, Score] = attr.ib()
+    position: Optional[Position] = attr.ib(default=None)

--- a/axelrod/prototypes.py
+++ b/axelrod/prototypes.py
@@ -17,7 +17,7 @@ Score = Union[float, int]
 # TODO(5.0): Explore what functions should be shared for all players / all
 #  scorers.
 class BasePlayer(object):
-    """A player for any game.  No gauranteed functionality."""
+    """A player for any game.  No guaranteed functionality."""
     pass
 
 

--- a/axelrod/tests/integration/test_ultimatum_match.py
+++ b/axelrod/tests/integration/test_ultimatum_match.py
@@ -26,7 +26,7 @@ class TestUltimatumMatch(unittest.TestCase):
         stingy = SimpleThresholdPlayer(0.0)
 
         # TODO(5.0): Hack to keep deterministic cache from running.  Doesn't
-        # work with ultimatum yet.
+        #  work with ultimatum yet.
         generous.classifier["stochastic"] = True
 
         match = axl.Match(
@@ -37,7 +37,7 @@ class TestUltimatumMatch(unittest.TestCase):
         )
 
         # TODO(5.0): Other match functions for reporting don't work.  List of
-        # Outcomes is hard to parse.
+        #  Outcomes is hard to parse.
         self.assertListEqual(
             match.play(),
             [

--- a/axelrod/tests/integration/test_ultimatum_match.py
+++ b/axelrod/tests/integration/test_ultimatum_match.py
@@ -1,0 +1,47 @@
+import unittest
+
+import axelrod as axl
+from axelrod.game_params import Outcome
+from axelrod.ultimatum.game import UltimatumScorer
+from axelrod.ultimatum.game_params import ultimatum_alternating_params
+from axelrod.ultimatum.player import UltimatumPosition
+from axelrod.ultimatum.strategies import SimpleThresholdPlayer
+
+
+class TestUltimatumMatch(unittest.TestCase):
+    def _build_outcome(self, offer, decision, offer_score, decision_score):
+        return Outcome(
+            actions={
+                UltimatumPosition.OFFERER: offer,
+                UltimatumPosition.DECIDER: decision,
+            },
+            scores={
+                UltimatumPosition.OFFERER: offer_score,
+                UltimatumPosition.DECIDER: decision_score,
+            },
+        )
+
+    def test_match_of_simple_threshold_players(self):
+        generous = SimpleThresholdPlayer(1.0)
+        stingy = SimpleThresholdPlayer(0.0)
+
+        # TODO(5.0): Hack to keep deterministic cache from running.  Doesn't
+        # work with ultimatum yet.
+        generous.classifier["stochastic"] = True
+
+        match = axl.Match(
+            players=[generous, stingy],
+            turns=2,
+            game=UltimatumScorer(),
+            game_params=ultimatum_alternating_params,
+        )
+
+        # TODO(5.0): Other match functions for reporting don't work.  List of
+        # Outcomes is hard to parse.
+        self.assertListEqual(
+            match.play(),
+            [
+                self._build_outcome(1.0, True, 0.0, 1.0),
+                self._build_outcome(0.0, False, 0.0, 0.0),
+            ],
+        )

--- a/axelrod/tests/integration/test_ultimatum_match.py
+++ b/axelrod/tests/integration/test_ultimatum_match.py
@@ -1,7 +1,7 @@
 import unittest
 
 import axelrod as axl
-from axelrod.game_params import Outcome
+from axelrod.prototypes import Outcome
 from axelrod.ultimatum.game import UltimatumScorer
 from axelrod.ultimatum.game_params import ultimatum_alternating_params
 from axelrod.ultimatum.player import UltimatumPosition

--- a/axelrod/tests/ultimatum/test_game_params.py
+++ b/axelrod/tests/ultimatum/test_game_params.py
@@ -1,0 +1,55 @@
+import unittest
+
+from axelrod.game_params import PlayParams
+from axelrod.ultimatum import SimpleThresholdPlayer
+from axelrod.ultimatum.game_params import (
+    UltimatumPosition,
+    ultimatum_alternating_turns,
+    ultimatum_static_turns,
+)
+
+
+class TestUltimatumGameParams(unittest.TestCase):
+    def _build_params(self, offerer, decider):
+        return PlayParams(
+            player_positions={
+                UltimatumPosition.OFFERER: offerer,
+                UltimatumPosition.DECIDER: decider,
+            }
+        )
+
+    def test_ultimatum_alternating_turns(self):
+        player_1, player_2 = (
+            SimpleThresholdPlayer(0.3),
+            SimpleThresholdPlayer(0.7),
+        )
+        actual_turns = [
+            x
+            for x in ultimatum_alternating_turns([player_1, player_2], rounds=5)
+        ]
+        expected_turns = [
+            self._build_params(player_1, player_2),
+            self._build_params(player_2, player_1),
+            self._build_params(player_1, player_2),
+            self._build_params(player_2, player_1),
+            self._build_params(player_1, player_2),
+        ]
+
+        self.assertListEqual(actual_turns, expected_turns)
+
+    def test_ultimatum_static_turns(self):
+        player_1, player_2 = (
+            SimpleThresholdPlayer(0.3),
+            SimpleThresholdPlayer(0.7),
+        )
+        actual_turns = [
+            x
+            for x in ultimatum_static_turns([player_1, player_2], rounds=3)
+        ]
+        expected_turns = [
+            self._build_params(player_1, player_2),
+            self._build_params(player_1, player_2),
+            self._build_params(player_1, player_2),
+        ]
+
+        self.assertListEqual(actual_turns, expected_turns)

--- a/axelrod/tests/unit/test_pickling.py
+++ b/axelrod/tests/unit/test_pickling.py
@@ -318,7 +318,7 @@ class TestPickle(unittest.TestCase):
         player = MyCooperator()
         class_names = [class_.__name__ for class_ in MyCooperator.mro()]
         self.assertEqual(
-            class_names, ["FlippedMyCooperator", "MyCooperator", "Player", "object"]
+            class_names, ["FlippedMyCooperator", "MyCooperator", "Player", "BasePlayer", "object"]
         )
 
         self.assert_original_equals_pickled(player)
@@ -334,6 +334,7 @@ class TestPickle(unittest.TestCase):
                 "FlippedCooperator",
                 "Cooperator",
                 "Player",
+                "BasePlayer",
                 "object",
             ],
         )
@@ -351,6 +352,7 @@ class TestPickle(unittest.TestCase):
                 "FlippedMyDefector",
                 "MyDefector",
                 "Player",
+                "BasePlayer",
                 "object",
             ],
         )

--- a/axelrod/ultimatum/game_params.py
+++ b/axelrod/ultimatum/game_params.py
@@ -1,0 +1,71 @@
+from typing import Any, Generator, List, Optional, Tuple
+
+from axelrod.prototypes import BaseScorer
+from axelrod.game_params import GameParams, Outcome, PlayParams, x_plays_y_round
+from .player import UltimatumPlayer, UltimatumPosition
+
+
+def ultimatum_alternating_turns(
+    players: List[UltimatumPlayer], rounds: int
+) -> Generator[PlayParams, None, None]:
+    """Alternate roles between two players, with the first player offering
+    first."""
+    assert len(players) == 2
+    player_positions = {
+        UltimatumPosition.OFFERER: players[0],
+        UltimatumPosition.DECIDER: players[1],
+    }
+    for _ in range(rounds):
+        yield PlayParams(player_positions=player_positions)
+        player_positions = {
+            UltimatumPosition.OFFERER: player_positions[UltimatumPosition.DECIDER],
+            UltimatumPosition.DECIDER: player_positions[UltimatumPosition.OFFERER],
+        }
+
+
+def ultimatum_static_turns(
+    players: List[UltimatumPlayer], rounds: int
+) -> Generator[PlayParams, None, None]:
+    """First player offers, and second play decides.  No role change."""
+    assert len(players) == 2
+    player_positions = {
+        UltimatumPosition.OFFERER: players[0],
+        UltimatumPosition.DECIDER: players[1],
+    }
+    for _ in range(rounds):
+        yield PlayParams(player_positions=player_positions)
+
+
+def ultimatum_play_round(
+    params: PlayParams, game: BaseScorer, noise: Optional[float] = None
+) -> Outcome:
+    def outcomes_to_actions(
+        outcome_1: Outcome, outcome_2: Outcome
+    ) -> Tuple[Any]:
+        action_1 = outcome_1.actions[outcome_1.position]
+        action_2 = outcome_2.actions[outcome_2.position]
+        return action_1, action_2
+
+    # Offerer plays against decider.
+    return x_plays_y_round(
+        UltimatumPosition.OFFERER,
+        UltimatumPosition.DECIDER,
+        params,
+        game,
+        outcomes_to_actions=outcomes_to_actions,
+        noise=noise,
+    )
+
+
+ultimatum_alternating_params = GameParams(
+    game_type="Ultimatum",
+    generate_play_params=ultimatum_alternating_turns,
+    play_round=ultimatum_play_round,
+)
+
+
+ultimatum_static_params = GameParams(
+    game_type="Ultimatum",
+    generate_play_params=ultimatum_static_turns,
+    play_round=ultimatum_play_round,
+)

--- a/axelrod/ultimatum/game_params.py
+++ b/axelrod/ultimatum/game_params.py
@@ -1,7 +1,7 @@
 from typing import Any, Generator, List, Optional, Tuple
 
-from axelrod.prototypes import BaseScorer
-from axelrod.game_params import GameParams, Outcome, PlayParams, x_plays_y_round
+from axelrod.game_params import GameParams, PlayParams, x_plays_y_round
+from axelrod.prototypes import BaseScorer, Outcome
 from .player import UltimatumPlayer, UltimatumPosition
 
 

--- a/axelrod/ultimatum/game_params.py
+++ b/axelrod/ultimatum/game_params.py
@@ -1,3 +1,10 @@
+"""Implements two GameParams for Ultimatum:  One for matches where the players
+alternate roles, and one for matches where the players keep roles.
+
+In both cases, playing a round involves having the Offerer extend an offer to
+the Decider.
+"""
+
 from typing import Any, Generator, List, Optional, Tuple
 
 from axelrod.game_params import GameParams, PlayParams, x_plays_y_round
@@ -18,8 +25,12 @@ def ultimatum_alternating_turns(
     for _ in range(rounds):
         yield PlayParams(player_positions=player_positions)
         player_positions = {
-            UltimatumPosition.OFFERER: player_positions[UltimatumPosition.DECIDER],
-            UltimatumPosition.DECIDER: player_positions[UltimatumPosition.OFFERER],
+            UltimatumPosition.OFFERER: player_positions[
+                UltimatumPosition.DECIDER
+            ],
+            UltimatumPosition.DECIDER: player_positions[
+                UltimatumPosition.OFFERER
+            ],
         }
 
 
@@ -39,6 +50,7 @@ def ultimatum_static_turns(
 def ultimatum_play_round(
     params: PlayParams, game: BaseScorer, noise: Optional[float] = None
 ) -> Outcome:
+    # TODO(5.0): There is a probably a cleaner way to implement.
     def outcomes_to_actions(
         outcome_1: Outcome, outcome_2: Outcome
     ) -> Tuple[Any]:

--- a/axelrod/ultimatum/player.py
+++ b/axelrod/ultimatum/player.py
@@ -6,6 +6,7 @@ from collections import abc
 from typing import List, Optional, Tuple
 
 from axelrod.game_params import Outcome, Position
+from axelrod.prototypes import BasePlayer
 
 
 class UltimatumPosition(Position):
@@ -57,7 +58,7 @@ class History(abc.Sequence):
         return self._decide_history
 
 
-class UltimatumPlayer(object):
+class UltimatumPlayer(BasePlayer):
     """A generic abstract player of the ultimatum game."""
 
     name = "Ultimatum Player"

--- a/axelrod/ultimatum/player.py
+++ b/axelrod/ultimatum/player.py
@@ -1,5 +1,16 @@
-"""
-Ultimatum Game.
+"""Define player for Ultimatum game
+
+The Ultimatum game involves two players.  The first player chooses how to split
+1.0 point, offering some portion to the other player.  The second player decides
+if they accept or reject the offer.  If the offer is accepted, then the second
+player gets the offered amount, and the first player gets the remainder of the
+1.0 point.  If the offer is rejected, then neither player gets any points.
+
+The game has two roles or Positions, an Offerer and a Decider.  Every
+UltimatumPlayer needs to have a strategy for how to offer and how to decide.
+
+This file also defines a history class which contains functionality for looking
+up only offer history and only decision history.
 """
 
 from collections import abc
@@ -14,6 +25,8 @@ class UltimatumPosition(Position):
     DECIDER = 2
 
 
+# TODO(5.0): History and Outcomes have proven to not be that user-friendly.
+#  Explore different APIs.
 class History(abc.Sequence):
     """A history class for ultimatum player.
 
@@ -78,7 +91,8 @@ class UltimatumPlayer(BasePlayer):
         raise NotImplementedError
 
     def consider(self, offer: float) -> bool:
-        """Decision rule for whether to accept the offer."""
+        """Decision rule for whether to accept the offer.  True means accept,
+        and false means reject."""
         raise NotImplementedError
 
     def set_match_attributes(self, **match_attributes):

--- a/axelrod/ultimatum/player.py
+++ b/axelrod/ultimatum/player.py
@@ -81,6 +81,9 @@ class UltimatumPlayer(BasePlayer):
         """Decision rule for whether to accept the offer."""
         raise NotImplementedError
 
+    def set_match_attributes(self, **match_attributes):
+        pass
+
     def play(
         self, coplayer: "UltimatumPlayer", noise: Optional[float] = None
     ) -> Tuple[Outcome, Outcome]:

--- a/axelrod/ultimatum/player.py
+++ b/axelrod/ultimatum/player.py
@@ -5,8 +5,8 @@ Ultimatum Game.
 from collections import abc
 from typing import List, Optional, Tuple
 
-from axelrod.game_params import Outcome, Position
-from axelrod.prototypes import BasePlayer
+from axelrod.game_params import Position
+from axelrod.prototypes import BasePlayer, Outcome
 
 
 class UltimatumPosition(Position):

--- a/axelrod/ultimatum/strategies.py
+++ b/axelrod/ultimatum/strategies.py
@@ -47,6 +47,7 @@ class SimpleThresholdPlayer(
     """
 
     name = "Simple Threshold Player"
+    classifier = dict(stochastic=False)
 
     def __init__(
         self, offer_proportion: float = 0.5, lower_threshold: float = 0.5
@@ -71,6 +72,7 @@ class AcceptanceThresholdPlayer(
     """
 
     name = "Acceptance Threshold Player"
+    classifier = dict(stochastic=False)
 
     def __init__(
         self,
@@ -96,8 +98,7 @@ class DoubleThresholdsPlayer(ConsiderThresholdPlayer, UltimatumPlayer):
     """
 
     name = "Double Thresholds Player"
-
-    classifier = dict(stochastic=True)
+    classifier = dict(stochastic=False)
 
     def __init__(
         self,
@@ -140,6 +141,7 @@ class DistributionPlayer(UltimatumPlayer):
     """
 
     name = "Distribution Player"
+    classifier = dict(stochastic=True)
 
     def __init__(
         self,
@@ -174,6 +176,7 @@ class BinarySearchOfferPlayer(ConsiderThresholdPlayer, UltimatumPlayer):
     """
 
     name = "Binary Search Offers Player"
+    classifier = dict(stochastic=False)
 
     def __init__(
         self, lower_threshold: float = 0.5, upper_threshold: float = 1.0,
@@ -210,6 +213,7 @@ class TitForTatOfferPlayer(ConsiderThresholdPlayer, UltimatumPlayer):
     """
 
     name = "TitForTat Offer Player"
+    classifier = dict(stochastic=False)
 
     def __init__(
         self,
@@ -241,6 +245,7 @@ class TitForTatDecisionPlayer(ConstantOfferPlayer, UltimatumPlayer):
     """
 
     name = "TitForTat Decision Player"
+    classifier = dict(stochastic=False)
 
     def __init__(
         self, offer_proportion: float = 0.5, default_acceptance: bool = True
@@ -271,6 +276,7 @@ class RejectionLiftPlayer(ConstantOfferPlayer, UltimatumPlayer):
     """
 
     name = "Rejection-Lift Player"
+    classifier = dict(stochastic=False)
 
     def __init__(self, offer_proportion: float = 0.5, discount: float = 0.9):
         super().__init__()

--- a/axelrod/ultimatum/strategies.py
+++ b/axelrod/ultimatum/strategies.py
@@ -1,6 +1,4 @@
-"""
-Implements strategies for ultimatum.
-"""
+"""Implements strategies for ultimatum."""
 
 from typing import Optional
 

--- a/docs/reference/adding_games.rst
+++ b/docs/reference/adding_games.rst
@@ -1,0 +1,36 @@
+Other games
+===========
+
+The Axelrod library was originally built to support playing the iterated
+prisoner's dilemma.  But there is work underway to expand this to other games,
+for example, the Ultimatum game.
+
+This document explains what work needs to be done to add a new game to the
+Axelrod library.
+
+Adding a game
+-------------
+
+You should first create a folder in axelrod/ with the name of the game.
+
+Then you need to build the following objects within that folder:
+
+- A player class which inherits from BasePlayer.  Every strategy that will
+  compete in your game should inherit from this class, so you should include
+  stubs of any function that you expect this function to have.  Player class
+  should have class variables of name (a text field specific to a strategy), and
+  classifiers dict, which should at least include a "stochastic" key with a
+  boolean value indicating if the strategy includes any random components.
+- Specific strategies, inheriting from your player class.
+- A scorer class which inherits from BaseScorer and implements the score method,
+  which returns the Scores resulting from a tuple of Actions.
+- Position enumeration (if not symmetric 2-player).  This indicates all the
+  possible positions for a game.  Every round of the game should be played with
+  exactly one player filling each position.
+- A GameParams instance, which includes:
+
+    - game_type: A short string identifying your new game.
+    - generate_play_params: An iterator which describes how to choose players
+      for each position, from a pool of players, for each round of play.
+    - play_round: A function which, given players/positions, plays a round of
+      the game, returning Actions.

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -14,3 +14,4 @@ Contents:
    all_strategies.rst
    bibliography.rst
    glossary.rst
+   adding_games.rst


### PR DESCRIPTION
After defining game_params for ultimatum, we can run a Match.  I added an integration test which does this.

I added some TODOs to track things I want to circle back to, and I added more docstrings to all the new files, following marcharper's request on the last PR.

I added an "adding_games" document in our documentation, which outlines all the things that need to be addressed when we create a new game.  This is a bit of stub and will need to be expanded, but want to use it to keep track of all the changes I'm making.