### PR TITLE
fixed the rock-paper-scissors docs example

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+   configuration: docs/conf.py
+
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 docutils <= 0.17  # Added this for a problem with sphinx https://github.com/sphinx-doc/sphinx/commit/13803a79e7179f40a27f46d5a5a05f1eebbcbb63
+numpy==1.24.3  # numpy isn't mocked due to complex use in doctests

--- a/docs/tutorials/implement_new_games/index.rst
+++ b/docs/tutorials/implement_new_games/index.rst
@@ -29,14 +29,9 @@ corresponding to rows 1 and 2 respectively). If we tried to use it on rock-paper
 interpret the game in the following way:
 
 1. On the first turn, choose rock (option 1, cooperate)
-2. If the opponent's last move is the Python object
-   :code:`axl.Action.D` (which it may never be unless the opponent also thinks it's playing IPD!), 
-   then choose paper (option 2, defection)
+2. If the opponent's last move is action 2, then choose paper (action 2, defect)
 
-and so as we see, :code:`Tit-For-Tat` would simply play Rock every turn, unless it
-were playing against another Prisoners' Dilemma strategy (then it
-plays rock unless the opponent last played paper, in which case it plays paper). In
-particular, it would never play scissors - it does not know that Scissors is something
+In particular, it would never play scissors - it does not know that Scissors is something
 it can even do. This is not a bug, or an issue with the strategy itself; 
 simply that :code:`Tit-For-Tat` *thinks* it is playing the Iterated Prisoners' Dilemma
 and its :code:`Action` set, regardless of what the actual game is.
@@ -53,11 +48,16 @@ has :code:`flip`, which flips a :code:`C` to a :code:`D` and vice versa!)
 A simple rock-paper-scissors action class would look like so::
 
     >>> from enum import Enum
+    >>> from functools import total_ordering
+    >>> @total_ordering
     >>> class RPSAction(Enum):
     ...     """Actions for Rock-Paper-Scissors."""
     ...     R = 0  # rock
     ...     P = 1  # paper
     ...     S = 2  # scissors
+    ...     
+    ...     def __lt__(self, other):
+    ...         return self.value < other.value
     ...     
     ...     def __repr__(self):
     ...         return self.name
@@ -77,6 +77,11 @@ A simple rock-paper-scissors action class would look like so::
     ...         }
     ...         
     ...         return rotations[self]
+
+Note that the :code:`total_ordering` decorator and the :code:`__lt__` method are required for
+Python to equate different types of Action sets based on what action they correspond
+to; without it, strategies on two separate games of the same size wouldn't be
+interoperable!
 
 We can then implement some strategies. Below we have the implementation of an
 Axelrod strategy into Python. These follow the same format;

--- a/docs/tutorials/implement_new_games/index.rst
+++ b/docs/tutorials/implement_new_games/index.rst
@@ -50,7 +50,7 @@ A simple rock-paper-scissors action class would look like so::
     >>> from enum import Enum
     >>> from functools import total_ordering
     >>> @total_ordering
-    >>> class RPSAction(Enum):
+    ... class RPSAction(Enum):
     ...     """Actions for Rock-Paper-Scissors."""
     ...     R = 0  # rock
     ...     P = 1  # paper


### PR DESCRIPTION
Fixes a mistake in the doc page added by #1413 - it turns out that strategies *can* recognise actions from different games corresponding to the same row/column, so long as both of the `Action` classes have a total ordering. That is:

Using the example code from before this PR:
`axl.rockpaperscissors.RPSAction.P == axl.Action.D` -> `False`
After this PR:
`axl.rockpaperscissors.RPSAction.P == axl.Action.D` -> `True`

This is good news for the interoperability of different games! :)