### PR TITLE
Move common play functionality

### DIFF
--- a/axelrod/action.py
+++ b/axelrod/action.py
@@ -10,6 +10,8 @@ from enum import Enum
 from functools import total_ordering
 from typing import Iterable
 
+from .prototypes import BaseAction
+
 
 class UnknownActionError(ValueError):
     """Error indicating an unknown action was used."""

--- a/axelrod/game.py
+++ b/axelrod/game.py
@@ -1,11 +1,11 @@
-from typing import Tuple, Union
+from typing import Dict, Tuple
 
 from axelrod import Action
-from .prototypes import BaseScorer
+from .game_params import Symm2pPosition
+from .prototypes import BaseScorer, Position, Score
 
 C, D = Action.C, Action.D
-
-Score = Union[int, float]
+POS_1, POS_2 = Symm2pPosition.POS_1, Symm2pPosition.POS_2
 
 
 # TODO(5.0): Consider making Game a part of the GameParams
@@ -18,7 +18,9 @@ class Game(BaseScorer):
         The numerical score attribute to all combinations of action pairs.
     """
 
-    def __init__(self, r: Score = 3, s: Score = 0, t: Score = 5, p: Score = 1) -> None:
+    def __init__(
+        self, r: Score = 3, s: Score = 0, t: Score = 5, p: Score = 1
+    ) -> None:
         """Create a new game object.
 
         Parameters
@@ -32,7 +34,12 @@ class Game(BaseScorer):
         p: int or float
             Score obtained by both player for mutual defection.
         """
-        self.scores = {(C, C): (r, r), (D, D): (p, p), (C, D): (s, t), (D, C): (t, s)}
+        self.scores = {
+            (C, C): (r, r),
+            (D, D): (p, p),
+            (C, D): (s, t),
+            (D, C): (t, s),
+        }
 
     def RPST(self) -> Tuple[Score, Score, Score, Score]:
         """Returns game matrix values in Press and Dyson notation."""
@@ -43,18 +50,6 @@ class Game(BaseScorer):
         return R, P, S, T
 
     def score(self, pair: Tuple[Action, Action]) -> Tuple[Score, Score]:
-        """Returns the appropriate score for a decision pair.
-
-        Parameters
-        ----------
-        pair: tuple(Action, Action)
-            A pair actions for two players, for example (C, C).
-
-        Returns
-        -------
-        tuple of int or float
-            Scores for two player resulting from their actions.
-        """
         return self.scores[pair]
 
     def __repr__(self) -> str:

--- a/axelrod/game_params.py
+++ b/axelrod/game_params.py
@@ -31,7 +31,6 @@ from .prototypes import (
     BaseAction,
     BasePlayer,
     BaseScorer,
-    BaseHistory,
     Outcome,
     Position,
 )
@@ -62,8 +61,6 @@ class GameParams(object):
     ----------
     game_type : Text
         Unique name for the type of game (IPD, Ultimatum, etc.)
-    history_factory : Callable[[], BaseHistory]
-        Returns a default history of the appropriate derived class.
     generate_play_params : Callable[
         [List[BasePlayer], int], Generator[PlayParams, None, None]
     ]
@@ -84,7 +81,6 @@ class GameParams(object):
     """
 
     game_type: Text = attr.ib()
