### PR TITLE
Added player assumption classification

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+   configuration: docs/conf.py
+
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/axelrod/classifier.py
+++ b/axelrod/classifier.py
@@ -72,6 +72,7 @@ manipulates_source = Classifier[Optional[bool]](
 manipulates_state = Classifier[Optional[bool]](
     "manipulates_state", lambda _: None
 )
+actions_size = Classifier[int]("actions_size", lambda _: 2)
 
 # Should list all known classifiers.
 all_classifiers = [
@@ -82,6 +83,7 @@ all_classifiers = [
     inspects_source,
     manipulates_source,
     manipulates_state,
+    actions_size,
 ]
 
 all_classifiers_map = {c.name: c.classify_player for c in all_classifiers}

--- a/axelrod/classifier.py
+++ b/axelrod/classifier.py
@@ -83,7 +83,7 @@ all_classifiers = [
     inspects_source,
     manipulates_source,
     manipulates_state,
-    actions_size,
+    assumptions,
 ]
 
 all_classifiers_map = {c.name: c.classify_player for c in all_classifiers}

--- a/axelrod/classifier.py
+++ b/axelrod/classifier.py
@@ -72,7 +72,7 @@ manipulates_source = Classifier[Optional[bool]](
 manipulates_state = Classifier[Optional[bool]](
     "manipulates_state", lambda _: None
 )
-actions_size = Classifier[int]("actions_size", lambda _: 2)
+assumptions = Classifier[Optional[dict]]("assumptions", lambda _: {'actions_size': 2})
 
 # Should list all known classifiers.
 all_classifiers = [

--- a/axelrod/game.py
+++ b/axelrod/game.py
@@ -20,7 +20,7 @@ class AsymmetricGame(object):
     """
 
     # pylint: disable=invalid-name
-    def __init__(self, A: np.array, B: np.array) -> None:
+    def __init__(self, A: np.array, B: np.array, **attributes) -> None:
         """
         Creates an asymmetric game from two matrices.
 
@@ -30,6 +30,9 @@ class AsymmetricGame(object):
             the payoff matrix for player A.
         B: np.array
             the payoff matrix for player B.
+        **attributes
+            optional attributes for the game. Used
+            to ensure strategies used with the game are valid.
         """
 
         if A.shape != B.transpose().shape:
@@ -40,6 +43,8 @@ class AsymmetricGame(object):
 
         self.A = A
         self.B = B
+
+        self.attributes = attributes
 
         self.scores = {
             pair: self.score(pair) for pair in ((C, C), (D, D), (C, D), (D, C))
@@ -75,6 +80,24 @@ class AsymmetricGame(object):
 
         return (self.A[row][col], self.B[row][col])
 
+    @property
+    def attributes(self):
+        return self._attributes
+
+    @attributes.setter
+    def attributes(self, attributes):
+        """
+        Adds or changes game attributes.
+
+        Parameters
+        ----------
+        attributes: dict
+            Attributes to add to the game. If the added
+            attribute already exists, it will overwrite the
+            previous value.
+        """
+        self._attributes = {**self._attributes, **attributes}
+
     def __repr__(self) -> str:
         return "Axelrod game with matrices: {}".format((self.A, self.B))
 
@@ -97,7 +120,7 @@ class Game(AsymmetricGame):
         The numerical score attribute to all combinations of action pairs.
     """
 
-    def __init__(self, r: Score = 3, s: Score = 0, t: Score = 5, p: Score = 1) -> None:
+    def __init__(self, r: Score = 3, s: Score = 0, t: Score = 5, p: Score = 1, **attributes) -> None:
         """Create a new game object.
 
         Parameters
@@ -110,10 +133,19 @@ class Game(AsymmetricGame):
             Score obtained by a player for defecting against a cooperator.
         p: int or float
             Score obtained by both player for mutual defection.
+        **attributes
+            optional attributes for the game. Used
+            to ensure strategies used with the game are valid.
+
         """
         A = np.array([[r, s], [t, p]])
 
-        super().__init__(A, A.transpose())
+        default_attributes = {
+            'has_RPST': True
+        }
+        attributes = {**default_attributes, **attributes}
+
+        super().__init__(A, A.transpose(), **attributes)
 
     def RPST(self) -> Tuple[Score, Score, Score, Score]:
         """Returns game matrix values in Press and Dyson notation."""
@@ -132,4 +164,4 @@ class Game(AsymmetricGame):
         return self.RPST() == other.RPST()
 
 
-DefaultGame = Game()
+DefaultGame = Game(3, 0, 5, 1, game_type='prisoners_dilemma')

--- a/axelrod/game.py
+++ b/axelrod/game.py
@@ -17,6 +17,9 @@ class AsymmetricGame(object):
     ----------
     scores: dict
         The numerical score attribute to all combinations of action pairs.
+    attributes: dict
+        A dictionary of attributes of the game. Used to ensure strategies
+        used with the game are valid.
     """
 
     # pylint: disable=invalid-name
@@ -96,7 +99,10 @@ class AsymmetricGame(object):
             attribute already exists, it will overwrite the
             previous value.
         """
-        self._attributes = {**self._attributes, **attributes}
+        try:
+            self._attributes = {**self._attributes, **attributes}
+        except AttributeError:
+            self._attributes = attributes
 
     def __repr__(self) -> str:
         return "Axelrod game with matrices: {}".format((self.A, self.B))

--- a/axelrod/game.py
+++ b/axelrod/game.py
@@ -23,7 +23,7 @@ class AsymmetricGame(object):
     """
 
     # pylint: disable=invalid-name
-    def __init__(self, A: np.array, B: np.array, **attributes) -> None:
+    def __init__(self, A: np.array, B: np.array, **characteristics) -> None:
         """
         Creates an asymmetric game from two matrices.
 
@@ -33,8 +33,8 @@ class AsymmetricGame(object):
             the payoff matrix for player A.
         B: np.array
             the payoff matrix for player B.
-        **attributes
-            optional attributes for the game. Used
+        **characteristics
+            optional characteristics detailing features of the game. Used
             to ensure strategies used with the game are valid.
         """
 
@@ -47,7 +47,7 @@ class AsymmetricGame(object):
         self.A = A
         self.B = B
 
-        self.attributes = attributes
+        self.characteristics = characteristics
 
         self.scores = {
             pair: self.score(pair) for pair in ((C, C), (D, D), (C, D), (D, C))
@@ -84,25 +84,25 @@ class AsymmetricGame(object):
         return (self.A[row][col], self.B[row][col])
 
     @property
-    def attributes(self):
-        return self._attributes
+    def characteristics(self):
+        return self._characteristics
 
-    @attributes.setter
-    def attributes(self, attributes):
+    @characteristics.setter
+    def characteristics(self, characteristics):
         """
-        Adds or changes game attributes.
+        Adds or changes game characteristics.
 
         Parameters
         ----------
-        attributes: dict
-            Attributes to add to the game. If the added
-            attribute already exists, it will overwrite the
+        characteristics: dict
+            characteristics to add to the game. If the added
+            characteristic already exists, it will overwrite the
             previous value.
         """
         try:
-            self._attributes = {**self._attributes, **attributes}
+            self._characteristics = {**self._characteristics, **characteristics}
         except AttributeError:
-            self._attributes = attributes
+            self._characteristics = characteristics
 
     def __repr__(self) -> str:
         return "Axelrod game with matrices: {}".format((self.A, self.B))
@@ -126,7 +126,7 @@ class Game(AsymmetricGame):
         The numerical score attribute to all combinations of action pairs.
     """
 
-    def __init__(self, r: Score = 3, s: Score = 0, t: Score = 5, p: Score = 1, **attributes) -> None:
+    def __init__(self, r: Score = 3, s: Score = 0, t: Score = 5, p: Score = 1, **characteristics) -> None:
         """Create a new game object.
 
         Parameters
@@ -146,12 +146,12 @@ class Game(AsymmetricGame):
         """
         A = np.array([[r, s], [t, p]])
 
-        default_attributes = {
-            'has_RPST': True
+        default_characteristics = {
+            'has_RPST': hasattr(self, 'RPST')
         }
-        attributes = {**default_attributes, **attributes}
+        characteristics = {**default_characteristics, **characteristics}
 
-        super().__init__(A, A.transpose(), **attributes)
+        super().__init__(A, A.transpose(), **characteristics)
 
     def RPST(self) -> Tuple[Score, Score, Score, Score]:
         """Returns game matrix values in Press and Dyson notation."""

--- a/axelrod/game.py
+++ b/axelrod/game.py
@@ -146,11 +146,6 @@ class Game(AsymmetricGame):
         """
         A = np.array([[r, s], [t, p]])
 
-        default_characteristics = {
-            'has_RPST': hasattr(self, 'RPST')
-        }
-        characteristics = {**default_characteristics, **characteristics}
-
         super().__init__(A, A.transpose(), **characteristics)
 
     def RPST(self) -> Tuple[Score, Score, Score, Score]:

--- a/axelrod/match.py
+++ b/axelrod/match.py
@@ -112,8 +112,8 @@ class Match(object):
         """Ensure that players are passed the match attributes"""
         newplayers = []
         # ensure players have the correct size action sets for the game
-        player[0].check_actions_size(self.game.A.shape[0])
-        player[1].check_actions_size(self.game.B.shape[0])
+        players[0].check_actions_size(self.game.A.shape[0])
+        players[1].check_actions_size(self.game.B.shape[0])
 
         for player in players:
             player.set_match_attributes(**self.match_attributes)

--- a/axelrod/match.py
+++ b/axelrod/match.py
@@ -30,7 +30,7 @@ class Match(object):
         match_attributes=None,
         reset=True,
         seed=None,
-        strict_player_compatibility=True
+        strict_player_checking=True
     ):
         """
         Parameters
@@ -55,7 +55,7 @@ class Match(object):
             Whether to reset players or not
         seed : int
             Random seed for reproducibility
-        strict_player_compatibility: bool, default True
+        strict_player_checking: bool, default True
             If True, throws an error if strategies make assumptions which aren't
             compatible with the game. if False, just produces warnings instead.
         """
@@ -93,7 +93,7 @@ class Match(object):
         else:
             self.match_attributes = match_attributes
 
-        self.strict_player_compatibility = strict_player_compatibility
+        self.strict_player_checking = strict_player_checking
         self.players = list(players)
         self.reset = reset
 
@@ -120,9 +120,9 @@ class Match(object):
         # note the game size attribute is added here because the player
         # and coplayer may have different game sizes if the game is asymmetric!
         players[0].check_assumptions({**self.game.attributes, 'actions_size': self.game.A.shape[0]},
-                                      raise_error=strict_player_compatibility)
+                                      raise_error=self.strict_player_checking)
         players[1].check_assumptions({**self.game.attributes, 'actions_size': self.game.B.shape[0]},
-                                      raise_error=strict_player_compatibility)
+                                      raise_error=self.strict_player_checking)
 
         for player in players:
             player.set_match_attributes(**self.match_attributes)

--- a/axelrod/match.py
+++ b/axelrod/match.py
@@ -117,11 +117,11 @@ class Match(object):
         """Ensure that players are passed the match attributes"""
         newplayers = []
         # ensure the game satisfies the player assumptions
-        # note the game size attribute is added here because the player
+        # note the game size characteristic is added here because the player
         # and coplayer may have different game sizes if the game is asymmetric!
-        players[0].check_assumptions({**self.game.attributes, 'actions_size': self.game.A.shape[0]},
+        players[0].check_assumptions({**self.game.characteristics, 'actions_size': self.game.A.shape[0]},
                                       raise_error=self.strict_player_checking)
-        players[1].check_assumptions({**self.game.attributes, 'actions_size': self.game.B.shape[0]},
+        players[1].check_assumptions({**self.game.characteristics, 'actions_size': self.game.B.shape[0]},
                                       raise_error=self.strict_player_checking)
 
         for player in players:

--- a/axelrod/match.py
+++ b/axelrod/match.py
@@ -111,9 +111,11 @@ class Match(object):
     def players(self, players):
         """Ensure that players are passed the match attributes"""
         newplayers = []
-        # ensure players have the correct size action sets for the game
-        players[0].check_actions_size(self.game.A.shape[0])
-        players[1].check_actions_size(self.game.B.shape[0])
+        # ensure the game satisfies the player assumptions
+        # note the game size attribute is added here because the player
+        # and coplayer may have different game sizes if the game is asymmetric!
+        players[0].check_assumptions({**self.game.attributes, 'actions_size': self.game.A.shape[0]})
+        players[1].check_assumptions({**self.game.attributes, 'actions_size': self.game.B.shape[0]})
 
         for player in players:
             player.set_match_attributes(**self.match_attributes)

--- a/axelrod/match.py
+++ b/axelrod/match.py
@@ -111,6 +111,10 @@ class Match(object):
     def players(self, players):
         """Ensure that players are passed the match attributes"""
         newplayers = []
+        # ensure players have the correct size action sets for the game
+        player[0].check_actions_size(self.game.A.shape[0])
+        player[1].check_actions_size(self.game.B.shape[0])
+
         for player in players:
             player.set_match_attributes(**self.match_attributes)
             newplayers.append(player)

--- a/axelrod/match.py
+++ b/axelrod/match.py
@@ -30,6 +30,7 @@ class Match(object):
         match_attributes=None,
         reset=True,
         seed=None,
+        strict_player_compatibility=True
     ):
         """
         Parameters
@@ -54,6 +55,9 @@ class Match(object):
             Whether to reset players or not
         seed : int
             Random seed for reproducibility
+        strict_player_compatibility: bool, default True
+            If True, throws an error if strategies make assumptions which aren't
+            compatible with the game. if False, just produces warnings instead.
         """
 
         defaults = {
@@ -89,6 +93,7 @@ class Match(object):
         else:
             self.match_attributes = match_attributes
 
+        self.strict_player_compatibility = strict_player_compatibility
         self.players = list(players)
         self.reset = reset
 
@@ -114,8 +119,10 @@ class Match(object):
         # ensure the game satisfies the player assumptions
         # note the game size attribute is added here because the player
         # and coplayer may have different game sizes if the game is asymmetric!
-        players[0].check_assumptions({**self.game.attributes, 'actions_size': self.game.A.shape[0]})
-        players[1].check_assumptions({**self.game.attributes, 'actions_size': self.game.B.shape[0]})
+        players[0].check_assumptions({**self.game.attributes, 'actions_size': self.game.A.shape[0]},
+                                      raise_error=strict_player_compatibility)
+        players[1].check_assumptions({**self.game.attributes, 'actions_size': self.game.B.shape[0]},
+                                      raise_error=strict_player_compatibility)
 
         for player in players:
             player.set_match_attributes(**self.match_attributes)

--- a/axelrod/mock_player.py
+++ b/axelrod/mock_player.py
@@ -26,9 +26,12 @@ class MockPlayer(Player):
         super().__init__()
         if not actions:
             actions = []
-        if classifier:
-            self.classifier = classifier
         self.actions = cycle(actions)
+
+        if not classifier:
+            self.classifier = {}
+        else:
+            self.classifier = classifier
 
     def strategy(self, opponent: Player) -> Action:
         # Return the next saved action, if present.

--- a/axelrod/mock_player.py
+++ b/axelrod/mock_player.py
@@ -26,8 +26,7 @@ class MockPlayer(Player):
         super().__init__()
         if not actions:
             actions = []
-        if classifier:
-            self.classifier = classifier
+        self.classifier = classifier
         self.actions = cycle(actions)
 
     def strategy(self, opponent: Player) -> Action:

--- a/axelrod/mock_player.py
+++ b/axelrod/mock_player.py
@@ -21,14 +21,13 @@ class MockPlayer(Player):
     """
 
     name = "Mock Player"
-    attributes = {}
 
-    def __init__(self, actions: List[Action] = None, attributes: dict = None) -> None:
+    def __init__(self, actions: List[Action] = None, classifier: dict = None) -> None:
         super().__init__()
         if not actions:
             actions = []
-        if attributes:
-            self.attributes = attributes
+        if classifier:
+            self.classifier = classifier
         self.actions = cycle(actions)
 
     def strategy(self, opponent: Player) -> Action:

--- a/axelrod/mock_player.py
+++ b/axelrod/mock_player.py
@@ -8,8 +8,8 @@ C, D = Action.C, Action.D
 
 
 class MockPlayer(Player):
-    """Creates a mock player that plays a given sequence of actions. If
-    no actions are given, or it runs out of actions,
+    """Creates a mock player that cycles through a given 
+    sequence of actions. If no actions are given, 
     plays like Cooperator. Used for testing.
 
     Parameters

--- a/axelrod/mock_player.py
+++ b/axelrod/mock_player.py
@@ -9,15 +9,26 @@ C, D = Action.C, Action.D
 
 class MockPlayer(Player):
     """Creates a mock player that plays a given sequence of actions. If
-    no actions are given, plays like Cooperator. Used for testing.
+    no actions are given, or it runs out of actions,
+    plays like Cooperator. Used for testing.
+
+    Parameters
+    ----------
+    actions: List[Action], default []
+        The sequence of actions played by the mock player.
+    attributes: dict, default {}
+        A dictionary of player attributes.
     """
 
     name = "Mock Player"
+    attributes = {}
 
-    def __init__(self, actions: List[Action] = None) -> None:
+    def __init__(self, actions: List[Action] = None, attributes: dict = None) -> None:
         super().__init__()
         if not actions:
             actions = []
+        if attributes:
+            self.attributes = attributes
         self.actions = cycle(actions)
 
     def strategy(self, opponent: Player) -> Action:

--- a/axelrod/mock_player.py
+++ b/axelrod/mock_player.py
@@ -26,7 +26,8 @@ class MockPlayer(Player):
         super().__init__()
         if not actions:
             actions = []
-        self.classifier = classifier
+        if classifier:
+            self.classifier = classifier
         self.actions = cycle(actions)
 
     def strategy(self, opponent: Player) -> Action:

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -258,6 +258,28 @@ class Player(object, metaclass=PostInitCaller):
     def update_history(self, play, coplay):
         self.history.append(play, coplay)
 
+    def check_actions_size(self, game_size: int):
+        """
+        Compares the actions set size of the player to a given game size.
+        If the game is too small, throws an error; if the game is too big,
+        creates a warning that the player may not use certain actions.
+
+        Parameters
+        ----------
+        game_size: int
+            The size of the game to compare player action size with.
+        """
+        
+        actions_size = self.classifier.get('actions_size', 2)
+        if actions_size > game_size:
+            raise IndexError("The action set of player {} is larger "
+                             "than the number of possible actions "
+                             "in the game.".format(self.name))
+        if actions_size < game_size:
+            warnings.warn("The action set of player {} is smaller "
+                          "than the size of the game; they may "
+                          "not play certain actions.")
+
     @property
     def history(self):
         return self._history

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -258,14 +258,14 @@ class Player(object, metaclass=PostInitCaller):
     def update_history(self, play, coplay):
         self.history.append(play, coplay)
 
-    def check_assumptions(self, characteristics: dict, raise_error: bool=True):
+    def check_assumptions(self, game_characteristics: dict, raise_error: bool=True):
         """
         Compares the player assumptions to a dictionary of game characteristics.
         Generates a warning or error if an assumption is not fulfilled.
 
         Parameters:
         -----------
-        characteristics: dict
+        game_characteristics: dict
             The dictionary of game characteristics to compare the player's assumptions to.
         raise_error: bool, default True
             If True, raises an error if the assumption is violated. Else,
@@ -274,22 +274,22 @@ class Player(object, metaclass=PostInitCaller):
 
         for key, value in self.classifier.get('assumptions', {}).items():
             msg = None
-            if key not in characteristics.keys():
+            if key not in game_characteristics.keys():
                 msg = ("Player {} assumes that "
                        "the game has the attribute {}, "
                        "but the game does not declare this attribute."
                        "".format(self.name, key))
-            elif value != characteristics[key]:
+            elif value != game_characteristics[key]:
                 msg = ("Player {} assumes that the game attribute "
                        "{} is set to {}, but it is actually set to {}."
-                       "".format(self.name, key, value, characteristics[key]))
+                       "".format(self.name, key, value, game_characteristics[key]))
 
             if msg is not None:
                 if raise_error:
                     raise RuntimeError(msg)
                 warnings.warn(msg + " The strategy may not behave as expected.")
 
-    def assumptions_satisfy(self, characteristics: dict) -> bool:
+    def assumptions_satisfy(self, game_characteristics: dict) -> bool:
         """
         Compares the player assumptions to a dictionary of game characteristics.
         Returns True if the player assumptions are all satisfied by
@@ -297,7 +297,7 @@ class Player(object, metaclass=PostInitCaller):
 
         Parameters:
         -----------
-        characteristics: dict
+        game_characteristics: dict
             The dictionary of game characteristics to compare the player's assumptions to.
 
         Returns
@@ -311,7 +311,7 @@ class Player(object, metaclass=PostInitCaller):
         # around as check_assumptions needs finer grained understanding of
         # the assumptions to produce useful error messages
         try:
-            self.check_assumptions(characteristics, raise_error=True)
+            self.check_assumptions(game_characteristics, raise_error=True)
         except RuntimeError:
             return False
         return True

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -258,7 +258,7 @@ class Player(object, metaclass=PostInitCaller):
     def update_history(self, play, coplay):
         self.history.append(play, coplay)
 
-    def check_assumptions(self, attributes, raise_error=True):
+    def check_assumptions(self, attributes: dict, raise_error: bool=True):
         """
         Compares the player assumptions to a dictionary of attributes.
         Generates a warning or error if an assumption is not fulfilled.
@@ -288,6 +288,33 @@ class Player(object, metaclass=PostInitCaller):
                 if raise_error:
                     raise RuntimeError(msg)
                 warnings.warn(msg + " The strategy may not behave as expected.")
+
+    def assumptions_satisfy(self, attributes: dict) -> bool:
+        """
+        Compares the player assumptions to a dictionary of attributes.
+        Returns True if the player assumptions are all satisfied by
+        these attributes, and False otherwise.
+
+        Parameters:
+        -----------
+        attributes: dict
+            The dictionary of attributes to compare the player's assumptions to.
+
+        Returns
+        -------
+        bool
+            A boolean of whether or not the attributes satisfy the player's
+            assumptions.
+        """
+
+        # we use check_assumptions as our 'base' rather than the other way
+        # around as check_assumptions needs finer grained understanding of
+        # the assumptions to produce useful error messages
+        try:
+            self.check_assumptions(attributes, raise_error=True)
+        except RuntimeError:
+            return False
+        return True
 
     @property
     def history(self):

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -272,7 +272,7 @@ class Player(object, metaclass=PostInitCaller):
             just generate a warning.
         """
 
-        for key, value in self.classifier.get('assumptions', {}):
+        for key, value in self.classifier.get('assumptions', {}).items():
             msg = None
             if key not in attributes.keys():
                 msg = ("Player {} assumes that "

--- a/axelrod/player.py
+++ b/axelrod/player.py
@@ -258,15 +258,15 @@ class Player(object, metaclass=PostInitCaller):
     def update_history(self, play, coplay):
         self.history.append(play, coplay)
 
-    def check_assumptions(self, attributes: dict, raise_error: bool=True):
+    def check_assumptions(self, characteristics: dict, raise_error: bool=True):
         """
-        Compares the player assumptions to a dictionary of attributes.
+        Compares the player assumptions to a dictionary of game characteristics.
         Generates a warning or error if an assumption is not fulfilled.
 
         Parameters:
         -----------
-        attributes: dict
-            The dictionary of attributes to compare the player's assumptions to.
+        characteristics: dict
+            The dictionary of game characteristics to compare the player's assumptions to.
         raise_error: bool, default True
             If True, raises an error if the assumption is violated. Else,
             just generate a warning.
@@ -274,36 +274,36 @@ class Player(object, metaclass=PostInitCaller):
 
         for key, value in self.classifier.get('assumptions', {}).items():
             msg = None
-            if key not in attributes.keys():
+            if key not in characteristics.keys():
                 msg = ("Player {} assumes that "
                        "the game has the attribute {}, "
                        "but the game does not declare this attribute."
                        "".format(self.name, key))
-            elif value != attributes[key]:
+            elif value != characteristics[key]:
                 msg = ("Player {} assumes that the game attribute "
                        "{} is set to {}, but it is actually set to {}."
-                       "".format(self.name, key, value, attributes[key]))
+                       "".format(self.name, key, value, characteristics[key]))
 
             if msg is not None:
                 if raise_error:
                     raise RuntimeError(msg)
                 warnings.warn(msg + " The strategy may not behave as expected.")
 
-    def assumptions_satisfy(self, attributes: dict) -> bool:
+    def assumptions_satisfy(self, characteristics: dict) -> bool:
         """
-        Compares the player assumptions to a dictionary of attributes.
+        Compares the player assumptions to a dictionary of game characteristics.
         Returns True if the player assumptions are all satisfied by
-        these attributes, and False otherwise.
+        these characteristics, and False otherwise.
 
         Parameters:
         -----------
-        attributes: dict
-            The dictionary of attributes to compare the player's assumptions to.
+        characteristics: dict
+            The dictionary of game characteristics to compare the player's assumptions to.
 
         Returns
         -------
         bool
-            A boolean of whether or not the attributes satisfy the player's
+            A boolean of whether or not the game characteristics satisfy the player's
             assumptions.
         """
 
@@ -311,7 +311,7 @@ class Player(object, metaclass=PostInitCaller):
         # around as check_assumptions needs finer grained understanding of
         # the assumptions to produce useful error messages
         try:
-            self.check_assumptions(attributes, raise_error=True)
+            self.check_assumptions(characteristics, raise_error=True)
         except RuntimeError:
             return False
         return True

--- a/axelrod/tests/strategies/test_player.py
+++ b/axelrod/tests/strategies/test_player.py
@@ -347,6 +347,28 @@ class TestPlayerClass(unittest.TestCase):
             TypeError, ParameterisedTestPlayer, "other", "other", "other"
         )
 
+    def test_assumption_checking(self):
+        """
+        Checks that assumptions are checked, and warnings
+        or errors are raised when they're unfulfilled.
+        """
+        player = axl.MockPlayer(classifier={'assumptions': {'foo': True, 'bar': 3}})
+
+        # these should pass without errors/warnings
+        player.check_assumptions({'foo': True, 'bar': 3})
+        player.check_assumptions({'foo': True, 'bar': 3, 'baz': []})
+
+        with self.assertRaises(RuntimeError):
+            player.check_assumptions({'foo': True})
+        with self.assertRaises(RuntimeError):
+            player.check_assumptions({'foo': True, 'bar': 5})
+
+        with self.assertWarns(UserWarning):
+            player.check_assumptions({'foo': True}, raise_error=False)
+        with self.assertWarns(UserWarning):
+            player.check_assumptions({'foo': True, 'bar': 5}, raise_error=False)
+
+
 
 class TestOpponent(axl.Player):
     """A player who only exists so we have something to test against"""

--- a/axelrod/tests/strategies/test_player.py
+++ b/axelrod/tests/strategies/test_player.py
@@ -355,18 +355,32 @@ class TestPlayerClass(unittest.TestCase):
         player = axl.MockPlayer(classifier={'assumptions': {'foo': True, 'bar': 3}})
 
         # these should pass without errors/warnings
-        player.check_assumptions({'foo': True, 'bar': 3})
-        player.check_assumptions({'foo': True, 'bar': 3, 'baz': []})
+        player.check_assumptions({'foo': True, 'bar': 3})  # correct characteristics
+        player.check_assumptions({'foo': True, 'bar': 3, 'baz': []})  # extraneous characteristic
 
         with self.assertRaises(RuntimeError):
-            player.check_assumptions({'foo': True})
+            player.check_assumptions({'foo': True})  # missing characteristic
         with self.assertRaises(RuntimeError):
-            player.check_assumptions({'foo': True, 'bar': 5})
+            player.check_assumptions({'foo': True, 'bar': 5})  # invalid charateristic value
 
         with self.assertWarns(UserWarning):
-            player.check_assumptions({'foo': True}, raise_error=False)
+            player.check_assumptions({'foo': True}, raise_error=False)  # missing characteristic
         with self.assertWarns(UserWarning):
-            player.check_assumptions({'foo': True, 'bar': 5}, raise_error=False)
+            player.check_assumptions({'foo': True, 'bar': 5}, raise_error=False)  # invalid charateristic value
+
+    def test_assumptions_satisfy(self):
+        """
+        Tests that the assumptions_satisfy() method works as intended.
+        It is a wrapper around check_assumptions() so the actual assumption
+        testing logic is checked more thoroughly there.
+        """
+        player = axl.MockPlayer(classifier={'assumptions': {'foo': True, 'bar': 3}})
+
+        self.assertEqual(player.assumptions_satisfy({'foo': True, 'bar': 3}), True)  # correct characteristics
+        self.assertEqual(player.assumptions_satisfy({'foo': True, 'bar': 3, 'baz': []}), True)  # extraneous characteristic
+        self.assertEqual(player.assumptions_satisfy({'foo': True}), False)  # missing characteristic
+        self.assertEqual(player.assumptions_satisfy({'foo': True, 'bar': 5}), False)  # invalid charateristic value
+
 
 
 

--- a/axelrod/tests/unit/test_match.py
+++ b/axelrod/tests/unit/test_match.py
@@ -356,16 +356,14 @@ class TestMatch(unittest.TestCase):
         self.assertEqual(match.sparklines("X", "Y"), expected_sparklines)
 
     @given(game=asymmetric_games(), n1=integers(min_value=2), n2=integers(min_value=2))
+    @settings(max_examples=5)
     def test_game_size_checking(self, game, n1, n2):
         """Tests warnings, errors or normal flow agrees with player action size."""
-        player1 = MockPlayer(classifier={'actions_size': n1})
-        player2 = MockPlayer(classifier={'actions_size': n2})
+        player1 = MockPlayer(classifier={'assumptions': {'actions_size': n1}})
+        player2 = MockPlayer(classifier={'assumptions': {'actions_size': n2}})
 
-        if (n1 > game.A.shape[0] or n2 > game.B.shape[0]):
-            with self.assertRaises(IndexError):
-                match = axl.Match((player1, player2), game=game)
-        elif (n1 < game.A.shape[0] or n2 < game.B.shape[0]):
-            with self.assertWarns(UserWarning):
+        if (n1 != game.A.shape[0] or n2 != game.B.shape[0]):
+            with self.assertRaises(RuntimeError):
                 match = axl.Match((player1, player2), game=game)
         else:
             match = axl.Match((player1, player2), game=game)

--- a/axelrod/tests/unit/test_match.py
+++ b/axelrod/tests/unit/test_match.py
@@ -3,8 +3,9 @@ from collections import Counter
 
 import axelrod as axl
 from axelrod.deterministic_cache import DeterministicCache
+from axelrod.mock_player import MockPlayer
 from axelrod.random_ import RandomGenerator
-from axelrod.tests.property import games
+from axelrod.tests.property import games, asymmetric_games
 from hypothesis import example, given
 from hypothesis.strategies import floats, integers
 
@@ -354,6 +355,20 @@ class TestMatch(unittest.TestCase):
         expected_sparklines = "XXXX\nXYXY"
         self.assertEqual(match.sparklines("X", "Y"), expected_sparklines)
 
+    @given(game=asymmetric_games(), n1=integers(min_value=2), n2=integers(min_value=2))
+    def test_game_size_checking(self, game, n1, n2):
+        """Tests warnings, errors or normal flow agrees with player action size."""
+        player1 = MockPlayer(classifier={'actions_size': n1})
+        player2 = MockPlayer(classifier={'actions_size': n2})
+
+        if (n1 > game.A.shape[0] or n2 > game.B.shape[0]):
+            with self.assertRaises(IndexError):
+                match = axl.Match((player1, player2), game=game)
+        elif (n1 < game.A.shape[0] or n2 < game.B.shape[0]):
+            with self.assertWarns(UserWarning):
+                match = axl.Match((player1, player2), game=game)
+        else:
+            match = axl.Match((player1, player2), game=game)
 
 class TestSampleLength(unittest.TestCase):
     def test_sample_length(self):

--- a/axelrod/tests/unit/test_match.py
+++ b/axelrod/tests/unit/test_match.py
@@ -6,7 +6,7 @@ from axelrod.deterministic_cache import DeterministicCache
 from axelrod.mock_player import MockPlayer
 from axelrod.random_ import RandomGenerator
 from axelrod.tests.property import games, asymmetric_games
-from hypothesis import example, given
+from hypothesis import example, given, settings
 from hypothesis.strategies import floats, integers
 
 C, D = axl.Action.C, axl.Action.D

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 docutils <= 0.17  # Added this for a problem with sphinx https://github.com/sphinx-doc/sphinx/commit/13803a79e7179f40a27f46d5a5a05f1eebbcbb63
+numpy==1.24.3  # numpy isn't mocked due to complex use in doctests

--- a/docs/tutorials/implement_new_games/index.rst
+++ b/docs/tutorials/implement_new_games/index.rst
@@ -124,6 +124,7 @@ an initialisation parameter for which move they start with::
     ...         "inspects_source": False,
     ...         "manipulates_source": False,
     ...         "manipulates_state": False,
+    ...         "actions_size": 3,
     ...     }
     ...     
     ...     def __init__(self, starting_move=S):
@@ -153,6 +154,7 @@ an initialisation parameter for which move they start with::
     ...         "inspects_source": False,
     ...         "manipulates_source": False,
     ...         "manipulates_state": False,
+    ...         "actions_size": 3,
     ...     }
     ...     
     ...     def __init__(self, starting_move=S):
@@ -164,6 +166,11 @@ an initialisation parameter for which move they start with::
     ...         if not self.history:
     ...             return self.starting_move
     ...         return self.history[-1].rotate()
+
+Note that in the classifier for each strategy we set 'actions_size' to `3`. This
+is how we let Axelrod know that this strategy is expecting to have 3 possible actions,
+because if we tried to use these strategies on the IPD and they played 'scissors' (action 3),
+the game wouldn't know what to do with that!
 
 We are now all set to run some matches and tournaments in our new game!
 Let's start with a match between our two new players::

--- a/docs/tutorials/implement_new_games/index.rst
+++ b/docs/tutorials/implement_new_games/index.rst
@@ -124,7 +124,7 @@ an initialisation parameter for which move they start with::
     ...         "inspects_source": False,
     ...         "manipulates_source": False,
     ...         "manipulates_state": False,
-    ...         "actions_size": 3,
+    ...         "assumptions": {"actions_size": 3},
     ...     }
     ...     
     ...     def __init__(self, starting_move=S):
@@ -154,7 +154,7 @@ an initialisation parameter for which move they start with::
     ...         "inspects_source": False,
     ...         "manipulates_source": False,
     ...         "manipulates_state": False,
-    ...         "actions_size": 3,
+    ...         "assumptions": {"actions_size": 3},
     ...     }
     ...     
     ...     def __init__(self, starting_move=S):
@@ -169,8 +169,8 @@ an initialisation parameter for which move they start with::
 
 Note that in the classifier for each strategy we set 'actions_size' to `3`. This
 is how we let Axelrod know that this strategy is expecting to have 3 possible actions,
-because if we tried to use these strategies on the IPD and they played 'scissors' (action 3),
-the game wouldn't know what to do with that!
+and when a match is created, it will check to make sure that this assumption is
+satisfied by the game.
 
 We are now all set to run some matches and tournaments in our new game!
 Let's start with a match between our two new players::


### PR DESCRIPTION
Fixes #1414 by adding a new 'assumptions' feature to strategy classifiers, which check the strategy's assumptions against 'attributes' defined for each game.

Changes:
~~- `Player`s now have an `'actions_size'` classifier, which is an integer, and defaults to 2.~~
~~- The `Player` class now has a method `check_actions_size` which compares their actions size to a given integer. If the game is too small for their actions size, an error is raised (as otherwise it may cause an `IndexError` if it plays an out-of-bounds action); if it is too big, a warning is raised (as it won't cause errors, but may cause unexpected behaviour).~~
~~- The `Match` class now checks these actions sizes against the game matrices when initialising.~~
**Note to reader: This PR originally just implemented game size checking, but as seen in the discussion below this was decided to be insufficient. The PR was then redone to introduce the following 'assumptions' model:**

- When creating a strategy, the classifier can now contain 'assumptions' like game size, `Action` class, things like RPST existing, or even specifically what the game is
- When creating a game, the game now has 'attributes' which identify features that strategies can make assumptions about
- Then when a match is created, the player's assumptions are checked against the game's attributes. If the player makes an assumption that the game doesn't have as an attribute, or if the values mismatch, an error is raised
  - Matches also now have a `strict_player_compatibility` parameter which, if set to False, downgrades these errors to warnings
- This allows each individual strategy to have as tight or loose compatibility with games as it needs, with automatic support for new games whether they're added 'officially' or for personal/individual use. 
- The `MockPlayer` accepts classifiers as an initialisation parameter to aid in the testing of this.

Some examples:
- `axl.Cooperator` would not need to assume anything! It always chooses action 1, which always exists.
- `axl.Adaptive` would assume its action set has size 2 exactly, as it is adapting according to that.
- `axl.Cycler`'s current implementation would need to assume that the actions are {C, D} as it specifically reads a string of C's and D's. (however it doesn't make assumptions on the actual game matrix itself!)
- `axl.FirstByDowning` would need to assume the game has RPST, since it uses that in its implementation.
- `axl.EvolvedANN` would assume *precisely* that the game is Prisoners' Dilemma, as it is trained on that game.