### PR TITLE
Fix Graph vertices logic and use Graph in MatchGenerator

### DIFF
--- a/axelrod/graph.py
+++ b/axelrod/graph.py
@@ -46,6 +46,7 @@ class Graph(object):
         self._edges = []
         if edges:
             self._add_edges(edges)
+        self._vertices = list(self.in_mapping.keys() | self.out_mapping.keys())
 
     def _add_edge(self, source, target, weight=None):
         if (source, target) not in self._edges:
@@ -77,7 +78,7 @@ class Graph(object):
 
     @property
     def vertices(self):
-        return list(self.out_mapping.keys())
+        return self._vertices
 
     def out_dict(self, source):
         """Returns a dictionary of the outgoing edges of source with weights."""

--- a/axelrod/match_generator.py
+++ b/axelrod/match_generator.py
@@ -1,4 +1,5 @@
 from axelrod.random_ import BulkRandomGenerator
+from .graph import complete_graph
 
 
 class MatchGenerator(object):
@@ -72,10 +73,9 @@ class MatchGenerator(object):
         tuples
             ((player1 index, player2 index), match object)
         """
+        edges = self.edges
         if self.edges is None:
-            edges = complete_graph(self.players)
-        else:
-            edges = self.edges
+            edges = complete_graph(len(self.players), loops=True, directed=True).edges
 
         for index_pair in edges:
             match_params = self.build_single_match_params()
@@ -93,15 +93,6 @@ class MatchGenerator(object):
             "prob_end": self.prob_end,
             "match_attributes": self.match_attributes,
         }
-
-
-def complete_graph(players):
-    """
-    Return generator of edges of a complete graph on a set of players
-    """
-    for player1_index, _ in enumerate(players):
-        for player2_index in range(player1_index, len(players)):
-            yield (player1_index, player2_index)
 
 
 def graph_is_connected(edges, players):


### PR DESCRIPTION
`complete_graph` already exists in the graph.py file, so change match_generator.py to use this logic.

This change uncovered a bug in `Graph` where vertices only includes source nodes in a connected graph.  So I fixed this real quick.