### PR TITLE
Add a long-run strategy to the filtering test

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -51,8 +51,8 @@ jobs:
         python run_mypy.py
     - name: Check imports are sorted
       run: |
-        python -m pip install isort
-        python -m isort --check-only
+        python -m pip install "isort==4.3.21"
+        python -m isort --check-only --recursive axelrod/.
     - name: Check that all strategies are indexed
       run: |
         python run_strategy_indexer.py

--- a/axelrod/tests/integration/test_filtering.py
+++ b/axelrod/tests/integration/test_filtering.py
@@ -21,6 +21,7 @@ class TestFiltersAgainstComprehensions(unittest.TestCase):
         warnings.simplefilter("default", category=UserWarning)
 
     @given(strategies=strategy_lists(min_size=20, max_size=20))
+    @example(strategies=[axl.DBS, axl.Cooperator])
     def test_boolean_filtering(self, strategies):
 
         classifiers = [

--- a/docs/tutorials/advanced/tournament_results.rst
+++ b/docs/tutorials/advanced/tournament_results.rst
@@ -343,7 +343,7 @@ This gives the count of cooperations made by each player during the first turn
 of every match::
 
     >>> results.initial_cooperation_count
-    [9.0, 0.0, 9.0, 9.0]
+    [9, 0, 9, 9]
 
 Each player plays an opponent a total of 9 times (3 opponents and 3
 repetitions). Apart from the :code:`Defector`, they all cooperate on the first


### PR DESCRIPTION
Currently `test_boolean_filtering` only uses strategies as given by the `strategy_list` hypothesis strategy. This by default only picks short run time strategies so we are not ensuring that the long run filter works.