### PR TITLE
Fix contributing guide links #1395

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -45,7 +45,7 @@ jobs:
         python doctests.py
     - name: Run static type checker
       run: |
-        python -m pip install mypy
+        python -m pip install mypy types-setuptools
         python run_mypy.py
     - name: Check imports are sorted
       run: |

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,1 +1,1 @@
-Detailed contribution guidelines are available as part of our documentation at http://axelrod.readthedocs.io/en/latest/tutorials/contributing/index.html
+Detailed contribution guidelines are available as part of our documentation at https://axelrod.readthedocs.io/en/latest/how-to/contributing/index.html

--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,7 @@ All contributions are welcome!
 
 You can find helpful instructions about contributing in the
 documentation:
-https://axelrod.readthedocs.org/en/latest/how-to/contributing/index.html
+https://axelrod.readthedocs.io/en/latest/how-to/contributing/index.html
 
 Publications
 ------------

--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,7 @@ All contributions are welcome!
 
 You can find helpful instructions about contributing in the
 documentation:
-http://axelrod.readthedocs.org/en/latest/tutorials/contributing/index.html
+https://axelrod.readthedocs.org/en/latest/how-to/contributing/index.html
 
 Publications
 ------------


### PR DESCRIPTION
I also converted the links to HTTPS and as the `.org` resolved to `.io` I changed the README to point to `.io`.