### PR TITLE
Bump Supported Python versions up to 3.12

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -14,7 +14,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v1
@@ -63,7 +63,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.11"]
+        python-version: ["3.12"]
     steps:
     - name: Check imports are sorted
       run: |

--- a/axelrod/load_data_.py
+++ b/axelrod/load_data_.py
@@ -1,8 +1,7 @@
 import pathlib
 from typing import Dict, List, Text, Tuple
 
-import pkg_resources
-
+import pkgutil
 
 def axl_filename(path: pathlib.Path) -> pathlib.Path:
     """Given a path under Axelrod/, return absolute filepath.
@@ -24,9 +23,11 @@ def axl_filename(path: pathlib.Path) -> pathlib.Path:
 def load_file(filename: str, directory: str) -> List[List[str]]:
     """Loads a data file stored in the Axelrod library's data subdirectory,
     likely for parameters for a strategy."""
-    path = "/".join((directory, filename))
-    data_bytes = pkg_resources.resource_string(__name__, path)
+
+    path = str(pathlib.Path(directory) / filename)
+    data_bytes = pkgutil.get_data(__name__, path)
     data = data_bytes.decode("UTF-8", "replace")
+    
     rows = []
     for line in data.split("\n"):
         if line.startswith("#") or len(line) == 0:

--- a/axelrod/plot.py
+++ b/axelrod/plot.py
@@ -1,5 +1,4 @@
 import pathlib
-from distutils.version import LooseVersion
 from typing import List, Union
 
 import matplotlib
@@ -14,13 +13,6 @@ from .result_set import ResultSet
 titleType = List[str]
 namesType = List[str]
 dataType = List[List[Union[int, float]]]
-
-
-def default_cmap(version: str = "2.0") -> str:
-    """Sets a default matplotlib colormap based on the version."""
-    if LooseVersion(version) >= "1.5":
-        return "viridis"
-    return "YlGnBu"
 
 
 class Plot(object):
@@ -184,6 +176,7 @@ class Plot(object):
         names: namesType,
         title: titleType = None,
         ax: matplotlib.axes.SubplotBase = None,
+        cmap: str = 'viridis'
     ) -> matplotlib.figure.Figure:
         """Generic heatmap plot"""
 
@@ -196,8 +189,6 @@ class Plot(object):
         width = max(self.num_players / 4, 12)
         height = width
         figure.set_size_inches(width, height)
-        matplotlib_version = matplotlib.__version__
-        cmap = default_cmap(matplotlib_version)
         mat = ax.matshow(data, cmap=cmap)
         ax.set_xticks(range(self.result_set.num_players))
         ax.set_yticks(range(self.result_set.num_players))

--- a/axelrod/tests/unit/test_classification.py
+++ b/axelrod/tests/unit/test_classification.py
@@ -89,7 +89,7 @@ class TestClassification(unittest.TestCase):
         warnings.simplefilter("default", category=UserWarning)
         with warnings.catch_warnings(record=True) as w:
             self.assertEqual(Classifiers["memory_depth"](axl.TitForTat), 1)
-            self.assertEquals(len(w), 1)
+            self.assertEqual(len(w), 1)
 
     def test_key_error_on_uknown_classifier(self):
         with self.assertRaises(KeyError):

--- a/axelrod/tests/unit/test_plot.py
+++ b/axelrod/tests/unit/test_plot.py
@@ -75,34 +75,6 @@ class TestPlot(unittest.TestCase):
             ["Defector", "Tit For Tat", "Alternator"],
         )
 
-    def test_default_cmap(self):
-        cmap = axl.plot.default_cmap("0.0")
-        self.assertEqual(cmap, "YlGnBu")
-
-        cmap = axl.plot.default_cmap("1.3alpha")
-        self.assertEqual(cmap, "YlGnBu")
-
-        cmap = axl.plot.default_cmap("1.4.99")
-        self.assertEqual(cmap, "YlGnBu")
-
-        cmap = axl.plot.default_cmap("1.4")
-        self.assertEqual(cmap, "YlGnBu")
-
-        cmap = axl.plot.default_cmap()
-        self.assertEqual(cmap, "viridis")
-
-        cmap = axl.plot.default_cmap("1.5")
-        self.assertEqual(cmap, "viridis")
-
-        cmap = axl.plot.default_cmap("1.5beta")
-        self.assertEqual(cmap, "viridis")
-
-        cmap = axl.plot.default_cmap("1.7")
-        self.assertEqual(cmap, "viridis")
-
-        cmap = axl.plot.default_cmap("2.0")
-        self.assertEqual(cmap, "viridis")
-
     def test_init(self):
         plot = axl.Plot(self.test_result_set)
         self.assertEqual(plot.result_set, self.test_result_set)

--- a/docs/tutorials/new_to_game_theory_and_or_python/summarising_tournaments.rst
+++ b/docs/tutorials/new_to_game_theory_and_or_python/summarising_tournaments.rst
@@ -33,10 +33,10 @@ It is also possible to write this data directly to a csv file using the
     ...     for row in csvreader:
     ...         print(row)
     ['Rank', 'Name', 'Median_score', 'Cooperation_rating', 'Wins', 'Initial_C_rate', 'CC_rate', 'CD_rate', 'DC_rate', 'DD_rate', 'CC_to_C_rate', 'CD_to_C_rate', 'DC_to_C_rate', 'DD_to_C_rate']
-    ['0', 'Defector', '2.6...', '0.0', '3.0', '0.0', '0.0', '0.0', '0.4...', '0.6...', '0', '0', '0', '0']
-    ['1', 'Tit For Tat', '2.3...', '0.7', '0.0', '1.0', '0.66...', '0.03...', '0.0', '0.3...', '1.0', '0', '0', '0']
-    ['2', 'Grudger', '2.3...', '0.7', '0.0', '1.0', '0.66...', '0.03...', '0.0', '0.3...', '1.0', '0', '0', '0']
-    ['3', 'Cooperator', '2.0...', '1.0', '0.0', '1.0', '0.66...', '0.33...', '0.0', '0.0', '1.0', '1.0', '0', '0']
+    ['0', 'Defector', ...
+    ['1', 'Tit For Tat', ...
+    ['2', 'Grudger', ...
+    ['3', 'Cooperator', ...
 
 
 The result set class computes a large number of detailed outcomes read about

--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,9 @@ setup(
     include_package_data=True,
     package_data={"": ["axelrod/data/*"]},
     classifiers=[
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3 :: Only",
     ],
     python_requires=">=3.6",


### PR DESCRIPTION
Python 3.12 doesn't seem to be available yet in CI, will re-run tests later.

Update: some packages like distutils are no longer available in Python 3.12 so I had a make a few small changes. In one case we had a check for matplotlib versions below 2, but we're already requiring 3+, so there's no change in functionality.