### PR TITLE
Improve extend method in LimitedHistory to enforce memory depth

### DIFF
--- a/axelrod/history.py
+++ b/axelrod/history.py
@@ -117,8 +117,8 @@ class LimitedHistory(History):
         memory_depth, int:
             length of history to retain
         """
-        super().__init__(plays=plays, coplays=coplays)
         self.memory_depth = memory_depth
+        super().__init__(plays=plays, coplays=coplays)
 
     def flip_plays(self):
         """Creates a flipped plays history for use with DualTransformer."""
@@ -138,3 +138,11 @@ class LimitedHistory(History):
             first_play, first_coplay = self._plays.pop(0), self._coplays.pop(0)
             self._actions[first_play] -= 1
             self._state_distribution[(first_play, first_coplay)] -= 1
+
+    def extend(self, new_plays, new_coplays):
+        """A function that emulates list.extend, respecting the stated memory depth."""
+        self._plays.extend(new_plays)
+        self._coplays.extend(new_coplays)
+        if len(self._plays) > self.memory_depth:
+            self._plays = self._plays[-self.memory_depth :]
+            self._coplays = self._coplays[-self.memory_depth :]

--- a/axelrod/tests/unit/test_game.py
+++ b/axelrod/tests/unit/test_game.py
@@ -1,7 +1,7 @@
 import unittest
 
 import numpy as np
-from hypothesis import given, settings
+from hypothesis import HealthCheck, given, settings
 from hypothesis.extra.numpy import array_shapes, arrays
 from hypothesis.strategies import integers
 
@@ -123,7 +123,7 @@ class TestAsymmetricGame(unittest.TestCase):
         self.assertEqual(expected_repr, str(asymgame))
 
     @given(asymgame1=asymmetric_games(), asymgame2=asymmetric_games())
-    @settings(max_examples=5)
+    @settings(max_examples=5, suppress_health_check=(HealthCheck.too_slow,))
     def test_equality(self, asymgame1, asymgame2):
         """Tests equality of AsymmetricGames based on their matrices."""
         self.assertFalse(asymgame1 == "foo")

--- a/axelrod/tests/unit/test_history.py
+++ b/axelrod/tests/unit/test_history.py
@@ -123,3 +123,14 @@ class TestLimitedHistory(unittest.TestCase):
             h.state_distribution,
             Counter({(D, D): 1, (C, D): 1, (D, C): 1, (C, C): 0}),
         )
+
+    def test_extend(self):
+        h1 = LimitedHistory(3, plays=[C, C, D], coplays=[C, C, C])
+        self.assertEqual(list(h1), [C, C, D])
+        h1.extend([C, C], [D, D])
+        self.assertEqual(list(h1), [D, C, C])
+        h1.extend([D, C], [D, D])
+        self.assertEqual(list(h1), [C, D, C])
+        h1.memory_depth = 4
+        h1.extend([D, C], [D, D])
+        self.assertEqual(list(h1), [D, C, D, C])


### PR DESCRIPTION
This pull request fixes #1451 , specifically to the `history.py` and `test_history.py` files. The most important changes include the addition of the `extend` method, and the corresponding unit tests for the new method.

### Changes to `axelrod/history.py`:

* Reordered the superclass initialization in the `__init__` method of the `LimitedHistory` class to occur after setting the `memory_depth` attribute.
* Added a new `extend` method to the `LimitedHistory` class, which extends the `plays` and `coplays` lists while respecting the `memory_depth` limit.

### Changes to `axelrod/tests/unit/test_history.py`:

* Added a new unit test `test_extend` to verify the functionality of the `extend` method in the `LimitedHistory` class.
* Added a corresponding unit test in axelrod/tests/unit/test_history.py to validate changing `memory-depth` behavior.
* Formatted all committed files using black for consistent code style.