### PR TITLE
Split requirements.txt to factor out hypothesis and prompt_toolkit

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -r requirements.txt
+        python -m pip install -r requirements/development.txt
     - name: Check that documentation builds
       run: |
         python -m pip install sphinx

--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -151,10 +151,10 @@ from .grumpy import Grumpy
 from .handshake import Handshake
 from .hmm import EvolvedHMM5
 from .hmm import EvolvableHMMPlayer, HMMPlayer  # pylint: disable=unused-import
-try: # pragma: no cover
+try:
     import prompt_toolkit
     from .human import Human  # pylint: disable=unused-import
-except ImportError:
+except ImportError: # pragma: no cover
     warnings.warn("Human strategy not available because python package prompt_toolkit is not available.")
 from .hunter import (
     AlternatorHunter,

--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -151,12 +151,15 @@ from .grumpy import Grumpy
 from .handshake import Handshake
 from .hmm import EvolvedHMM5
 from .hmm import EvolvableHMMPlayer, HMMPlayer  # pylint: disable=unused-import
+
 try:
     from .human import Human  # pylint: disable=unused-import
-except ImportError as ie: # pragma: no cover
+except ImportError as ie:  # pragma: no cover
     # Check that the expected module is missing and no other.
     if ie.name == "prompt_toolkit":
-        warnings.warn("Human strategy not available because python package prompt_toolkit is not available.")
+        warnings.warn(
+            "Human strategy not available because python package prompt_toolkit is not available."
+        )
     else:
         raise ie
 from .hunter import (

--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -151,7 +151,7 @@ from .grumpy import Grumpy
 from .handshake import Handshake
 from .hmm import EvolvedHMM5
 from .hmm import EvolvableHMMPlayer, HMMPlayer  # pylint: disable=unused-import
-try:
+try: # pragma: no cover
     import prompt_toolkit
     from .human import Human  # pylint: disable=unused-import
 except ImportError:

--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -20,6 +20,8 @@ annotated as to avoid some static testing. For example:
     )
     # isort:skip_file
 """
+import warnings
+
 from .adaptive import Adaptive
 from .adaptor import AdaptorBrief, AdaptorLong
 from .alternator import Alternator
@@ -149,7 +151,11 @@ from .grumpy import Grumpy
 from .handshake import Handshake
 from .hmm import EvolvedHMM5
 from .hmm import EvolvableHMMPlayer, HMMPlayer  # pylint: disable=unused-import
-from .human import Human  # pylint: disable=unused-import
+try:
+    import prompt_toolkit
+    from .human import Human  # pylint: disable=unused-import
+except ImportError:
+    warnings.warn("Human strategy not available because python package prompt_toolkit is not available.")
 from .hunter import (
     AlternatorHunter,
     CooperatorHunter,

--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -152,10 +152,13 @@ from .handshake import Handshake
 from .hmm import EvolvedHMM5
 from .hmm import EvolvableHMMPlayer, HMMPlayer  # pylint: disable=unused-import
 try:
-    import prompt_toolkit
     from .human import Human  # pylint: disable=unused-import
-except ImportError: # pragma: no cover
-    warnings.warn("Human strategy not available because python package prompt_toolkit is not available.")
+except ImportError as ie: # pragma: no cover
+    # Check that the expected module is missing and no other.
+    if ie.name == "prompt_toolkit":
+        warnings.warn("Human strategy not available because python package prompt_toolkit is not available.")
+    else:
+        raise ie
 from .hunter import (
     AlternatorHunter,
     CooperatorHunter,

--- a/docs/how-to/contributing/setting_up_the_environment.rst
+++ b/docs/how-to/contributing/setting_up_the_environment.rst
@@ -16,11 +16,11 @@ For example, when using the virtual environment library :code:`venv`::
   $ source axelrod_development/bin/activate
   $ pip install -r requirements/development.txt
 
-Alternatively, you can use `pip` and specify the development variant::
+Alternatively, you can specify the development variant rather than the path::
 
   $ python -m venv axelrod_development
   $ source axelrod_development/bin/activate
-  $ pip install axelrod[Development]
+  $ pip install .[development]
 
 The git workflow
 ----------------

--- a/docs/how-to/contributing/setting_up_the_environment.rst
+++ b/docs/how-to/contributing/setting_up_the_environment.rst
@@ -4,9 +4,9 @@ Setting up the environment
 Installing all dependencies
 ---------------------------
 
-All dependencies can be installed by running::
+All development dependencies can be installed by running::
 
-  $ pip install -r requirements.txt
+  $ pip install -r requirements/development.txt
 
 It is recommended to do this using a virtual environment tool of your choice.
 
@@ -14,7 +14,13 @@ For example, when using the virtual environment library :code:`venv`::
 
   $ python -m venv axelrod_development
   $ source axelrod_development/bin/activate
-  $ pip install -r requirements.txt
+  $ pip install -r requirements/development.txt
+
+Alternatively, you can use `pip` and specify the development variant::
+
+  $ python -m venv axelrod_development
+  $ source axelrod_development/bin/activate
+  $ pip install axelrod[Development]
 
 The git workflow
 ----------------

--- a/docs/tutorials/new_to_game_theory_and_or_python/installation.rst
+++ b/docs/tutorials/new_to_game_theory_and_or_python/installation.rst
@@ -10,6 +10,9 @@ repository::
 
     $ pip install axelrod
 
+If you want to have access to the manual Human strategy for interactive play, use the following command to also install `prompt_toolkit`::
+
+    $ pip install axelrod[Human]
 
 You can also build it from source if you would like to::
 

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+-r human.txt
+hypothesis==5.19.3

--- a/requirements/human.txt
+++ b/requirements/human.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+prompt-toolkit>=3.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,13 +2,11 @@
 cloudpickle>=0.2.2
 fsspec>=0.6.0
 toolz>=0.8.2
-
 dask>=2.9.2
-hypothesis==5.19.3
+
 matplotlib>=3.0.3
 numpy>=1.17.4
 pandas>=1.0.0
-prompt-toolkit>=3.0
 pyyaml>=5.1
 scipy>=1.3.3
 tqdm>=4.39.0

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,18 @@
+from collections import defaultdict
+import os
 from setuptools import setup
 
-# Read in the requirements.txt file
-with open("requirements.txt") as f:
-    requirements = []
-    for library in f.read().splitlines():
-        if "hypothesis" not in library:  # Skip: used only for dev
-            requirements.append(library)
+# Read in the requirements files.
+requirements = defaultdict(list)
+with os.listdir("requirements/") as filenames:
+    for filename in filenames:
+        variant = filename.split('.')[0]
+        with open(filename) as libraries:
+            for library in libraries:
+                if len(library) > 0 and (not library.startswith('-r')):
+                    requirements[variant].append(library)
+install_requires=requirements['requirements']
+del requirements['requirements']
 
 # Read in long description
 with open("README.rst", "r") as f:
@@ -17,7 +24,7 @@ exec(open("axelrod/version.py", "r").read())
 setup(
     name="Axelrod",
     version=__version__,
-    install_requires=requirements,
+    install_requires=install_requires,
     author="Vince Knight, Owen Campbell, Karol Langner, Marc Harper",
     author_email=("axelrod-python@googlegroups.com"),
     packages=["axelrod", "axelrod.strategies", "axelrod.data"],
@@ -35,4 +42,5 @@ setup(
         "Programming Language :: Python :: 3 :: Only",
     ],
     python_requires=">=3.6",
+    extras_require=requirements,
 )

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,24 @@
 from collections import defaultdict
 import os
+import pathlib
 from setuptools import setup
 
 # Read in the requirements files.
 requirements = defaultdict(list)
-with os.listdir("requirements/") as filenames:
-    for filename in filenames:
-        variant = filename.split('.')[0]
-        with open(filename) as libraries:
-            for library in libraries:
-                if len(library) > 0 and (not library.startswith('-r')):
-                    requirements[variant].append(library)
+
+requirements_directory = pathlib.Path.cwd() / "requirements"
+for filename in requirements_directory.glob('*.txt'):
+    variant = filename.stem
+    with filename.open() as libraries:
+        for library in libraries:
+            if len(library) > 0 and (not library.startswith('-r')):
+                requirements[variant].append(library.strip())
+
+# Grab the default requirements
 install_requires=requirements['requirements']
+# Delete the default from the dictionary for the extra variants.
 del requirements['requirements']
+extras_require = dict(requirements)
 
 # Read in long description
 with open("README.rst", "r") as f:
@@ -42,5 +48,5 @@ setup(
         "Programming Language :: Python :: 3 :: Only",
     ],
     python_requires=">=3.6",
-    extras_require=requirements,
+    extras_require=extras_require,
 )

--- a/setup.py
+++ b/setup.py
@@ -7,17 +7,17 @@ from setuptools import setup
 requirements = defaultdict(list)
 
 requirements_directory = pathlib.Path.cwd() / "requirements"
-for filename in requirements_directory.glob('*.txt'):
+for filename in requirements_directory.glob("*.txt"):
     variant = filename.stem
     with filename.open() as libraries:
         for library in libraries:
-            if len(library) > 0 and (not library.startswith('-r')):
+            if len(library) > 0 and (not library.startswith("-r")):
                 requirements[variant].append(library.strip())
 
 # Grab the default requirements
-install_requires=requirements['requirements']
+install_requires = requirements["requirements"]
 # Delete the default from the dictionary for the extra variants.
-del requirements['requirements']
+del requirements["requirements"]
 extras_require = dict(requirements)
 
 # Read in long description


### PR DESCRIPTION
To address #1379, this PR defines three installation options for requirements:
* base/default -- everything except hypothesis and prompt_toolkit
* human -- includes prompt_toolkit
* development -- includes hypothesis and prompt_toolkit

Once merged and released, the different variants can be installed like so:

```pip install axelrod[Human]```

with the default case not requiring specification (e.g. `pip install axelrod`). I tested the variants and warnings locally in a venv but didn't add explicit tests to CI.

Strategy import is updated to check for the presence of prompt_toolkit and include the Human strategy or not accordingly (and with a warning to the user that it's not available, when applicable).

I wasn't sure whether to include prompt_toolkit by default (the Human strategy is nice for live demos). We could go that route and instead have
* base/default -- everything except hypothesis
* non-human (or minimal?) -- everything except hypothesis and prompt_toolkit
* development -- everything

We could define further variants (e.g. don't import any plotting functions) if desired.

Fixes #1379 