### PR TITLE
Fix dead prisoners-dilemma.com links with Wayback Machine archives

### DIFF
--- a/docs/discussion/overview_of_past_tournaments.rst
+++ b/docs/discussion/overview_of_past_tournaments.rst
@@ -301,7 +301,7 @@ HARD_TFT
 ^^^^^^^^
 
 Hard TFT is not defined in [Stewart2012]_ but is
-`elsewhere <http://www.prisoners-dilemma.com/strategies.html>`_
+`elsewhere <https://web.archive.org/web/20171227021632/http://www.prisoners-dilemma.com/strategies.html>`_
 defined as follows. The strategy cooperates on the
 first move, defects if the opponent has defected on any of the previous three
 rounds, and otherwise cooperates.

--- a/docs/reference/bibliography.rst
+++ b/docs/reference/bibliography.rst
@@ -54,7 +54,7 @@ documentation.
 .. [Nowak1992] Nowak, M.., & May, R. M. (1992). Evolutionary games and spatial chaos. Nature. http://doi.org/10.1038/359826a0
 .. [Nowak1993] Nowak, M., & Sigmund, K. (1993). A strategy of win-stay, lose-shift that outperforms tit-for-tat in the Prisoner’s Dilemma game. Nature, 364(6432), 56–58. http://doi.org/10.1038/364056a0
 .. [Ohtsuki2006] Ohtsuki, Hisashi, et al. "A simple rule for the evolution of cooperation on graphs and social networks." Nature 441.7092 (2006): 502.
-.. [PD2017] http://www.prisoners-dilemma.com/competition.html (Accessed: 6 June 2017). Archived at https://web.archive.org/web/20171227021632/http://www.prisoners-dilemma.com/competition.html
+.. [PD2017] https://web.archive.org/web/20171227021632/http://www.prisoners-dilemma.com/competition.html (Accessed: 6 June 2017).
 .. [Press2012] Press, W. H., & Dyson, F. J. (2012). Iterated Prisoner’s Dilemma contains strategies that dominate any evolutionary opponent. Proceedings of the National Academy of Sciences, 109(26), 10409–10413.  http://doi.org/10.1073/pnas.1206569109
 .. [Prison1998] LIFL (1998) PRISON. Available at: http://www.lifl.fr/IPD/ipd.frame.html (Accessed: 19 September 2016).
 .. [Robson1990] Robson, Arthur J. "Efficiency in evolutionary games: Darwin, Nash and the secret handshake." Journal of theoretical Biology 144.3 (1990): 379-396.


### PR DESCRIPTION
www.prisoners-dilemma.com has new ownership and no longer hosts IPD strategy content. Replaced the two broken HTTP links with Wayback Machine archives — one in the HARD_TFT docs and one in the bibliography entry.
