### PR TITLE
ModalTFT, ModalDefector strategies - Ben McGuffog

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ The simplest way to install is::
 
 To install from source::
 
-    $ git clone https://github.com/Axelrod-Python/Axelrod.git
+    $ git clone https://github.com/benjjo/Axelrod.git
     $ cd Axelrod
     $ python setup.py install
 

--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -87,7 +87,7 @@ from .cycler import (
 from .cycler import Cycler, EvolvableCycler  # pylint: disable=unused-import
 from .darwin import Darwin
 from .dbs import DBS
-from .defector import Defector, TrickyDefector
+from .defector import Defector, TrickyDefector, ModalDefector
 from .doubler import Doubler
 from .finite_state_machines import (
     TF1,
@@ -410,6 +410,7 @@ all_strategies = [
     MEM2,
     MathConstantHunter,
     Michaelos,
+    ModalDefector,
     ModalTFT,
     NTitsForMTats,
     NaiveProber,

--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -260,6 +260,7 @@ from .titfortat import (
     HardTitFor2Tats,
     HardTitForTat,
     Michaelos,
+    ModalTFT,
     NTitsForMTats,
     OmegaTFT,
     OriginalGradual,
@@ -271,7 +272,6 @@ from .titfortat import (
     TitFor2Tats,
     TitForTat,
     TwoTitsForTat,
-    ModalTFT,
 )
 from .verybad import VeryBad
 from .worse_and_worse import (

--- a/axelrod/strategies/_strategies.py
+++ b/axelrod/strategies/_strategies.py
@@ -271,6 +271,7 @@ from .titfortat import (
     TitFor2Tats,
     TitForTat,
     TwoTitsForTat,
+    ModalTFT,
 )
 from .verybad import VeryBad
 from .worse_and_worse import (
@@ -409,6 +410,7 @@ all_strategies = [
     MEM2,
     MathConstantHunter,
     Michaelos,
+    ModalTFT,
     NTitsForMTats,
     NaiveProber,
     Negation,

--- a/axelrod/strategies/defector.py
+++ b/axelrod/strategies/defector.py
@@ -1,5 +1,6 @@
 from axelrod.action import Action
 from axelrod.player import Player
+import statistics
 
 C, D = Action.C, Action.D
 
@@ -61,3 +62,35 @@ class TrickyDefector(Player):
         ):
             return C
         return D
+
+
+class ModalDefector(Player):
+    """
+    A player starts by Defecting and then analyses the history of the opponent. If the opponent Cooperated in the
+    last round, they are returned with a Defection. If the opponent chose to Defect in the previous round,
+    then this strategy will return with the mode of the previous opponent responses.
+    """
+
+    # These are various properties for the strategy
+    name = "Modal Defector"
+    classifier = {
+        "memory_depth": float("inf"),
+        "stochastic": False,
+        "long_run_time": False,
+        "inspects_source": False,
+        "manipulates_source": False,
+        "manipulates_state": False,
+    }
+
+    def strategy(self, opponent: Player) -> Action:
+        """This is the actual strategy"""
+        # First move
+        if not self.history:
+            return D
+        # React to the opponent's historical moves
+        if opponent.history[-1] == C:
+            return D
+        else:
+            # returns with the mode of the opponent's history.
+            return statistics.mode(opponent.history)
+

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -956,8 +956,9 @@ class BurnBothEnds(Player):
 
 class ModalTFT(Player):
     """
-    A player starts by cooperating and then analyses the history of the opponent. From this information it will
-    respond with the mode of the opponents historical responses.
+    A player starts by cooperating and then analyses the history of the opponent. If the opponent Cooperated in the
+    last round, they are immediately returned with a Cooperation. If the opponent chose to Defect in the previous round,
+    then this strategy will return with the mode of the previous opponent responses.
     """
 
     # These are various properties for the strategy
@@ -977,5 +978,8 @@ class ModalTFT(Player):
         if not self.history:
             return C
         # React to the opponent's historical moves
-        return statistics.mode(opponent.history)
+        print(statistics.mode(opponent.history))
+        return C if opponent.history[-1] == C else statistics.mode(opponent.history)
+
+
 

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -977,5 +977,5 @@ class ModalTFT(Player):
         if not self.history:
             return C
         # React to the opponent's historical moves
-        return statistics.mode(self.history)
+        return statistics.mode(opponent.history)
 

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -1,5 +1,6 @@
 from axelrod.action import Action, actions_to_str
 from axelrod.player import Player
+import statistics
 from axelrod.strategy_transformers import (
     FinalTransformer,
     TrackHistoryTransformer,
@@ -945,9 +946,36 @@ class BurnBothEnds(Player):
         if not opponent.history:
             # Make sure we cooperate first turn
             return C
-        # BBE modification 
+        # BBE modification
         if opponent.history[-1] == C:
             # Cooperate with 0.9
             return self._random.random_choice(0.9)
         # Else TFT. Opponent played D, so play D in return.
         return D
+
+
+class ModalTFT(Player):
+    """
+    A player starts by cooperating and then analyses the history of the opponent. From this information it will
+    respond with the mode of the opponents historical response.
+    """
+
+    # These are various properties for the strategy
+    name = "Modal TFT"
+    classifier = {
+        "memory_depth": 1,  # Four-Vector = (1.,0.,1.,0.)
+        "stochastic": False,
+        "long_run_time": False,
+        "inspects_source": False,
+        "manipulates_source": False,
+        "manipulates_state": False,
+    }
+
+    def strategy(self, opponent: Player) -> Action:
+        """This is the actual strategy"""
+        # First move
+        if not self.history:
+            return C
+        # React to the opponent's historical moves
+        return statistics.mode(self.history)
+

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -957,7 +957,7 @@ class BurnBothEnds(Player):
 class ModalTFT(Player):
     """
     A player starts by cooperating and then analyses the history of the opponent. If the opponent Cooperated in the
-    last round, they are immediately returned with a Cooperation. If the opponent chose to Defect in the previous round,
+    last round, they are returned with a Cooperation. If the opponent chose to Defect in the previous round,
     then this strategy will return with the mode of the previous opponent responses.
     """
 
@@ -978,6 +978,9 @@ class ModalTFT(Player):
         if not self.history:
             return C
         # React to the opponent's historical moves
-        print(statistics.mode(opponent.history))
-        return C if opponent.history[-1] == C else statistics.mode(opponent.history)
+        if opponent.history[-1] == C:
+            return C
+        else:
+            # returns with the mode of the opponent's history.
+            return statistics.mode(opponent.history)
 

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -963,7 +963,7 @@ class ModalTFT(Player):
     # These are various properties for the strategy
     name = "Modal TFT"
     classifier = {
-        "memory_depth": 1,  # Four-Vector = (1.,0.,1.,0.)
+        "memory_depth": float("inf"),
         "stochastic": False,
         "long_run_time": False,
         "inspects_source": False,

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -873,7 +873,7 @@ class Michaelos(Player):
 class RandomTitForTat(Player):
     """
     A player starts by cooperating and then follows by copying its
-    opponent (tit for tat style).  From then on the player
+    opponent (tit-for-tat style).  From then on the player
     will switch between copying its opponent and randomly
     responding every other iteration.
 
@@ -980,6 +980,4 @@ class ModalTFT(Player):
         # React to the opponent's historical moves
         print(statistics.mode(opponent.history))
         return C if opponent.history[-1] == C else statistics.mode(opponent.history)
-
-
 

--- a/axelrod/strategies/titfortat.py
+++ b/axelrod/strategies/titfortat.py
@@ -957,7 +957,7 @@ class BurnBothEnds(Player):
 class ModalTFT(Player):
     """
     A player starts by cooperating and then analyses the history of the opponent. From this information it will
-    respond with the mode of the opponents historical response.
+    respond with the mode of the opponents historical responses.
     """
 
     # These are various properties for the strategy

--- a/axelrod/tests/strategies/test_defector.py
+++ b/axelrod/tests/strategies/test_defector.py
@@ -61,3 +61,21 @@ class TestTrickyDefector(TestPlayer):
         self.versus_test(
             axl.MockPlayer(actions=opponent_actions), expected_actions=actions
         )
+
+
+class TestModalDefector(TestPlayer):
+    name = "Modal Defector"
+    player = axl.ModalDefector
+    expected_classifier = {
+        "memory_depth": float("inf"),
+        "stochastic": False,
+        "makes_use_of": set(),
+        "inspects_source": False,
+        "manipulates_source": False,
+        "manipulates_state": False,
+    }
+
+    def test_strategy(self):
+        opponent = axl.MockPlayer(actions=[C, C, D, D, D, D, C, D])
+        actions = [(D, C), (D, C), (D, D), (C, D), (C, D), (D, D), (D, C), (D, D), (D, C)]
+        self.versus_test(opponent, expected_actions=actions)

--- a/axelrod/tests/strategies/test_titfortat.py
+++ b/axelrod/tests/strategies/test_titfortat.py
@@ -1341,3 +1341,23 @@ class TestBurnBothEnds(TestPlayer):
     def test_vs_defector(self):
         actions = [(C, D), (D, D), (D, D), (D, D), (D, D)]
         self.versus_test(axl.Defector(), expected_actions=actions)
+
+
+class TestModalTFT(TestPlayer):
+    name = "Modal TFT"
+    player = axl.ModalTFT
+    expected_classifier = {
+        "memory_depth": float("inf"),
+        "stochastic": False,
+        "makes_use_of": set(),
+        "inspects_source": False,
+        "manipulates_source": False,
+        "manipulates_state": False,
+    }
+
+    def test_strategy(self):
+        opponent = axl.MockPlayer(actions=[C, C, D, D, D, D, C, D])
+        actions = [(C, C), (C, C), (C, D), (C, D), (C, D), (D, D), (D, C), (C, D), (D, C)]
+        self.versus_test(opponent, expected_actions=actions)
+
+


### PR DESCRIPTION
Hi, I've added two strategies that are interesting (well at least I think). Here are their descritpions:

ModalTFT
    A player starts by cooperating and then analyses the history of the opponent. If the opponent Cooperated in the
    last round, they are returned with a Cooperation. If the opponent chose to Defect in the previous round,
    then this strategy will return with the mode of the previous opponent responses.
 
ModalDefector
    A player starts by Defecting and then analyses the history of the opponent. If the opponent Cooperated in the
    last round, they are returned with a Defection. If the opponent chose to Defect in the previous round,
    then this strategy will return with the mode of the previous opponent responses.
 
Interestingly, when pitted against a few of the classics from the orignal Axelrod tournement, they do quite well. When tested agianst all of the strategies in this repository, they rank 103 and 200 respectively. 

I have never written code for other people in my life. This would be the first. My tests, while simple, seem to pass though. 
This is also my first pull request ever so I'm probably doing a number on it. 
I have tried searching through your code to see if these strategies already exist and I haven't found any like them. It may be that I've simply missread the code and im wasting your time right now, for which I appologise in advance. 
It would be cool to have the contributors badge on my account though. 