-    history_factory: Callable[[], BaseHistory] = attr.ib()
     # TODO(5.0): This should be called generate_round, since the user won't know
     #  what PlayParams are.
     generate_play_params: Callable[

--- a/axelrod/ipd_params.py
+++ b/axelrod/ipd_params.py
@@ -12,9 +12,11 @@ from .action import Action
 from .game_params import (
     GameParams,
     Symm2pPosition,
+    symm2p_get_actions,
     symm2p_generate_play_params,
     symm2p_play_round
 )
+from .history import History
 from .prototypes import Outcome
 
 
@@ -27,7 +29,9 @@ def ipd_result(outcome: Outcome) -> Tuple[Action, Action]:
 
 ipd_params = GameParams(
     game_type="IPD",
+    history_factory=lambda: History(),
     generate_play_params=symm2p_generate_play_params,
     play_round=symm2p_play_round,
+    get_actions=symm2p_get_actions,
     result=ipd_result,
 )

--- a/axelrod/ipd_params.py
+++ b/axelrod/ipd_params.py
@@ -29,7 +29,6 @@ def ipd_result(outcome: Outcome) -> Tuple[Action, Action]:
 
 ipd_params = GameParams(
     game_type="IPD",
-    history_factory=lambda: History(),
     generate_play_params=symm2p_generate_play_params,
     play_round=symm2p_play_round,
     get_actions=symm2p_get_actions,

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -9,6 +9,7 @@ import numpy as np
 from axelrod.action import Action
 from axelrod.game import DefaultGame
 from .game_params import Symm2pPosition
+from .history import History
 from .ipd_params import ipd_params
 from axelrod.prototypes import BasePlayer, PlayerName
 
@@ -24,6 +25,9 @@ class Player(BasePlayer):
 
     name: PlayerName = "Player"
     classifier = {}  # type: Dict[str, Any]
+
+    def history_factory(self):
+        return History()
 
     def __new__(cls, *args, **kwargs):
         """Caches arguments for Player cloning."""

--- a/axelrod/prototypes.py
+++ b/axelrod/prototypes.py
@@ -96,7 +96,7 @@ class BasePlayer(object):
 
         Must be overwritten for each derived Player class.
         """
-        return BaseHistory()
+        return BaseHistory()  # pragma: no cover
 
     def reset(self) -> None:
         self._history = self.history_factory()

--- a/axelrod/prototypes.py
+++ b/axelrod/prototypes.py
@@ -88,11 +88,18 @@ class BasePlayer(object):
             raise RuntimeError(  # pragma: no cover
                 "game_params must be set before initializing parent."
             )
-        self._history = self.game_params.history_factory()
+        self._history = self.history_factory()
         self.classifier = copy.deepcopy(self.classifier)
 
+    def history_factory(self):
+        """Generates a history class.
+
+        Must be overwritten for each derived Player class.
+        """
+        return BaseHistory()
+
     def reset(self) -> None:
-        self._history = self.game_params.history_factory()
+        self._history = self.history_factory()
 
     def update_outcome_history(self, outcome):
         """Updates history using an outcome."""

--- a/axelrod/prototypes.py
+++ b/axelrod/prototypes.py
@@ -3,31 +3,19 @@
 This is used for type annotations and deriving functions.
 """
 
+from collections import abc
+import copy
 from enum import Enum
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Text, Tuple, Union
 
 import attr
 
-from .action import Action
-
+PlayerName = Text
 Position = Enum
 Score = Union[float, int]
 
-
-# TODO(5.0): Explore what functions should be shared for all players / all
-#  scorers.
-class BasePlayer(object):
-    """A player for any game.  No guaranteed functionality."""
-    pass
-
-
-class BaseScorer(object):
-    """Scorer function for any game.  Should at least include a score
-    function."""
-    def score(self, actions: Tuple[Action, ...]) -> Tuple[Score, ...]:
-        """Taking player actions in some understood order, returns the scores
-        in this round for the player taking that action (in the same order)."""
-        raise NotImplementedError()  # pragma: no cover
+# TODO(5.0): Need to build this out.
+BaseAction = Any
 
 
 @attr.s
@@ -38,16 +26,122 @@ class Outcome(object):
     ----------
     actions : Dict[Position, Any]
         The chosen action for each player, keyed by the player's position.
-    scores : Dict[Position, Score]
+    scores : Optional[Dict[Position, Score]]
         The resulting score for the player, keyed by the player's position.
-    position : Position
+    position : Optional[Position]
         An Outcome object will contain info about each position's action and
         score, but may also have a perspective indicating a single position.
         For example, when Outcome is stored to a player's history, position
         indicates which position that player played as on that turn.
     """
 
-    # TODO(5.0): Change Any to Action, creating an ultimatum action.
+    # TODO(5.0): Change Any to Action, creating an ultimatum action, throughout.
     actions: Dict[Position, Any] = attr.ib()
-    scores: Dict[Position, Score] = attr.ib()
+    scores: Optional[Dict[Position, Score]] = attr.ib(default=None)
     position: Optional[Position] = attr.ib(default=None)
+
+    def play(self) -> Any:
+        if not self.position:
+            raise ValueError("No position set.")
+        return self.actions[self.position]
+
+    def coplay(self) -> Any:
+        if not self.position:
+            raise ValueError("No position set.")
+        if len(self.actions) != 2:
+            raise RuntimeError("Coplay not defined for multiplayer.")
+        for k, v in self.actions.items():
+            if k != self.position:
+                return v
+
+
+# TODO(5.0): Explore what functions should be shared for all players / all
+#  scorers, and all histories.  Probably most of it.
+class BaseHistory(abc.Sequence):
+    """A class representing a player's history.
+
+    The base class maintains a basic sequence of Outcomes.  The class can be
+    derived to expand or change the behavior.
+    """
+
+    def __init__(self):
+        self._history: List[Outcome] = list()
+
+    def __getitem__(self, index):
+        return self._history[index]
+
+    def __len__(self) -> int:
+        return len(self._history)
+
+    def append(self, outcome: Outcome) -> None:
+        """Append the given Outcome to the history list."""
+        self._history.append(outcome)
+
+
+class BasePlayer(object):
+    """A player for any game."""
+
+    classifier = dict()
+
+    def __init__(self):
+        if "game_params" not in self.__dict__:
+            raise RuntimeError(  # pragma: no cover
+                "game_params must be set before initializing parent."
+            )
+        self._history = self.game_params.history_factory()
+        self.classifier = copy.deepcopy(self.classifier)
+
+    def reset(self) -> None:
+        self._history = self.game_params.history_factory()
+
+    def update_outcome_history(self, outcome):
+        """Updates history using an outcome."""
+        self._history.append_outcome(outcome)
+
+    # TODO(5.0): Will need to think about how to generalize to three players.
+    def play(self, coplayer, noise=0):
+        """This pits two players against each other."""
+        # Get one round of play
+        round_params = next(
+            self.game_params.generate_play_params([self, coplayer], 1)
+        )
+        # TODO(5.0): I'd like to provide a scorer here.  Need to rethink
+        #  makes_use_of["game"].  Otherwise should remove score from Outcome,
+        #  which isn't being used.
+        actions = self.game_params.get_actions(round_params, noise=noise)
+        outcome = Outcome(actions=actions)
+
+        # Update histories
+        for pos, player in round_params.player_positions.items():
+            outcome_copy = copy.copy(outcome)
+            outcome_copy.position = pos
+            player.update_outcome_history(outcome_copy)
+            if player is self:
+                result = outcome_copy
+
+        return self.game_params.result(result)
+
+    @property
+    def history(self):
+        return self._history
+
+
+class BaseScorer(object):
+    """Scorer function for any game.  Should at least include a score
+    function."""
+
+    def score(self, actions: Tuple[BaseAction, ...]) -> Tuple[Score, ...]:
+        """Taking player actions in some understood order, returns the scores
+        in this round for the player taking that action (in the same order).
+
+        Parameters
+        ----------
+        actions: tuple(Action, BaseAction)
+            A pair actions for two players, for example (C, C).
+
+        Returns
+        -------
+        tuple of int or float
+            Scores for two player resulting from their actions.
+        """
+        raise NotImplementedError()  # pragma: no cover

--- a/axelrod/random_.py
+++ b/axelrod/random_.py
@@ -1,9 +1,11 @@
+from enum import Enum
 import random
 
 import numpy as np
 from numpy.random import choice
 
 from axelrod.action import Action
+from .prototypes import BaseAction
 
 C, D = Action.C, Action.D
 
@@ -41,12 +43,13 @@ def random_choice(p: float = 0.5) -> Action:
     return D
 
 
-def random_flip(action: Action, threshold: float) -> Action:
-    """
-    Return flipped action with probability `threshold`
+def random_flip(action: BaseAction, threshold: float) -> Action:
+    """Return flipped action with probability `threshold`
+
+    If action is not an Action (IPD action), then just return the passed action
+    with probability 100%.
 
     No random sample is carried out if threshold is 0 or 1.
-
     Parameters
     ----------
     action:
@@ -58,7 +61,8 @@ def random_flip(action: Action, threshold: float) -> Action:
     -------
     axelrod.Action
     """
-    if random_choice(threshold) == C:
+    # TODO(5.0): Make this work for non-IPD.
+    if isinstance(action, Action) and random_choice(threshold) == C:
         return action.flip()
     return action
 

--- a/axelrod/strategies/appeaser.py
+++ b/axelrod/strategies/appeaser.py
@@ -35,4 +35,5 @@ class Appeaser(Player):
                     return D
                 else:
                     return C
+
         return self.history[-1]

--- a/axelrod/tests/integration/test_ultimatum_match.py
+++ b/axelrod/tests/integration/test_ultimatum_match.py
@@ -4,23 +4,10 @@ import axelrod as axl
 from axelrod.prototypes import Outcome
 from axelrod.ultimatum.game import UltimatumScorer
 from axelrod.ultimatum.game_params import ultimatum_alternating_params
-from axelrod.ultimatum.player import UltimatumPosition
-from axelrod.ultimatum.strategies import SimpleThresholdPlayer
+from axelrod.ultimatum import SimpleThresholdPlayer, UltimatumPosition
 
 
 class TestUltimatumMatch(unittest.TestCase):
-    def _build_outcome(self, offer, decision, offer_score, decision_score):
-        return Outcome(
-            actions={
-                UltimatumPosition.OFFERER: offer,
-                UltimatumPosition.DECIDER: decision,
-            },
-            scores={
-                UltimatumPosition.OFFERER: offer_score,
-                UltimatumPosition.DECIDER: decision_score,
-            },
-        )
-
     def test_match_of_simple_threshold_players(self):
         generous = SimpleThresholdPlayer(1.0)
         stingy = SimpleThresholdPlayer(0.0)
@@ -36,12 +23,22 @@ class TestUltimatumMatch(unittest.TestCase):
             game_params=ultimatum_alternating_params,
         )
 
+        results = match.play()
+
         # TODO(5.0): Other match functions for reporting don't work.  List of
         #  Outcomes is hard to parse.
-        self.assertListEqual(
-            match.play(),
-            [
-                self._build_outcome(1.0, True, 0.0, 1.0),
-                self._build_outcome(0.0, False, 0.0, 0.0),
-            ],
-        )
+        for i in [0, 1]:
+            self.assertDictEqual(
+                results[0][i].actions,
+                {
+                    UltimatumPosition.OFFERER: 1.0,
+                    UltimatumPosition.DECIDER: True,
+                },
+            )
+            self.assertDictEqual(
+                results[1][i].actions,
+                {
+                    UltimatumPosition.OFFERER: 0.0,
+                    UltimatumPosition.DECIDER: False,
+                },
+            )

--- a/axelrod/tests/ultimatum/test_player.py
+++ b/axelrod/tests/ultimatum/test_player.py
@@ -33,32 +33,32 @@ class TestPlay(unittest.TestCase):
         coplayer = SimpleThresholdPlayer(0.5, 0.5)
         result = player.play(coplayer)
         np.testing.assert_almost_equal(
-            result[0].scores[UltimatumPosition.OFFERER], 0.4
+            result[0].actions[UltimatumPosition.OFFERER], 0.6
         )
         np.testing.assert_almost_equal(
-            result[0].scores[UltimatumPosition.DECIDER], 0.6
+            result[0].actions[UltimatumPosition.DECIDER], True
         )
         result = coplayer.play(player)
         np.testing.assert_almost_equal(
-            result[0].scores[UltimatumPosition.OFFERER], 0.5
+            result[0].actions[UltimatumPosition.OFFERER], 0.5
         )
         np.testing.assert_almost_equal(
-            result[0].scores[UltimatumPosition.DECIDER], 0.5
+            result[0].actions[UltimatumPosition.DECIDER], True
         )
         player = SimpleThresholdPlayer(0.4, 0.6)
         result = player.play(coplayer)
         np.testing.assert_almost_equal(
-            result[0].scores[UltimatumPosition.OFFERER], 0.0
+            result[0].actions[UltimatumPosition.OFFERER], 0.4
         )
         np.testing.assert_almost_equal(
-            result[0].scores[UltimatumPosition.DECIDER], 0.0
+            result[0].actions[UltimatumPosition.DECIDER], False
         )
         result = coplayer.play(player)
         np.testing.assert_almost_equal(
-            result[0].scores[UltimatumPosition.OFFERER], 0.0
+            result[0].actions[UltimatumPosition.OFFERER], 0.5
         )
         np.testing.assert_almost_equal(
-            result[0].scores[UltimatumPosition.DECIDER], 0.0
+            result[0].actions[UltimatumPosition.DECIDER], False
         )
 
         # Check history

--- a/axelrod/tests/unit/test_pickling.py
+++ b/axelrod/tests/unit/test_pickling.py
@@ -1,5 +1,5 @@
 import unittest
-import pickle
+import dill
 import random
 
 import axelrod as axl
@@ -204,7 +204,7 @@ transformer_instances = [
 
 class TestPickle(unittest.TestCase):
     def assert_equals_instance_from_pickling(self, original_instance):
-        clone = pickle.loads(pickle.dumps(original_instance))
+        clone = dill.loads(dill.dumps(original_instance))
         self.assertEqual(clone, original_instance)
 
     def assert_original_equals_pickled(self, player_, turns=10):
@@ -212,7 +212,7 @@ class TestPickle(unittest.TestCase):
         for opponent_class in opponents:
             # Check that player and copy play the same way.
             player = player_.clone()
-            clone = pickle.loads(pickle.dumps(player))
+            clone = dill.loads(dill.dumps(player))
             clone = clone.clone()
 
             opponent_1 = opponent_class()
@@ -252,7 +252,7 @@ class TestPickle(unittest.TestCase):
 
     def test_final_transformer_called(self):
         player = axl.Alexei()
-        copy = pickle.loads(pickle.dumps(player))
+        copy = dill.loads(dill.dumps(player))
         match = axl.Match((player, copy), turns=3)
         results = match.play()
         self.assertEqual(results, [(C, C), (C, C), (D, D)])
@@ -367,13 +367,9 @@ class TestPickle(unittest.TestCase):
         class LocalCooperator(axl.Cooperator):
             pass
 
-        un_transformed = LocalCooperator()
-
-        self.assertRaises(AttributeError, pickle.dumps, un_transformed)
-
         player = axl.strategy_transformers.FlipTransformer()(LocalCooperator)()
-        pickled = pickle.dumps(player)
-        self.assertRaises(AttributeError, pickle.loads, pickled)
+        pickled = dill.dumps(player)
+        self.assertRaises(AttributeError, dill.loads, pickled)
 
     def test_with_various_name_prefixes(self):
         no_prefix = Flip()

--- a/axelrod/tests/unit/test_prototypes.py
+++ b/axelrod/tests/unit/test_prototypes.py
@@ -1,0 +1,32 @@
+import unittest
+
+from axelrod.prototypes import Outcome, Position
+
+
+class TestPosition(Position):
+    POS_1 = 1
+    POS_2 = 2
+    POS_3 = 3
+
+
+class TestOutcome(unittest.TestCase):
+    def test_play_coplay_returns_value_error(self):
+        outcome = Outcome(
+            actions={TestPosition.POS_1: 1, TestPosition.POS_2: 2}
+        )
+        with self.assertRaises(ValueError):
+            outcome.play()
+        with self.assertRaises(ValueError):
+            outcome.coplay()
+
+    def test_coplay_returns_runtime_error(self):
+        outcome = Outcome(
+            actions={
+                TestPosition.POS_1: 1,
+                TestPosition.POS_2: 2,
+                TestPosition.POS_3: 3,
+            },
+            position=TestPosition.POS_1,
+        )
+        with self.assertRaises(RuntimeError):
+            outcome.coplay()

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -2,11 +2,11 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+import dill
 import io
 import logging
 import os
 import pathlib
-import pickle
 import warnings
 from multiprocessing import Queue, cpu_count
 
@@ -511,9 +511,9 @@ class TestTournament(unittest.TestCase):
         # For test coverage purposes. This confirms PickleableMock can be
         # pickled exactly once. Windows multi-processing must pickle this Mock
         # exactly once during testing.
-        pickled = pickle.loads(pickle.dumps(tournament))
+        pickled = dill.loads(dill.dumps(tournament))
         self.assertIsInstance(pickled._write_interactions_to_file, MagicMock)
-        self.assertRaises(pickle.PicklingError, pickle.dumps, pickled)
+        self.assertRaises(dill.PicklingError, dill.dumps, pickled)
 
         self.assertTrue(tournament._run_parallel())
 

--- a/axelrod/ultimatum/game.py
+++ b/axelrod/ultimatum/game.py
@@ -1,6 +1,7 @@
-from typing import Tuple
+from typing import Any, Dict, Tuple
 
 from axelrod.prototypes import BaseScorer, Score
+from .position import UltimatumPosition
 
 
 class UltimatumScorer(BaseScorer):
@@ -8,8 +9,7 @@ class UltimatumScorer(BaseScorer):
         super().__init__()
 
     def score(self, offer_decision: Tuple) -> Tuple[Score, Score]:
-        """Given offer and decision, returns the score to the offerer and
-        decider, resp."""
+        """Expects actions as offer first, then decision."""
         offer, decision = offer_decision
         if decision:
             return 1.0 - offer, offer

--- a/axelrod/ultimatum/game_params.py
+++ b/axelrod/ultimatum/game_params.py
@@ -100,7 +100,6 @@ def ultimatum_result(outcome: Outcome) -> Tuple[Outcome, Outcome]:
 
 ultimatum_alternating_params = GameParams(
     game_type="Ultimatum",
-    history_factory=lambda: UltimatumHistory(),
     generate_play_params=ultimatum_alternating_turns,
     play_round=ultimatum_play_round,
     get_actions=ultimatum_get_actions,
@@ -110,7 +109,6 @@ ultimatum_alternating_params = GameParams(
 
 ultimatum_static_params = GameParams(
     game_type="Ultimatum",
-    history_factory=lambda: UltimatumHistory(),
     generate_play_params=ultimatum_static_turns,
     play_round=ultimatum_play_round,
     get_actions=ultimatum_get_actions,

--- a/axelrod/ultimatum/history.py
+++ b/axelrod/ultimatum/history.py
@@ -1,0 +1,46 @@
+"""..........."""
+
+from typing import List
+
+from axelrod.prototypes import BaseHistory, Outcome
+from .position import UltimatumPosition
+
+
+# TODO(5.0): History and Outcomes have proven to not be that user-friendly.
+#  Explore different APIs.
+class UltimatumHistory(BaseHistory):
+    """A history class for ultimatum player.
+
+    The parent class continues to manage self._history, but this derived class
+    adds extra breakdowns.
+
+    Attributes
+    ----------
+    _offer_history: List[Outcome]
+        Outcome history for previous rounds of play in which the player was the
+        offerer.
+    _decide_history: List[Outcome]
+        Outcome history for previous rounds of play in which the player was the
+        decider.
+    """
+
+    def __init__(self):
+        self._offer_history: List[Outcome] = list()
+        self._decide_history: List[Outcome] = list()
+        super().__init__()
+
+    def append_outcome(self, outcome: Outcome) -> None:
+        """Append to a sublist based on position of the Outcome."""
+        if outcome.position == UltimatumPosition.OFFERER:
+            self._offer_history.append(outcome)
+        if outcome.position == UltimatumPosition.DECIDER:
+            self._decide_history.append(outcome)
+        super().append(outcome)
+
+    @property
+    def offers(self) -> List[Outcome]:
+        return self._offer_history
+
+    @property
+    def decisions(self) -> List[Outcome]:
+        return self._decide_history

--- a/axelrod/ultimatum/player.py
+++ b/axelrod/ultimatum/player.py
@@ -15,6 +15,7 @@ up only offer history and only decision history.
 
 from axelrod.prototypes import BasePlayer
 from .game_params import ultimatum_static_params
+from .history import UltimatumHistory
 
 
 class UltimatumPlayer(BasePlayer):
@@ -22,6 +23,9 @@ class UltimatumPlayer(BasePlayer):
 
     name = "Ultimatum Player"
     classifier = dict(stochastic=False)
+
+    def history_factory(self):
+        return UltimatumHistory()
 
     def __init__(self):
         # TODO(5.0): Between the two ultimatum game_params, the only difference

--- a/axelrod/ultimatum/position.py
+++ b/axelrod/ultimatum/position.py
@@ -1,0 +1,9 @@
+"""Holds UltimatumPosition"""
+
+from axelrod.prototypes import Position
+
+
+# TODO(5.0): Move to someplace better.
+class UltimatumPosition(Position):
+    OFFERER = 1
+    DECIDER = 2

--- a/axelrod/ultimatum/strategies.py
+++ b/axelrod/ultimatum/strategies.py
@@ -4,7 +4,8 @@ from typing import Optional
 
 from scipy import stats
 
-from .player import UltimatumPlayer, UltimatumPosition
+from .player import UltimatumPlayer
+from .position import UltimatumPosition
 
 
 class ConsiderThresholdPlayer(object):

--- a/docs/reference/adding_games.rst
+++ b/docs/reference/adding_games.rst
@@ -21,6 +21,11 @@ Then you need to build the following objects within that folder:
   should have class variables of name (a text field specific to a strategy), and
   classifiers dict, which should at least include a "stochastic" key with a
   boolean value indicating if the strategy includes any random components.
+
+    - If the a basic sequence of Outcomes is insufficient, derive from
+      BaseHistory, and make _build_history in the player class initialize an
+      instance of this new history.
+
 - Specific strategies, inheriting from your player class.
 - A scorer class which inherits from BaseScorer and implements the score method,
   which returns the Scores resulting from a tuple of Actions.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ attrs>=19.3.0
 cloudpickle>=0.2.1
 fsspec>=0.4.3
 dask>=2.3.0
+dill
 matplotlib>=2.0.0
 numpy>=1.9.2
 pandas>=0.18.1

--- a/test_outputs/classifier_test.yaml
+++ b/test_outputs/classifier_test.yaml
@@ -1,0 +1,4 @@
+Cooperator:
+  name: Cooperator
+Defector:
+  name: Defector


### PR DESCRIPTION
We make a BasePlayer, with a common play function.  This play function looks at a GameParams object (passed at initialization) to use get_actions, which says how to get a set of actions from the players playing; it then saves history and returns outcomes.  (To save the GameParams object, we need to change pickling to dilling in many places.)  In order to save history, we need to make a common BaseHistory class, along with a history factory that we store to GameParams.