### PR TITLE
Update finite_state_machines.py

### DIFF
--- a/axelrod/strategies/finite_state_machines.py
+++ b/axelrod/strategies/finite_state_machines.py
@@ -1024,8 +1024,8 @@ class TF3(FSMPlayer):
         super().__init__(
             transitions=transitions, initial_state=0, initial_action=C
         )
-
- class EvolvedFSM8(FSMPlayer):
+        
+class EvolvedFSM8(FSMPlayer):
     """
     An 8 state FSM player trained with an evolutionary algorithm.
     

--- a/axelrod/strategies/finite_state_machines.py
+++ b/axelrod/strategies/finite_state_machines.py
@@ -1029,30 +1029,7 @@ class EvolvedFSM8(FSMPlayer):
     """
     An 8 state FSM player trained with an evolutionary algorithm.
     
-    Evolved from the 10 state FSM designed by Frederick Vincent with transitions
-    
-    transitions = (
-            (1, C, 2, C),
-            (1, D, 3, D),
-            (2, C, 1, C),
-            (2, D, 4, D),
-            (3, C, 4, C),
-            (3, D, 5, D),
-            (4, C, 5, C),
-            (4, D, 6, D),
-            (5, C, 2, C),
-            (5, D, 9, D),
-            (6, C, 5, D),
-            (6, D, 7, D),
-            (7, C, 5, C),
-            (7, D, 8, D),
-            (8, C, 5, D),
-            (8, D, 5, C),
-            (9, C, 2, C),
-            (9, D, 10, C),
-            (10, C, 2, C),
-            (10, D, 4, D)
-    )
+    Evolved from the 10 state FSM designed by Frederick Vincent.
 
     Names:
 

--- a/axelrod/strategies/finite_state_machines.py
+++ b/axelrod/strategies/finite_state_machines.py
@@ -1024,3 +1024,71 @@ class TF3(FSMPlayer):
         super().__init__(
             transitions=transitions, initial_state=0, initial_action=C
         )
+
+ class EvolvedFSM8(FSMPlayer):
+    """
+    An 8 state FSM player trained with an evolutionary algorithm.
+    
+    Evolved from the 10 state FSM designed by Frederick Vincent with transitions
+    
+    transitions = (
+            (1, C, 2, C),
+            (1, D, 3, D),
+            (2, C, 1, C),
+            (2, D, 4, D),
+            (3, C, 4, C),
+            (3, D, 5, D),
+            (4, C, 5, C),
+            (4, D, 6, D),
+            (5, C, 2, C),
+            (5, D, 9, D),
+            (6, C, 5, D),
+            (6, D, 7, D),
+            (7, C, 5, C),
+            (7, D, 8, D),
+            (8, C, 5, D),
+            (8, D, 5, C),
+            (9, C, 2, C),
+            (9, D, 10, C),
+            (10, C, 2, C),
+            (10, D, 4, D)
+    )
+
+    Names:
+
+        - Evolved FSM 8: Original name by Frederick Vincent & Dashiell Fryer
+    """
+
+    name = "Evolved FSM 8"
+    classifier = {
+        "memory_depth": float("inf"),
+        "stochastic": False,
+        "long_run_time": False,
+        "inspects_source": False,
+        "manipulates_source": False,
+        "manipulates_state": False,
+    }
+
+    def __init__(self) -> None:
+        transitions =  (
+            (0, C, 2, C), 
+            (0, D, 7, C), 
+            (1, C, 0, D), 
+            (1, D, 4, D), 
+            (2, C, 2, D), 
+            (2, D, 7, D), 
+            (3, C, 6, D), 
+            (3, D, 4, C), 
+            (4, C, 4, C), 
+            (4, D, 6, D), 
+            (5, C, 2, D), 
+            (5, D, 7, D), 
+            (6, C, 3, C), 
+            (6, D, 5, D), 
+            (7, C, 2, C), 
+            (7, D, 3, D)
+        )
+
+        super().__init__(
+            transitions=transitions, initial_state=4, initial_action=C
+        )


### PR DESCRIPTION
The Evolved FSM 8 was evolved from a 10 state FSM designed to reduce the Cooperation rate after DD and CD while increasing the Cooperation rate after DC and CC. That strategy scored well in tournaments but after evolving for 500 generations results in this winning strategy.