### PR TITLE
Change cache pattern

### DIFF
--- a/axelrod/match.py
+++ b/axelrod/match.py
@@ -184,7 +184,8 @@ class Match(object):
         cache_key = (self.players[0], self.players[1])
 
         if self._cached_enough_turns(cache_key, turns):
-            return self._cache[cache_key][:turns]
+            self.result = self._cache[cache_key][:turns]
+            return self.result
 
         for p in self.players:
             if self.reset:
@@ -202,7 +203,7 @@ class Match(object):
             self._cache[cache_key] = result
 
         self.result = result
-        return result
+        return self.result
 
     def scores(self):
         """Returns the scores of the previous Match plays."""

--- a/axelrod/match.py
+++ b/axelrod/match.py
@@ -196,7 +196,9 @@ class Match(object):
                 p.set_seed(self._random.random_seed_int())
         result = []
         for _ in range(turns):
-            plays = self.simultaneous_play(self.players[0], self.players[1], self.noise)
+            plays = self.simultaneous_play(
+                self.players[0], self.players[1], self.noise
+            )
             result.append(plays)
 
         if self._cache_update_required:

--- a/axelrod/match.py
+++ b/axelrod/match.py
@@ -130,7 +130,8 @@ class Match(object):
         A boolean to show whether the deterministic cache should be updated.
         """
         return (
-            not self.noise
+            not self.is_stochastic
+            and not self.noise
             and self._cache.mutable
             and not (any(Classifiers["stochastic"](p) for p in self.players))
         )
@@ -182,25 +183,25 @@ class Match(object):
             turns = self.turns
         cache_key = (self.players[0], self.players[1])
 
-        if self._stochastic or not self._cached_enough_turns(cache_key, turns):
-            for p in self.players:
-                if self.reset:
-                    p.reset()
-                p.set_match_attributes(**self.match_attributes)
-                # Generate a random seed for the player, if stochastic
-                if Classifiers["stochastic"](p):
-                    p.set_seed(self._random.random_seed_int())
-            result = []
-            for _ in range(turns):
-                plays = self.simultaneous_play(
-                    self.players[0], self.players[1], self.noise
-                )
-                result.append(plays)
+        if self._cached_enough_turns(cache_key, turns):
+            return self._cache[cache_key][:turns]
 
-            if self._cache_update_required:
-                self._cache[cache_key] = result
-        else:
-            result = self._cache[cache_key][:turns]
+        for p in self.players:
+            if self.reset:
+                p.reset()
+            p.set_match_attributes(**self.match_attributes)
+            # Generate a random seed for the player, if stochastic
+            if Classifiers["stochastic"](p):
+                p.set_seed(self._random.random_seed_int())
+        result = []
+        for _ in range(turns):
+            plays = self.simultaneous_play(
+                self.players[0], self.players[1], self.noise
+            )
+            result.append(plays)
+
+        if self._cache_update_required:
+            self._cache[cache_key] = result
 
         self.result = result
         return result

--- a/axelrod/match.py
+++ b/axelrod/match.py
@@ -130,7 +130,7 @@ class Match(object):
         A boolean to show whether the deterministic cache should be updated.
         """
         return (
-            not self.is_stochastic
+            not self._stochastic
             and not self.noise
             and self._cache.mutable
             and not (any(Classifiers["stochastic"](p) for p in self.players))
@@ -195,9 +195,7 @@ class Match(object):
                 p.set_seed(self._random.random_seed_int())
         result = []
         for _ in range(turns):
-            plays = self.simultaneous_play(
-                self.players[0], self.players[1], self.noise
-            )
+            plays = self.simultaneous_play(self.players[0], self.players[1], self.noise)
             result.append(plays)
 
         if self._cache_update_required:


### PR DESCRIPTION
Switches caching pattern to check-cache-and-early-exit to make code slightly more readable.

Previously, caching was only read if the strategy was not stochastic.  This new pattern doesn't save caches in the stochastic case.