### PR TITLE
Build moran benchmark

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,75 @@
+"""Benchmark test
+
+Use this on an ad hoc basis to test the performance of library changes.
+
+To run:
+`pip install pytest-benchmark`
+`pytest benchmark.py`
+"""
+
+import axelrod as axl
+from axelrod.graph import Graph
+
+def few_players_no_mutations():
+    edges = [(0, 1), (1, 2), (2, 3), (3, 1)]
+    graph = Graph(edges)
+    players = [axl.Cooperator(), axl.Cooperator(), axl.Cooperator(), axl.Defector()]
+    mp = axl.MoranProcess(players, interaction_graph=graph, seed=40)
+    _ = mp.play()
+
+def few_players_mutations():
+    edges = [(0, 1), (1, 2), (2, 3), (3, 1)]
+    graph = Graph(edges)
+    players = [axl.Cooperator(), axl.Cooperator(), axl.Cooperator(), axl.Defector()]
+    mp = axl.MoranProcess(players, interaction_graph=graph, mutation_rate=0.5, seed=40)
+    for _ in range(100):
+        try:
+            mp.__next__()
+        except StopIteration:
+            break
+
+def four_distinct_players_no_mutations():
+    players = [axl.Cooperator(), axl.Defector(), axl.TitForTat(), axl.Grudger()]
+    mp = axl.MoranProcess(players, seed=40)
+    _ = mp.play()
+
+def four_distinct_players_mutations():
+    players = [axl.Cooperator(), axl.Defector(), axl.TitForTat(), axl.Grudger()]
+    mp = axl.MoranProcess(players, mutation_rate=0.5, seed=40)
+    for _ in range(50):
+        try:
+            mp.__next__()
+        except StopIteration:
+            break
+
+def more_players_no_mutations():
+    players = [axl.Cooperator() for _ in range(9)] + [axl.Defector() for _ in range(3)]
+    mp = axl.MoranProcess(players, seed=40)
+    _ = mp.play()
+
+def more_players_mutations():
+    players = [axl.Cooperator() for _ in range(9)] + [axl.Defector() for _ in range(3)]
+    mp = axl.MoranProcess(players, mutation_rate=0.5, seed=40)
+    for _ in range(50):
+        try:
+            mp.__next__()
+        except StopIteration:
+            break
+
+def test_few_players_no_mutations(benchmark):
+    benchmark(few_players_no_mutations)
+
+def test_few_players_mutations(benchmark):
+    benchmark(few_players_mutations)
+
+def test_four_distinct_players_no_mutations(benchmark):
+    benchmark(four_distinct_players_no_mutations)
+
+def test_four_distinct_players_mutations(benchmark):
+    benchmark(four_distinct_players_mutations)
+
+def test_more_players_no_mutations(benchmark):
+    benchmark(more_players_no_mutations)
+
+def test_more_players_mutations(benchmark):
+    benchmark(more_players_mutations)

--- a/benchmark.py
+++ b/benchmark.py
@@ -10,28 +10,44 @@ To run:
 import axelrod as axl
 from axelrod.graph import Graph
 
+
 def few_players_no_mutations():
     edges = [(0, 1), (1, 2), (2, 3), (3, 1)]
     graph = Graph(edges)
-    players = [axl.Cooperator(), axl.Cooperator(), axl.Cooperator(), axl.Defector()]
+    players = [
+        axl.Cooperator(),
+        axl.Cooperator(),
+        axl.Cooperator(),
+        axl.Defector(),
+    ]
     mp = axl.MoranProcess(players, interaction_graph=graph, seed=40)
     _ = mp.play()
+
 
 def few_players_mutations():
     edges = [(0, 1), (1, 2), (2, 3), (3, 1)]
     graph = Graph(edges)
-    players = [axl.Cooperator(), axl.Cooperator(), axl.Cooperator(), axl.Defector()]
-    mp = axl.MoranProcess(players, interaction_graph=graph, mutation_rate=0.5, seed=40)
+    players = [
+        axl.Cooperator(),
+        axl.Cooperator(),
+        axl.Cooperator(),
+        axl.Defector(),
+    ]
+    mp = axl.MoranProcess(
+        players, interaction_graph=graph, mutation_rate=0.5, seed=40
+    )
     for _ in range(100):
         try:
             mp.__next__()
         except StopIteration:
             break
 
+
 def four_distinct_players_no_mutations():
     players = [axl.Cooperator(), axl.Defector(), axl.TitForTat(), axl.Grudger()]
     mp = axl.MoranProcess(players, seed=40)
     _ = mp.play()
+
 
 def four_distinct_players_mutations():
     players = [axl.Cooperator(), axl.Defector(), axl.TitForTat(), axl.Grudger()]
@@ -42,13 +58,19 @@ def four_distinct_players_mutations():
         except StopIteration:
             break
 
+
 def more_players_no_mutations():
-    players = [axl.Cooperator() for _ in range(9)] + [axl.Defector() for _ in range(3)]
+    players = [axl.Cooperator() for _ in range(9)] + [
+        axl.Defector() for _ in range(3)
+    ]
     mp = axl.MoranProcess(players, seed=40)
     _ = mp.play()
 
+
 def more_players_mutations():
-    players = [axl.Cooperator() for _ in range(9)] + [axl.Defector() for _ in range(3)]
+    players = [axl.Cooperator() for _ in range(9)] + [
+        axl.Defector() for _ in range(3)
+    ]
     mp = axl.MoranProcess(players, mutation_rate=0.5, seed=40)
     for _ in range(50):
         try:
@@ -56,20 +78,26 @@ def more_players_mutations():
         except StopIteration:
             break
 
+
 def test_few_players_no_mutations(benchmark):
     benchmark(few_players_no_mutations)
+
 
 def test_few_players_mutations(benchmark):
     benchmark(few_players_mutations)
 
+
 def test_four_distinct_players_no_mutations(benchmark):
     benchmark(four_distinct_players_no_mutations)
+
 
 def test_four_distinct_players_mutations(benchmark):
     benchmark(four_distinct_players_mutations)
 
+
 def test_more_players_no_mutations(benchmark):
     benchmark(more_players_no_mutations)
+
 
 def test_more_players_mutations(benchmark):
     benchmark(more_players_mutations)

--- a/docs/how-to/contributing/running_tests.rst
+++ b/docs/how-to/contributing/running_tests.rst
@@ -58,3 +58,21 @@ You can also run the doctests on any given file. For example, to run the
 doctests for the :code:`docs/tutorials/getting_started/match.rst` file::
 
     $ python -m doctest docs/tutorials/getting_started/match.rst
+
+Performance testing
+-------------------
+
+Performance is not automatically tested as of yet.  To check the performance
+of a change, first install pytest-benchmark::
+
+    $ pip install pytest-benchmark
+
+Then run benchmark.py before and after the change::
+
+    $ pytest benchmark.py
+
+Record the before and after report on the pull request.
+
+benchmark.py only tests the Moran process, which in turn tests a lot of other
+functionality.  If the function you're changing is not covered by the file,
+add another function.

--- a/docs/how-to/contributing/running_tests.rst
+++ b/docs/how-to/contributing/running_tests.rst
@@ -65,7 +65,7 @@ Performance testing
 Performance is not automatically tested as of yet.  To check the performance
 of a change, first install pytest-benchmark::
 
-    $ pip install pytest-benchmark
+    $ python -m pip install pytest-benchmark
 
 Then run benchmark.py before and after the change::
 


### PR DESCRIPTION
This benchmark was used to analyze #1460.

There's a way to integrate pytest-benchmark with tox.  This PR doesn't do that, but may be a good starting point.