### PR TITLE
Add archived url of PD2017 due to missing page

### DIFF
--- a/docs/reference/bibliography.rst
+++ b/docs/reference/bibliography.rst
@@ -55,7 +55,7 @@ documentation.
 .. [Nowak1992] Nowak, M.., & May, R. M. (1992). Evolutionary games and spatial chaos. Nature. http://doi.org/10.1038/359826a0
 .. [Nowak1993] Nowak, M., & Sigmund, K. (1993). A strategy of win-stay, lose-shift that outperforms tit-for-tat in the Prisoner’s Dilemma game. Nature, 364(6432), 56–58. http://doi.org/10.1038/364056a0
 .. [Ohtsuki2006] Ohtsuki, Hisashi, et al. "A simple rule for the evolution of cooperation on graphs and social networks." Nature 441.7092 (2006): 502.
-.. [PD2017] http://www.prisoners-dilemma.com/competition.html (Accessed: 6 June 2017)
+.. [PD2017] http://www.prisoners-dilemma.com/competition.html (Accessed: 6 June 2017). Archived at https://web.archive.org/web/20171227021632/http://www.prisoners-dilemma.com/competition.html
 .. [Press2012] Press, W. H., & Dyson, F. J. (2012). Iterated Prisoner’s Dilemma contains strategies that dominate any evolutionary opponent. Proceedings of the National Academy of Sciences, 109(26), 10409–10413.  http://doi.org/10.1073/pnas.1206569109
 .. [Prison1998] LIFL (1998) PRISON. Available at: http://www.lifl.fr/IPD/ipd.frame.html (Accessed: 19 September 2016).
 .. [Robson1990] Robson, Arthur J. "Efficiency in evolutionary games: Darwin, Nash and the secret handshake." Journal of theoretical Biology 144.3 (1990): 379-396.


### PR DESCRIPTION
I've noticed that the "The Prisoner's Dilemma Competition" (competition.html) page does not exist anymore on the website. The page is referenced by `Negation` and `HardTitForTat` strategies and the original link redirects to the main page of the website.

Though I am not sure how useful/desired that would be, I've added the archived version at the Wayback Machine where one can find the relevant information about the two strategies. I've picked the closest date available (27 December 2017) after the access date (6 June 2017). 