### PR TITLE
Heterogeneous play with custom Match classes

### DIFF
--- a/axelrod/moran.py
+++ b/axelrod/moran.py
@@ -29,6 +29,7 @@ class MoranProcess(object):
         mutation_method="transition",
         stop_on_fixation=True,
         seed=None,
+        match_class=Match,
     ) -> None:
         """
         An agent based Moran process class. In each round, each player plays a
@@ -106,6 +107,7 @@ class MoranProcess(object):
         else:
             self.deterministic_cache = DeterministicCache()
         self.turns = turns
+        self.match_class = match_class
         self.prob_end = prob_end
         self.game = game
         self.noise = noise
@@ -376,7 +378,7 @@ class MoranProcess(object):
         for i, j in self._matchup_indices():
             player1 = self.players[i]
             player2 = self.players[j]
-            match = Match(
+            match = self.match_class(
                 (player1, player2),
                 turns=self.turns,
                 prob_end=self.prob_end,
@@ -574,3 +576,4 @@ class ApproximateMoranProcess(MoranProcess):
         except KeyError:  # If players are stored in opposite order
             match_scores = self.cached_outcomes[player_names[::-1]].sample()
             return match_scores[::-1]
+            

--- a/axelrod/tests/unit/test_heterogeneous.py
+++ b/axelrod/tests/unit/test_heterogeneous.py
@@ -1,0 +1,364 @@
+import filecmp
+import pathlib
+import unittest
+
+import axelrod as axl
+from axelrod import MoranProcess
+from axelrod.load_data_ import axl_filename
+from axelrod.strategy_transformers import FinalTransformer
+from axelrod.tests.property import tournaments
+from hypothesis import given, settings
+
+import unittest
+from collections import Counter
+
+C, D = axl.Action.C, axl.Action.D
+random = axl.RandomGenerator()
+
+masses = [1 * i for i in range(20)]
+
+class MassBaseMatch(axl.Match):
+    """Axelrod Match object with a modified final score function to enable mass to influence the final score as a multiplier"""
+    def final_score_per_turn(self):
+        base_scores = axl.Match.final_score_per_turn(self)
+        return [player.mass * score for player, score in zip(self.players, base_scores)] 
+
+def set_player_mass(players, masses):
+    """Add mass attribute to player strategy classes to be accessable via self.mass"""
+    for player, mass in zip(players, masses):
+        setattr(player, "mass", mass)
+
+class TestTournament(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.game = axl.Game()
+        cls.players = [
+            axl.Cooperator(),
+            axl.TitForTat(),
+            axl.Defector(),
+            axl.Grudger(),
+            axl.GoByMajority(),
+        ]
+        cls.masses = [100, -150, 0, 100, 500]
+        cls.player_names = [str(p) for p in cls.players]
+        cls.test_name = "test"
+        cls.test_repetitions = 3
+        set_player_mass(cls.players, cls.masses)
+
+        cls.expected_outcome = [
+            ("Cooperator", [45, 45, 45]),
+            ("Defector", [52, 52, 52]),
+            ("Grudger", [49, 49, 49]),
+            ("Soft Go By Majority", [49, 49, 49]),
+            ("Tit For Tat", [49, 49, 49]),
+        ]
+        cls.expected_outcome.sort()
+
+    @given(
+        tournaments(
+            strategies=axl.short_run_time_strategies,
+            min_size=10,
+            max_size=30,
+            min_turns=2,
+            max_turns=210,
+            min_repetitions=1,
+            max_repetitions=4,
+        )
+    )
+    @settings(max_examples=1)
+    def test_big_tournaments(self, tournament):
+        """A test to check that tournament runs with a sample of non-cheating
+        strategies."""
+        path = pathlib.Path("test_outputs/test_tournament.csv")
+        filename = axl_filename(path)
+        self.assertIsNone(
+            tournament.play(
+                progress_bar=False, filename=filename, build_results=False
+            )
+        )
+
+    def test_serial_play(self):
+        tournament = axl.Tournament(
+            name=self.test_name,
+            players=self.players,
+            game=self.game,
+            turns=5,
+            repetitions=self.test_repetitions,
+            match_class=MassBaseMatch,
+        )
+        scores = tournament.play(progress_bar=False).scores
+        actual_outcome = sorted(zip(self.player_names, scores))
+        self.assertEqual(actual_outcome, self.expected_outcome)
+
+    def test_parallel_play(self):
+        tournament = axl.Tournament(
+            name=self.test_name,
+            players=self.players,
+            game=self.game,
+            turns=5,
+            repetitions=self.test_repetitions,
+            match_class=MassBaseMatch,
+        )
+        scores = tournament.play(processes=2, progress_bar=False).scores
+        actual_outcome = sorted(zip(self.player_names, scores))
+        self.assertEqual(actual_outcome, self.expected_outcome)
+
+    def test_repeat_tournament_deterministic(self):
+        """A test to check that tournament gives same results."""
+        deterministic_players = [
+            s()
+            for s in axl.short_run_time_strategies
+            if not axl.Classifiers["stochastic"](s())
+        ]
+        files = []
+        for _ in range(2):
+            tournament = axl.Tournament(
+                name="test",
+                players=deterministic_players,
+                game=self.game,
+                turns=2,
+                repetitions=2,
+                match_class=MassBaseMatch,
+            )
+            path = pathlib.Path(
+                "test_outputs/stochastic_tournament_{}.csv".format(_)
+            )
+            files.append(axl_filename(path))
+            tournament.play(
+                progress_bar=False, filename=files[-1], build_results=False
+            )
+        self.assertTrue(filecmp.cmp(files[0], files[1]))
+
+    def test_repeat_tournament_stochastic(self):
+        """
+        A test to check that tournament gives same results when setting seed.
+        """
+        files = []
+        for _ in range(2):
+            stochastic_players = [
+                s()
+                for s in axl.short_run_time_strategies
+                if axl.Classifiers["stochastic"](s())
+            ]
+            tournament = axl.Tournament(
+                name="test",
+                players=stochastic_players,
+                game=self.game,
+                turns=2,
+                repetitions=2,
+                seed=17,
+                match_class=MassBaseMatch,
+            )
+            path = pathlib.Path(
+                "test_outputs/stochastic_tournament_{}.csv".format(_)
+            )
+            files.append(axl_filename(path))
+            tournament.play(
+                progress_bar=False, filename=files[-1], build_results=False
+            )
+        self.assertTrue(filecmp.cmp(files[0], files[1]))
+
+
+class TestNoisyTournament(unittest.TestCase):
+    def test_noisy_tournament(self):
+        # Defector should win for low noise
+        players = [axl.Cooperator(), axl.Defector()]
+        tournament = axl.Tournament(players, turns=5, repetitions=3, noise=0.0, match_class=MassBaseMatch)
+        results = tournament.play(progress_bar=False)
+        self.assertEqual(results.ranked_names[0], "Defector")
+
+        # If the noise is large enough, cooperator should win
+        players = [axl.Cooperator(), axl.Defector()]
+        tournament = axl.Tournament(players, turns=5, repetitions=3, noise=0.75, match_class=MassBaseMatch)
+        results = tournament.play(progress_bar=False)
+        self.assertEqual(results.ranked_names[0], "Cooperator")
+
+
+class TestProbEndTournament(unittest.TestCase):
+    def test_players_do_not_know_match_length(self):
+        """Create two players who should cooperate on last two turns if they
+        don't know when those last two turns are.
+        """
+        p1 = FinalTransformer(["D", "D"])(axl.Cooperator)()
+        p2 = FinalTransformer(["D", "D"])(axl.Cooperator)()
+        players = [p1, p2]
+        tournament = axl.Tournament(players, prob_end=0.5, repetitions=1, match_class=MassBaseMatch)
+        results = tournament.play(progress_bar=False)
+        # Check that both plays always cooperated
+        for rating in results.cooperating_rating:
+            self.assertEqual(rating, 1)
+
+    def test_matches_have_different_length(self):
+        """
+        A match between two players should have variable length across the
+        repetitions
+        """
+        p1 = axl.Cooperator()
+        p2 = axl.Cooperator()
+        p3 = axl.Cooperator()
+        players = [p1, p2, p3]
+        tournament = axl.Tournament(
+            players, prob_end=0.5, repetitions=2, seed=3, match_class=MassBaseMatch
+        )
+        results = tournament.play(progress_bar=False)
+        # Check that match length are different across the repetitions
+        self.assertNotEqual(results.match_lengths[0], results.match_lengths[1])
+
+#Moran process tests
+class MassBasedMoranProcess(axl.MoranProcess):
+    """Axelrod MoranProcess class """
+    def __next__(self):
+        set_player_mass(self.players, masses)
+        super().__next__()
+        return self
+
+class TestMoranProcess(unittest.TestCase):
+    def test_init(self):
+        players = axl.Cooperator(), axl.Defector()
+        masses = [10, 20]
+        set_player_mass(players, masses)
+        mp = MassBasedMoranProcess(players, match_class=MassBaseMatch)
+        self.assertEqual(mp.turns, axl.DEFAULT_TURNS)
+        self.assertIsNone(mp.prob_end)
+        self.assertIsNone(mp.game)
+        self.assertEqual(mp.noise, 0)
+        self.assertEqual(mp.initial_players, players)
+        self.assertEqual(mp.players, list(players))
+        self.assertEqual(
+            mp.populations, [Counter({"Cooperator": 1, "Defector": 1})]
+        )
+        self.assertIsNone(mp.winning_strategy_name)
+        self.assertEqual(mp.mutation_rate, 0)
+        self.assertEqual(mp.mode, "bd")
+        self.assertEqual(mp.deterministic_cache, axl.DeterministicCache())
+        self.assertEqual(
+            mp.mutation_targets,
+            {"Cooperator": [players[1]], "Defector": [players[0]]},
+        )
+        self.assertEqual(mp.interaction_graph._edges, [(0, 1), (1, 0)])
+        self.assertEqual(
+            mp.reproduction_graph._edges, [(0, 1), (1, 0), (0, 0), (1, 1)]
+        )
+        self.assertEqual(mp.fitness_transformation, None)
+        self.assertEqual(mp.locations, [0, 1])
+        self.assertEqual(mp.index, {0: 0, 1: 1})
+
+        # Test non default graph cases
+        players = axl.Cooperator(), axl.Defector(), axl.TitForTat()
+        masses = [10, 20, 10]
+        set_player_mass(players, masses)
+        edges = [(0, 1), (2, 0), (1, 2)]
+        graph = axl.graph.Graph(edges, directed=True)
+        mp = MassBasedMoranProcess(players, match_class=MassBaseMatch, interaction_graph=graph)
+        self.assertEqual(mp.interaction_graph._edges, [(0, 1), (2, 0), (1, 2)])
+        self.assertEqual(
+            sorted(mp.reproduction_graph._edges),
+            sorted([(0, 1), (2, 0), (1, 2), (0, 0), (1, 1), (2, 2)]),
+        )
+
+        mp = MassBasedMoranProcess(
+            players, interaction_graph=graph, reproduction_graph=graph
+        )
+        self.assertEqual(mp.interaction_graph._edges, [(0, 1), (2, 0), (1, 2)])
+        self.assertEqual(mp.reproduction_graph._edges, [(0, 1), (2, 0), (1, 2)])
+
+    def test_set_players(self):
+        """Test that set players resets all players"""
+        players = axl.Cooperator(), axl.Defector()
+        masses = [10, 20]
+        set_player_mass(players, masses)
+        mp = MassBasedMoranProcess(players, match_class=MassBaseMatch)
+        players[0].history.append(C, D)
+        mp.set_players()
+        self.assertEqual(players[0].cooperations, 0)
+
+    def test_death_in_db(self):
+        players = axl.Cooperator(), axl.Defector(), axl.TitForTat()
+        masses = [10, 20, 10]
+        set_player_mass(players, masses)
+        mp = MoranProcess(players, match_class=MassBaseMatch, mutation_rate=0.5, mode="db", seed=1)
+        self.assertEqual(mp.death(), 2)
+        self.assertEqual(mp.dead, 2)
+        mp = MoranProcess(players, match_class=MassBaseMatch, mutation_rate=0.5, mode="db", seed=2)
+        self.assertEqual(mp.death(), 0)
+        self.assertEqual(mp.dead, 0)
+        mp = MoranProcess(players, match_class=MassBaseMatch, mutation_rate=0.5, mode="db", seed=9)
+        self.assertEqual(mp.death(), 1)
+        self.assertEqual(mp.dead, 1)
+
+    def test_death_in_bd(self):
+        players = axl.Cooperator(), axl.Defector(), axl.TitForTat()
+        masses = [10, 20, 10]
+        set_player_mass(players, masses)
+        edges = [(0, 1), (2, 0), (1, 2)]
+        graph = axl.graph.Graph(edges, directed=True)
+        mp = MoranProcess(players, match_class=MassBaseMatch, mode="bd", interaction_graph=graph, seed=1)
+        self.assertEqual(mp.death(0), 1)
+        mp = MoranProcess(players, match_class=MassBaseMatch, mode="bd", interaction_graph=graph, seed=2)
+        self.assertEqual(mp.death(0), 1)
+        mp = MoranProcess(players, match_class=MassBaseMatch, mode="bd", interaction_graph=graph, seed=3)
+        self.assertEqual(mp.death(0), 0)
+
+    def test_birth_in_db(self):
+        players = axl.Cooperator(), axl.Defector(), axl.TitForTat()
+        masses = [10, 20, 10]
+        set_player_mass(players, masses)
+        mp = MoranProcess(players, match_class=MassBaseMatch, mode="db", seed=1)
+        self.assertEqual(mp.death(), 2)
+        self.assertEqual(mp.birth(0), 2)
+
+    def test_birth_in_bd(self):
+        players = axl.Cooperator(), axl.Defector(), axl.TitForTat()
+        masses = [1, 1, 1]
+        set_player_mass(players, masses)
+        mp = MoranProcess(players, match_class=MassBaseMatch, mode="bd", seed=2)
+        self.assertEqual(mp.birth(), 0)
+
+    def test_fixation_check(self):
+        players = axl.Cooperator(), axl.Cooperator()
+        masses = [10, 20]
+        set_player_mass(players, masses)
+        mp = MassBasedMoranProcess(players, match_class=MassBaseMatch)
+        self.assertTrue(mp.fixation_check())
+        players = axl.Cooperator(), axl.Defector()
+        mp = MassBasedMoranProcess(players, match_class=MassBaseMatch)
+        self.assertFalse(mp.fixation_check())
+
+    def test_next(self):
+        players = axl.Cooperator(), axl.Defector()
+        masses = [10, 20]
+        set_player_mass(players, masses)
+        mp = MassBasedMoranProcess(players, match_class=MassBaseMatch)
+        self.assertIsInstance(next(mp), axl.MoranProcess)
+
+    def test_matchup_indices(self):
+        players = axl.Cooperator(), axl.Defector()
+        masses = [10, 20]
+        set_player_mass(players, masses)
+        mp = MassBasedMoranProcess(players, match_class=MassBaseMatch)
+        self.assertEqual(mp._matchup_indices(), {(0, 1)})
+
+        players = axl.Cooperator(), axl.Defector(), axl.TitForTat()
+        masses = [10, 20, 10]
+        set_player_mass(players, masses)
+        edges = [(0, 1), (2, 0), (1, 2)]
+        graph = axl.graph.Graph(edges, directed=True)
+        mp = MassBasedMoranProcess(players, match_class=MassBaseMatch, mode="bd", interaction_graph=graph)
+        self.assertEqual(mp._matchup_indices(), {(0, 1), (1, 2), (2, 0)})
+
+    def test_fps(self):
+        players = axl.Cooperator(), axl.Defector()
+        masses = [10, 20]
+        set_player_mass(players, masses)
+        mp = MoranProcess(players, match_class=MassBaseMatch, seed=1)
+        self.assertEqual(mp.fitness_proportionate_selection([0, 0, 1]), 2)
+        self.assertEqual(mp.fitness_proportionate_selection([1, 1, 1]), 2)
+        self.assertEqual(mp.fitness_proportionate_selection([1, 1, 1]), 0)
+
+    def test_exit_condition(self):
+        p1, p2 = axl.Cooperator(), axl.Cooperator()
+        masses = [10, 20]
+        set_player_mass([p1, p2], masses)
+        mp = MassBasedMoranProcess((p1, p2), match_class=MassBaseMatch)
+        mp.play()
+        self.assertEqual(len(mp), 1)

--- a/axelrod/tournament.py
+++ b/axelrod/tournament.py
@@ -34,6 +34,7 @@ class Tournament(object):
         edges: List[Tuple] = None,
         match_attributes: dict = None,
         seed: int = None,
+        match_class = Match,
     ) -> None:
         """
         Parameters
