### PR TITLE
Create MatchChunk dataclass

### DIFF
--- a/axelrod/match_generator.py
+++ b/axelrod/match_generator.py
@@ -1,4 +1,19 @@
+from dataclasses import dataclass
+from typing import Any, Dict, Iterator, Tuple
+
 from axelrod.random_ import BulkRandomGenerator
+
+
+@dataclass
+class MatchChunk(object):
+    index_pair: Tuple[int]
+    match_params: Dict[str, Any]
+    repetitions: int
+    seed: BulkRandomGenerator
+
+    def as_tuple(self) -> Tuple:
+        """Kept for legacy reasons"""
+        return (self.index_pair, self.match_params, self.repetitions, self.seed)
 
 
 class MatchGenerator(object):
@@ -62,7 +77,7 @@ class MatchGenerator(object):
     def __len__(self):
         return self.size
 
-    def build_match_chunks(self):
+    def build_match_chunks(self) -> Iterator[MatchChunk]:
         """
         A generator that returns player index pairs and match parameters for a
         round robin tournament.
@@ -80,7 +95,7 @@ class MatchGenerator(object):
         for index_pair in edges:
             match_params = self.build_single_match_params()
             r = next(self.random_generator)
-            yield (index_pair, match_params, self.repetitions, r)
+            yield MatchChunk(index_pair=index_pair, match_params=match_params, repetitions=self.repetitions, seed=r)
 
     def build_single_match_params(self):
         """

--- a/axelrod/match_generator.py
+++ b/axelrod/match_generator.py
@@ -95,7 +95,12 @@ class MatchGenerator(object):
         for index_pair in edges:
             match_params = self.build_single_match_params()
             r = next(self.random_generator)
-            yield MatchChunk(index_pair=index_pair, match_params=match_params, repetitions=self.repetitions, seed=r)
+            yield MatchChunk(
+                index_pair=index_pair,
+                match_params=match_params,
+                repetitions=self.repetitions,
+                seed=r,
+            )
 
     def build_single_match_params(self):
         """

--- a/axelrod/tests/unit/test_match_generator.py
+++ b/axelrod/tests/unit/test_match_generator.py
@@ -171,7 +171,7 @@ class TestMatchGenerator(unittest.TestCase):
             game=test_game,
             repetitions=repetitions,
         )
-        chunks = list(rr.build_match_chunks())
+        chunks = [chunk.as_tuple() for chunk in rr.build_match_chunks()]
         match_definitions = [
             tuple(list(index_pair) + [repetitions])
             for (index_pair, match_params, repetitions, _) in chunks
@@ -239,7 +239,7 @@ class TestMatchGenerator(unittest.TestCase):
             edges=cycle,
             repetitions=repetitions,
         )
-        chunks = list(rr.build_match_chunks())
+        chunks = [chunk.as_tuple() for chunk in rr.build_match_chunks()]
         match_definitions = [
             tuple(list(index_pair) + [repetitions])
             for (index_pair, match_params, repetitions, _) in chunks

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -663,7 +663,9 @@ class TestTournament(unittest.TestCase):
                 for player2_index in range(player1_index, len(self.players)):
                     index_pair = (player1_index, player2_index)
                     match_params = {"turns": turns, "game": self.game}
-                    yield MatchChunk(index_pair, match_params, self.test_repetitions, 0)
+                    yield MatchChunk(
+                        index_pair, match_params, self.test_repetitions, 0
+                    )
 
         chunk_generator = make_chunk_generator()
         interactions = {}

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -24,7 +24,7 @@ from axelrod.tests.property import (
     strategy_lists,
     tournaments,
 )
-from axelrod.tournament import _close_objects, MatchChunk
+from axelrod.tournament import MatchChunk, _close_objects
 
 C, D = axl.Action.C, axl.Action.D
 

--- a/axelrod/tests/unit/test_tournament.py
+++ b/axelrod/tests/unit/test_tournament.py
@@ -24,7 +24,7 @@ from axelrod.tests.property import (
     strategy_lists,
     tournaments,
 )
-from axelrod.tournament import _close_objects
+from axelrod.tournament import _close_objects, MatchChunk
 
 C, D = axl.Action.C, axl.Action.D
 
@@ -663,7 +663,7 @@ class TestTournament(unittest.TestCase):
                 for player2_index in range(player1_index, len(self.players)):
                     index_pair = (player1_index, player2_index)
                     match_params = {"turns": turns, "game": self.game}
-                    yield (index_pair, match_params, self.test_repetitions, 0)
+                    yield MatchChunk(index_pair, match_params, self.test_repetitions, 0)
 
         chunk_generator = make_chunk_generator()
         interactions = {}


### PR DESCRIPTION
This avoids necessitating agreement on ordering between setting and reading.  This is slightly more readable and maintainable.

This doesn't break API, because match_generator isn't imported on __init__.