### PR TITLE
Update Python versions up through 3.10

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -14,7 +14,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
   pull_request:
-  # Run weakly at 00:00 on Sunday.
+  # Run weekly at 00:00 on Sunday.
   schedule:
   - cron:  '0 0 * * 0'
 

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -14,7 +14,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v1

--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ a peer reviewed paper introducing the library (22 authors).
 Installation
 ------------
 
-The library is tested on Python versions 3.6, 3.7, and 3.8.
+The library is tested on Python versions 3.8, 3.9, and 3.10.
 
 The simplest way to install is::
 

--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ a peer reviewed paper introducing the library (22 authors).
 Installation
 ------------
 
-The library requires Python 3.6 or greater.
+The library is tested on Python versions 3.6, 3.7, and 3.8.
 
 The simplest way to install is::
 

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,9 @@ setup(
     include_package_data=True,
     package_data={"": ["axelrod/data/*"]},
     classifiers=[
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3 :: Only",
     ],
     python_requires=">=3.6",


### PR DESCRIPTION
We support the last three trailing official Python releases. This PR updates the testing and packaging files for Python 3.8, 3.9, and 3.10.