@@ -78,6 +79,7 @@ class Tournament(object):
             turns = DEFAULT_TURNS
 
         self.turns = turns
+        self.match_class = match_class
         self.prob_end = prob_end
         self.match_generator = MatchGenerator(
             players=players,
@@ -451,7 +453,7 @@ class Tournament(object):
         player2 = self.players[p2_index].clone()
         match_params["players"] = (player1, player2)
         match_params["seed"] = seed
-        match = Match(**match_params)
+        match = self.match_class(**match_params)
         for _ in range(repetitions):
             match.play()
 

--- a/docs/how-to/heterogeneous_matches.rst
+++ b/docs/how-to/heterogeneous_matches.rst
@@ -1,7 +1,7 @@
 .. _heterogeneous-matches:
 
-Heterogeneous Matches
-=====================
+Use custom matches
+================
 
 Axelrod Matches are homogeneous by nature but can be extended to utilize additional attributes of heterogeneous players. 
 This tutorial indicates how the Axelrod :code:`Match` class can be manipulated in order to play heterogeneous tournaments and Moran processes using country mass as a score modifier.

--- a/docs/how-to/heterogeneous_matches.rst
+++ b/docs/how-to/heterogeneous_matches.rst
@@ -24,7 +24,7 @@ Using the :code:`setattr()` method, additional attributes can be passed to playe
     >>> set_player_mass(players, masses)
 
 The :code:`Match` class can be partially altered to enable different behaviour. Here we extend :code:`axl.Match` and overwrite its :code:`final_score_per_turn()`
-function to utilize the player mass attribute als a multiplier for the final score::
+function to utilize the player mass attribute as a multiplier for the final score::
 
     >>> class MassBaseMatch(axl.Match):
     >>> """Axelrod Match object with a modified final score function to enable mass to influence the final score as a multiplier"""

--- a/docs/how-to/heterogeneous_matches.rst
+++ b/docs/how-to/heterogeneous_matches.rst
@@ -1,0 +1,65 @@
+.. _heterogeneous-matches:
+
+Heterogeneous Matches
+=====================
+
+Axelrod Matches are homogeneous by nature but can be extended to utilize additional attributes of heterogeneous players. 
+This tutorial indicates how the Axelrod :code:`Match` class can be manipulated in order to play heterogeneous tournaments and Moran processes using country mass as a score modifier.
+
+The following lines of code creates a list of players from the available demo strategies along with an ascending list of values we will use for the players::
+
+    >>> import axelrod as axl
+    >>> players = [player() for player in axl.demo_strategies]
+    >>> masses = [1 * i for i in range(len(players))]
+    >>> players
+    [Cooperator, Defector, Tit For Tat, Grudger, Random: 0.5]
+
+Using the :code:`setattr()` method, additional attributes can be passed to players to enable access during matches and tournaments without manual modification of individual strategies::
+
+    >>> def set_player_mass(players, masses):
+    >>> """Add mass attribute to player strategy classes to be accessable via self.mass"""
+    >>>     for player, mass in zip(players, masses):
+    >>>         setattr(player, "mass", mass)
+    >>>
+    >>> set_player_mass(players, masses)
+
+The :code:`Match` class can be partially altered to enable different behaviour. Here we extend :code:`axl.Match` and overwrite its :code:`final_score_per_turn()`
+function to utilize the player mass attribute als a multiplier for the final score::
+
+    >>> class MassBaseMatch(axl.Match):
+    >>> """Axelrod Match object with a modified final score function to enable mass to influence the final score as a multiplier"""
+    >>> def final_score_per_turn(self):
+    >>>     base_scores = axl.Match.final_score_per_turn(self)
+    >>>     return [player.mass * score for player, score in zip(self.players, base_scores)] 
+
+We can now create a tournament like we normally would and pass our custom :code:`MassBaseMatch` to the tournament with the :code:`match_class` keyword argument::
+
+    >>> tournament = axl.Tournament(players=players, match_class=MassBaseMatch)
+    >>> results = tournament.play()
+    >>> print(results.ranked_names)
+    ['Defector', 'Grudger', 'Tit For Tat', 'Cooperator', 'Random: 0.5']
+
+Additionally, Moran Processes can also be altered to incorporate heterogeneous matches. In order to 
+use our previously defined :code:`MassBaseMatch`, we require one additional change to the :code:`MoranProcess` class::
+
+    >>> class MassBasedMoranProcess(axl.MoranProcess):
+    >>> """Axelrod MoranProcess class """
+    >>> def __next__(self):
+    >>>     set_player_mass(self.players, masses)
+    >>>     super().__next__()
+    >>>     return self
+
+With this code snippet we can override the :code:`__next__()` call within the MoranProcess to include :code:`set_player_mass()` 
+every round. This ensures that every player has mass attributes after the Moran process is triggered. 
+Subsequently, with :code:`super().__next__()` the base MoranProcess :code:`__next__()` call is triggered. This method enables quick 
+modifications to tournaments and moran processes with minimal repetitive code.
+
+We can now create a Moran process as we normally would, with the inclusion of the match class as a keyword argument::
+
+    >>> mp = MassBasedMoranProcess(players, match_class=MassBaseMatch)
+    >>> mp.play()
+    >>> print(mp.winning_strategy_name)
+    Grudger
+
+Note that the snippets here only influence the final score of matches. The behavior of matches, tournaments and moran 
+processes can be more heavily influenced by partially overwriting other :code:`match` functions or :code:`birth` and :code:`death` functions within :code:`MoranProcess`.

--- a/docs/how-to/heterogeneous_matches.rst
+++ b/docs/how-to/heterogeneous_matches.rst
@@ -1,7 +1,7 @@
 .. _heterogeneous-matches:
 
-Heterogeneous Matches
-=====================
+Use custom matches
+===================
 
 Axelrod Matches are homogeneous by nature but can be extended to utilize additional attributes of heterogeneous players. 
 This tutorial indicates how the Axelrod :code:`Match` class can be manipulated in order to play heterogeneous tournaments and Moran processes using country mass as a score modifier.
@@ -17,20 +17,20 @@ The following lines of code creates a list of players from the available demo st
 Using the :code:`setattr()` method, additional attributes can be passed to players to enable access during matches and tournaments without manual modification of individual strategies::
 
     >>> def set_player_mass(players, masses):
-    >>> """Add mass attribute to player strategy classes to be accessable via self.mass"""
-    >>>     for player, mass in zip(players, masses):
-    >>>         setattr(player, "mass", mass)
-    >>>
+    ...     """Add mass attribute to player strategy classes to be accessable via self.mass"""
+    ...     for player, mass in zip(players, masses):
+    ...         setattr(player, "mass", mass)
+    ...
     >>> set_player_mass(players, masses)
 
 The :code:`Match` class can be partially altered to enable different behaviour. Here we extend :code:`axl.Match` and overwrite its :code:`final_score_per_turn()`
-function to utilize the player mass attribute als a multiplier for the final score::
+function to utilize the player mass attribute as a multiplier for the final score::
 
     >>> class MassBaseMatch(axl.Match):
-    >>> """Axelrod Match object with a modified final score function to enable mass to influence the final score as a multiplier"""
-    >>> def final_score_per_turn(self):
-    >>>     base_scores = axl.Match.final_score_per_turn(self)
-    >>>     return [player.mass * score for player, score in zip(self.players, base_scores)] 
+    ...     """Axelrod Match object with a modified final score function to enable mass to influence the final score as a multiplier"""
+    ...     def final_score_per_turn(self):
+    ...         base_scores = axl.Match.final_score_per_turn(self)
+    ...         return [player.mass * score for player, score in zip(self.players, base_scores)] 
 
 We can now create a tournament like we normally would and pass our custom :code:`MassBaseMatch` to the tournament with the :code:`match_class` keyword argument::
 
@@ -39,22 +39,17 @@ We can now create a tournament like we normally would and pass our custom :code:
     >>> print(results.ranked_names)
     ['Defector', 'Grudger', 'Tit For Tat', 'Cooperator', 'Random: 0.5']
 
-Additionally, Moran Processes can also be altered to incorporate heterogeneous matches. In order to 
-use our previously defined :code:`MassBaseMatch`, we require one additional change to the :code:`MoranProcess` class::
+Similarly to [Krapohl2020] we are going to assign a mass to each individual for a Moran process.
+This requires us to build a specific match class:
 
     >>> class MassBasedMoranProcess(axl.MoranProcess):
-    >>> """Axelrod MoranProcess class """
-    >>> def __next__(self):
-    >>>     set_player_mass(self.players, masses)
-    >>>     super().__next__()
-    >>>     return self
+    ...     """Axelrod MoranProcess class """
+    ...     def __next__(self):
+    ...         set_player_mass(self.players, masses)
+    ...         super().__next__()
+    ...         return self
 
-With this code snippet we can override the :code:`__next__()` call within the MoranProcess to include :code:`set_player_mass()` 
-every round. This ensures that every player has mass attributes after the Moran process is triggered. 
-Subsequently, with :code:`super().__next__()` the base MoranProcess :code:`__next__()` call is triggered. This method enables quick 
-modifications to tournaments and moran processes with minimal repetitive code.
-
-We can now create a Moran process as we normally would, with the inclusion of the match class as a keyword argument::
+In [Krapohl2020] a non standard Moran process is used where the mass of individuals is not reproduced so we will use inheritance to create a new Moran process that keeps the mass of the individuals constant.
 
     >>> mp = MassBasedMoranProcess(players, match_class=MassBaseMatch)
     >>> mp.play()

--- a/docs/how-to/heterogeneous_matches.rst
+++ b/docs/how-to/heterogeneous_matches.rst
@@ -49,7 +49,7 @@ This requires us to build a specific match class:
     ...         super().__next__()
     ...         return self
 
-In [Krapohl2020] a non standard Moran process is used where the mass of individuals is not reproduced so we will use inheritance to create a new Moran process that keeps the mass of the individuals constant.
+In [Krapohl2020]_ a non standard Moran process is used where the mass of individuals is not reproduced so we will use inheritance to create a new Moran process that keeps the mass of the individuals constant.
 
     >>> mp = MassBasedMoranProcess(players, match_class=MassBaseMatch)
     >>> mp.play()

--- a/docs/how-to/heterogeneous_matches.rst
+++ b/docs/how-to/heterogeneous_matches.rst
@@ -1,11 +1,7 @@
 .. _heterogeneous-matches:
 
 Use custom matches
-<<<<<<< HEAD
 ===================
-=======
-===================
->>>>>>> a90487a68b0b2997e860d6735dea0b52deece66b
 
 Axelrod Matches are homogeneous by nature but can be extended to utilize additional attributes of heterogeneous players. 
 This tutorial indicates how the Axelrod :code:`Match` class can be manipulated in order to play heterogeneous tournaments and Moran processes using country mass as a score modifier.

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -27,5 +27,6 @@ with the Axelrod library.
    set_a_seed.rst
    set_player_information.rst
    check_player_equality.rst
+   heterogeneous_matches.rst
    cite_the_library.rst
    contributing/index.rst

--- a/docs/reference/bibliography.rst
+++ b/docs/reference/bibliography.rst
@@ -35,6 +35,7 @@ documentation.
 .. [Hilbe2017] Hilbe, C., Martinez-Vaquero, L. A., Chatterjee K., Nowak M. A. (2017). Memory-n strategies of direct reciprocity, Proceedings of the National Academy of Sciences May 2017, 114 (18) 4715-4720; doi: 10.1073/pnas.1621239114.
 .. [Kuhn2017] Kuhn, Steven, "Prisoner's Dilemma", The Stanford Encyclopedia of Philosophy (Spring 2017 Edition), Edward N. Zalta (ed.), https://plato.stanford.edu/archives/spr2017/entries/prisoner-dilemma/
 .. [Kraines1989] Kraines, David, and Vivian Kraines. "Pavlov and the prisoner's dilemma." Theory and decision 26.1 (1989): 47-79. doi:10.1007/BF00134056
+.. [Krapohl2020] Krapohl, S., Ocelík, V. & Walentek, D.M. The instability of globalization: applying evolutionary game theory to global trade cooperation. Public Choice 188, 31–51 (2021). https://doi.org/10.1007/s11127-020-00799-1
 .. [LessWrong2011] Zoo of Strategies (2011) LessWrong. Available at: http://lesswrong.com/lw/7f2/prisoners_dilemma_tournament_results/
 .. [Li2007] Li, J, How to Design a Strategy to Win an IPD Tournament, in Kendall G., Yao X. and Chong S. (eds.) The iterated prisoner’s dilemma: 20 years on. World Scientific, chapter 4, pp. 29-40, 2007.
 .. [Li2009] Li, J. & Kendall, G. (2009). A Strategy with Novel Evolutionary Features for the Iterated Prisoner’s Dilemma. Evolutionary Computation 17(2): 257–274.


### PR DESCRIPTION
Implementation of heterogeneous players through custom match classes that can be passed as keyword arguments to Tournament and MoranProcess. Additionally, this PR includes unittests with the custom match class for tournaments and moran processes as well as documentation including a guide on how to partially overwrite Match and MoranProcess to include player attributes.

This PR was developed upon request of @skrapohl and under supervision of @drvinceknight 