### PR TITLE
Modify test to ensure that all strategies have names

### DIFF
--- a/axelrod/tests/integration/test_names.py
+++ b/axelrod/tests/integration/test_names.py
@@ -5,7 +5,7 @@ import axelrod as axl
 
 class TestNames(unittest.TestCase):
     def test_all_strategies_have_names(self):
-        names = [s.name for s in axl.all_strategies if s.name]
+        names = [s.name for s in axl.all_strategies if s.name != 'Player']
         self.assertEqual(len(names), len(axl.all_strategies))
 
     def test_all_names_are_unique(self):

--- a/docs/tutorials/advanced/classification_of_strategies.rst
+++ b/docs/tutorials/advanced/classification_of_strategies.rst
@@ -43,7 +43,7 @@ strategy's logic as default, we use :code:`Classifiers[<classifier>](
 <strategy>)`::
 
     >>> from axelrod import Classifiers
-    >>> Classifiers['memory_depth'](axl.TitForTat)
+    >>> Classifiers['memory_depth'](axl.TitForTat())
     1
     >>> Classifiers['stochastic'](axl.Random())
     True


### PR DESCRIPTION
Test 'test_all_strategies_have_names' is always passed because when a strategy has no name, it adopts the name attribute from the 'Player' class.